### PR TITLE
Misc. improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /docs/images/src/
 papi-web.ini
 /tmp/
+__pycache__/

--- a/common/config_reader.py
+++ b/common/config_reader.py
@@ -15,7 +15,7 @@ TMP_DIR: Path = Path('tmp')
 # https://docs.python.org/3/library/configparser.html
 class ConfigReader(ConfigParser):
     def __init__(self, ini_file: Path, silent: bool):
-        super().__init__(interpolation=None)
+        super().__init__(interpolation=None, empty_lines_in_values=False)
         self.__ini_file: Path = ini_file
         ini_marker_dir: Path = Path(TMP_DIR, self.ini_file.parents[0])
         ini_marker_file: Path = Path(ini_marker_dir, self.ini_file.name + '.read')

--- a/data/player.py
+++ b/data/player.py
@@ -184,8 +184,7 @@ class Player:
     def handicap_str(self) -> Optional[str]:
         if self.__handicap_initial_time is None:
             return None
-        minutes = math.floor(self.__handicap_initial_time / 60)
-        seconds = self.__handicap_initial_time - 60 * minutes
+        (minutes, seconds) = divmod(self.__handicap_initial_time, 60)
         minutes_str: str = f'{minutes}\'' if minutes > 0 else ''
         seconds_str: str = f'{seconds}"' if seconds > 0 else ''
         class_str: str = 'modified-time' if self.__handicap_time_modified else 'base-time'

--- a/data/result.py
+++ b/data/result.py
@@ -88,8 +88,9 @@ class Result:
         files: List[str] = glob.glob(str(Path(results_dir, '*')))
         if not files:
             return results
+        prog = re.compile('^([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)$')
         for file in reversed(files):
-            matches = re.match('^([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)$', Path(file).name)
+            matches = prog.match(Path(file).name)
             if not matches:
                 logger.warning(f'invalid result filename [{file}]')
                 continue

--- a/data/result.py
+++ b/data/result.py
@@ -1,10 +1,9 @@
-import glob
 import re
 from datetime import datetime
 from functools import total_ordering
 from logging import Logger
 from pathlib import Path
-from typing import List
+from typing import List, Iterator
 
 from common.config_reader import TMP_DIR
 from common.logger import get_logger
@@ -85,7 +84,7 @@ class Result:
         results_dir: Path = cls.results_dir(event_id)
         if not results_dir.is_dir():
             return results
-        files: List[str] = glob.glob(str(Path(results_dir, '*')))
+        files: Iterator[str] = results_dir.glob("*")
         if not files:
             return results
         prog = re.compile('^([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+)$')

--- a/docs/04-install.md
+++ b/docs/04-install.md
@@ -5,7 +5,7 @@
 ## Prérequis
 
 Un ordinateur sous Windows avec :
-  - [la dernière version de Papi](https://dna.ffechecs.fr/ressources/appariements/papi/) opérationnelle (septembre 2023 : version 3.3.6)
+  - [la dernière version de Papi](https://dna.ffechecs.fr/ressources/appariements/papi/) opérationnelle (septembre 2023 : version 3.3.7)
   - [le pilote Access](https://www.microsoft.com/en-us/download/details.aspx?id=54920) permettant de modifier les fichiers Papi
 
 [!NOTE]


### PR DESCRIPTION
Summary and explanation of the changes: 
- Ignore precompiled modules (`__pycache__` should be automatically ignored)
- Corrected version mistake in docs (Papi 3.3.6 -> Papi 3.3.7)
- Removed ability for empty lines in values (config reader)
- Simplified time conversion logic (`divmod` exists for this)
- Used a compiled regular expression object (efficiency change)
- Replace glob.glob with Path.glob in  `data/results.py` (removed unnecessary module), `data/event.py` should change as well

Incomplete and untested changes