### PR TITLE
Use more clear and efficient Regular Expression matching

### DIFF
--- a/common/config_reader.py
+++ b/common/config_reader.py
@@ -130,9 +130,9 @@ class ConfigReader(ConfigParser):
         subsections: List[str] = []
         for section in self.sections():
             if first_level_only:
-                pattern = '^{}\\.([^.]+)$'
+                pattern = r'^{}\.([^.]+)$'
             else:
-                pattern = '^{}\\.([^.]+(\\.[^.]+)*)$'
+                pattern = r'^{}\.([^.]+(\.[^.]+)*)$'
             matches = re.match(pattern.format(prefix.replace('.', '\\.')), section)
             if matches:
                 subsections.append(matches.group(1))

--- a/common/papi_web_config.py
+++ b/common/papi_web_config.py
@@ -67,7 +67,7 @@ class PapiWebConfig(ConfigReader):
                     self._add_warning(f'option absente', section, key)
                 else:
                     self.__web_host = self.get(section, key)
-                    matches = re.match('^(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)$', self.__web_host)
+                    matches = re.match(r'^(\d+)\.(\d+)\.(\d+)\.(\d+)$', self.__web_host)
                     if matches:
                         for i in range(4):
                             if int(matches.group(i + 1)) > 255:

--- a/data/event.py
+++ b/data/event.py
@@ -909,6 +909,9 @@ class Event(ConfigReader):
         if not self.has_section(section):
             return
         section_keys = [str(id) for id in range(1, 4)]
+        simplfied_hex_pattern = re.compile('^#?([0-9A-F])([0-9A-F])([0-9A-F])$')
+        hex_pattern = re.compile('^#?([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$')
+        rgb_pattern = re.compile(r'^(RBG)*\(([0-9]+),([0-9]+)([0-9]+)\)*$')
         for key in self.options(section):
             if key not in section_keys:
                 self._add_warning(f'option de couleur invalide (acceptées : [{", ".join(section_keys)}]), '
@@ -917,7 +920,7 @@ class Event(ConfigReader):
             color_id = int(key)
             color_rbg: Optional[Tuple[int, int, int]] = None
             color_value: str = self.get(section, key).replace(' ', '').upper()
-            matches = re.match('^#?([0-9A-F])([0-9A-F])([0-9A-F])$', color_value)
+            matches = simplified_hex_pattern.match(color_value)
             if matches:
                 color_rbg = (
                     int(matches.group(1) * 2, 16),
@@ -925,7 +928,7 @@ class Event(ConfigReader):
                     int(matches.group(3) * 2, 16),
                 )
             else:
-                matches = re.match('^#?([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$', color_value)
+                matches = hex_pattern.match(color_value)
                 if matches:
                     color_rbg = (
                         int(matches.group(1), 16),
@@ -933,7 +936,7 @@ class Event(ConfigReader):
                         int(matches.group(3), 16),
                     )
                 else:
-                    matches = re.match('^(RBG)*\\(([0-9]+),([0-9]+)([0-9]+)\\)*$', color_value)
+                    matches = rgb_pattern.match(color_value)
                     if matches:
                         color_rbg = (
                             int(matches.group(1)),


### PR DESCRIPTION
Here, I used raw-string to avoid the `\\` escaping problem.
Furthermore, all patterns that are matched against on a loop are compiled out inside the same function.
This could be extended further to compile the patterns as module-level constants (TBD)
