### PR TITLE
Using the mapping protocol for ConfigReader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,9 @@
 /fees/
 /docs/images/src/
 papi-web.ini
-/tmp/
+tmp/
 __pycache__/
+
+# Vim scratch files
+*.swp
+*.swo

--- a/common/config_reader.py
+++ b/common/config_reader.py
@@ -69,9 +69,10 @@ class ConfigReader(ConfigParser):
     def __format_message(self, text: str, section: Optional[str], key: Optional[str]):
         if section is None:
             return f'{self.ini_file.name}: {text}'
-        if key is None:
+        elif key is None:
             return f'{self.ini_file.name}[{section}]: {text}'
-        return f'{self.ini_file.name}[{section}].{key}: {text}'
+        else: 
+            return f'{self.ini_file.name}[{section}].{key}: {text}'
 
     def _add_debug(self, text: str, section: Optional[str] = None, key: Optional[str] = None):
         message = self.__format_message(text, section, key)

--- a/common/config_reader.py
+++ b/common/config_reader.py
@@ -1,8 +1,10 @@
 import re
 from pathlib import Path
 
-from configparser import ConfigParser, DuplicateSectionError, DuplicateOptionError, MissingSectionHeaderError, \
-    ParsingError, Error
+from configparser import (
+        ConfigParser, DuplicateSectionError, DuplicateOptionError,
+        MissingSectionHeaderError, ParsingError, Error
+    )
 from typing import List, Optional
 from logging import Logger
 from common.logger import get_logger
@@ -17,8 +19,8 @@ class ConfigReader(ConfigParser):
     def __init__(self, ini_file: Path, silent: bool):
         super().__init__(interpolation=None, empty_lines_in_values=False)
         self.__ini_file: Path = ini_file
-        ini_marker_dir: Path = Path(TMP_DIR, self.ini_file.parent)
-        ini_marker_file: Path = Path(ini_marker_dir, f'{self.ini_file.name}.read')
+        ini_marker_dir: Path = TMP_DIR / self.ini_file.parent
+        ini_marker_file: Path = ini_marker_dir / f'{self.ini_file.name}.read'
         self.__infos: List[str] = []
         self.__warnings: List[str] = []
         self.__errors: List[str] = []

--- a/data/event.py
+++ b/data/event.py
@@ -323,6 +323,7 @@ class Event(ConfigReader):
         initial_time: Optional[int] = None
         if not self.has_option(section, key):
             self._add_warning(f'option absente, configuration de handicap ignorée', section, key)
+            return HandicapTournament()
         else:
             initial_time = self._getint_safe(section, key, minimum=1)
             if initial_time is None:
@@ -332,40 +333,46 @@ class Event(ConfigReader):
         increment: Optional[int] = None
         if not self.has_option(section, key):
             self._add_info(f'option absente, configuration de handicap ignorée', section, key)
+            return HandicapTournament()
         else:
             increment = self._getint_safe(section, key, minimum=0)
             if increment is None:
                 self._add_warning(
                     f'un entier positif est attendu, configuration de handicap ignorée', section, key)
+                return HandicapTournament()
         key = 'penalty_step'
         penalty_step: Optional[int] = None
         if not self.has_option(section, key):
             self._add_info(f'option absente, configuration de handicap ignorée', section, key)
+            return HandicapTournament()
         else:
             penalty_step = self._getint_safe(section, key, minimum=1)
             if penalty_step is None:
                 self._add_warning(
                     f'un entier positif non nul est attendu, configuration de handicap ignorée', section, key)
+                return HandicapTournament()
         key = 'penalty_value'
         penalty_value: Optional[int] = None
         if not self.has_option(section, key):
             self._add_info(f'option absente, configuration de handicap ignorée', section, key)
+            return HandicapTournament()
         else:
             penalty_value = self._getint_safe(section, key, minimum=1)
             if penalty_value is None:
                 self._add_warning(
                     f'un entier positif non nul est attendu, configuration de handicap ignorée', section, key)
+                return HandicapTournament()
         key = 'min_time'
         min_time: Optional[int] = None
         if not self.has_option(section, key):
             self._add_info(f'option absente, configuration de handicap ignorée', section, key)
+            return HandicapTournament()
         else:
             min_time = self._getint_safe(section, key, minimum=1)
             if min_time is None:
                 self._add_warning(
                     f'un entier positif non nul est attendu, configuration de handicap ignorée', section, key)
-        if None in [initial_time, increment, penalty_step, penalty_value, min_time]:
-            return HandicapTournament()
+                return HandicapTournament()
         return HandicapTournament(initial_time, increment, penalty_step, penalty_value, min_time)
 
     def __build_templates(self):

--- a/data/event.py
+++ b/data/event.py
@@ -357,7 +357,7 @@ class Event(ConfigReader):
                 'ffe_id',
                 'ffe_password',
             ]
-        for key, value in self.items(section):
+        for key, value in section.items():
             if key not in section_keys:
                 self._add_warning('option inconnue', section, key)
         handicap_section = 'tournament.' + tournament_id + '.handicap'
@@ -1095,9 +1095,9 @@ class Event(ConfigReader):
                 self._add_error('rubrique non trouvée', section)
                 return screen_sets
             key = 'tournament'
-            if key not in current_section
+            if key not in current_section:
                 if len(self.tournaments) == 1:
-                    current_section[ley] = list(self.tournaments.keys())[0]
+                    current_section[key] = list(self.tournaments.keys())[0]
                 else:
                     self._add_warning(
                         'option absente, écran ignoré',
@@ -1224,7 +1224,7 @@ class Event(ConfigReader):
         section = f'rotator.{rotator_id}'
         rotator_section = self[section]
         section_keys: List[str] = ['screens', 'families', 'delay', ]
-        for for key, value in rotator_section:
+        for key in rotator_section:
             if key not in section_keys:
                 self._add_warning('option inconnue', section, key)
         key = 'delay'
@@ -1238,7 +1238,7 @@ class Event(ConfigReader):
                 key
             )
         else:
-            delay = self._getint_safe(section, key, minmum=1)
+            delay = self._getint_safe(section, key, minimum=1)
             if delay is None:
                 self._add_warning(
                     f'un entier positif non nul est attendu, par défaut '

--- a/data/event.py
+++ b/data/event.py
@@ -174,31 +174,23 @@ class Event(ConfigReader):
         try:
             self.__update_password = section[key]
         except KeyError:
-            self.__add_info(
+            self._add_info(
                 f'option absente, aucun mot de passe ne sera demandé pour les saisies',
                 section_key,
                 key
             )
 
         section_keys: List[str] = ['name', 'path', 'update_password', 'css', ]
-        for key, value in section:
+        for key, value in section.items():
             if key not in section_keys:
                 self._add_warning(f'option inconnue', section, key)
 
     def __rename_section(self, old_name: str, new_name: str):
-        # TODO(Amaras) see if the current function body is equivalent to:
-        # self[new_name] = self[old_name]
-        # del self[old_name]
-        # NOTE(Amaras) if it is equivalent, it could be safely replaced by
-        # the two lines above in each call site
-        
         # NOTE(Amaras) this can add values that are in DEFAULTSEC if any.
         # This can also cause a crash if we're trying to delete DEFAULTSEC,
         # as deleting DEFAUTLSEC causes a ValueError.
-        self.add_secion(new_name)
-        for key, value in self[old_name].items():
-            self[new_name][key] = value
-        self[old_name].clear()
+        # self.add_section(new_name)
+        self[new_name] = self[old_name]
         del self[old_name]
 
     def __build_tournaments(self):
@@ -301,9 +293,9 @@ class Event(ConfigReader):
         handicap_penalty_step: Optional[int]
         handicap_penalty_value: Optional[int]
         handicap_min_time: Optional[int]
-        handicap_section = 'tournament.' + tournament_id + 'handicap'
-        handicap_initial_time, handicap_increment, handicap_penalty_step, handicap_penalty_value, handicap_min_time = \
-            self.__build_tournament_handicap(handicap_section)
+        handicap_section = 'tournament.' + tournament_id + '.handicap'
+        handicap_values = self.__build_tournament_handicap(handicap_section)
+        handicap_initial_time, handicap_increment, handicap_penalty_step, handicap_penalty_value, handicap_min_time = handicap_values
         if handicap_initial_time is not None and ffe_id is not None:
             self._add_warning(f'les tournois à handicap ne devraient pas être homologués', handicap_section)
         self.__tournaments[tournament_id] = Tournament(
@@ -332,7 +324,7 @@ class Event(ConfigReader):
         key = 'increment'
         increment: Optional[int] = None
         if not self.has_option(section, key):
-            self._add_info(f'option absente, configuration de handicap ignorée', section, key)
+            self._add_warning(f'option absente, configuration de handicap ignorée', section, key)
             return HandicapTournament()
         else:
             increment = self._getint_safe(section, key, minimum=0)
@@ -343,7 +335,7 @@ class Event(ConfigReader):
         key = 'penalty_step'
         penalty_step: Optional[int] = None
         if not self.has_option(section, key):
-            self._add_info(f'option absente, configuration de handicap ignorée', section, key)
+            self._add_warning(f'option absente, configuration de handicap ignorée', section, key)
             return HandicapTournament()
         else:
             penalty_step = self._getint_safe(section, key, minimum=1)
@@ -354,7 +346,7 @@ class Event(ConfigReader):
         key = 'penalty_value'
         penalty_value: Optional[int] = None
         if not self.has_option(section, key):
-            self._add_info(f'option absente, configuration de handicap ignorée', section, key)
+            self._add_warning(f'option absente, configuration de handicap ignorée', section, key)
             return HandicapTournament()
         else:
             penalty_value = self._getint_safe(section, key, minimum=1)
@@ -365,7 +357,7 @@ class Event(ConfigReader):
         key = 'min_time'
         min_time: Optional[int] = None
         if not self.has_option(section, key):
-            self._add_info(f'option absente, configuration de handicap ignorée', section, key)
+            self._add_warning(f'option absente, configuration de handicap ignorée', section, key)
             return HandicapTournament()
         else:
             min_time = self._getint_safe(section, key, minimum=1)

--- a/data/event.py
+++ b/data/event.py
@@ -132,7 +132,7 @@ class Event(ConfigReader):
             # After this, the secion has already been retrieved, so no future
             # access will throw a TypeError.
             self._add_error(
-                    f'la rubrique est devenue une clé, erreur fatale',
+                    f'la rubrique est devenue une option, erreur fatale',
                     section_key
             )
             return
@@ -199,7 +199,7 @@ class Event(ConfigReader):
             tournament_ids.remove('handicap')
         if self.has_section('tournament'):
             if tournament_ids:
-                sections: str = ', '.join(['[tournament.' + id + ']' for id in tournament_ids])
+                sections: str = ', '.join(('[tournament.' + id + ']' for id in tournament_ids))
                 self._add_error(f'la rubrique [tournament] ne doit être utilisée que lorsque l\'évènement '
                                 f'ne compte qu\'un tournoi, d\'autres rubriques sont présentes ({sections})',
                                 'tournament.*')

--- a/data/event.py
+++ b/data/event.py
@@ -593,26 +593,24 @@ class Event(ConfigReader):
             return
 
         family_indices: Optional[List[str]] = None
-        matches = re.match(r'^(\d+)-(\d+)$', range_str)
-        if matches:
+        # NOTE(Amaras) The walrus operator (:= aka assignment expression)
+        # is available since Python 3.8 and this use case is one of the
+        # motivational examples for its introduction, so let's use it.
+        if (matches := re.match(r'^(\d+)-(\d+)$', range_str)):
             first_number = int(matches.group(1))
             last_number = int(matches.group(2))
             if first_number <= last_number:
                 family_indices = [str(number) for number in range(first_number, last_number + 1)]
-        else:
-            matches = re.match('^([A-Z])-([A-Z])$', range_str)
-            if matches:
-                first_letter = matches.group(1)
-                last_letter = matches.group(2)
-                if ord(first_letter) <= ord(last_letter):
-                    family_indices = [chr(i) for i in range(ord(first_letter), ord(last_letter) + 1)]
-            else:
-                matches = re.match('^([a-z])-([a-z])$', range_str)
-                if matches:
-                    first_letter = matches.group(1)
-                    last_letter = matches.group(2)
-                    if ord(first_letter) <= ord(last_letter):
-                        family_indices = [chr(i) for i in range(ord(first_letter), ord(last_letter) + 1)]
+        elif (matches := re.match('^([A-Z])-([A-Z])$', range_str)):
+            first_letter = matches.group(1)
+            last_letter = matches.group(2)
+            if ord(first_letter) <= ord(last_letter):
+                family_indices = [chr(i) for i in range(ord(first_letter), ord(last_letter) + 1)]
+        elif (matches := re.match('^([a-z])-([a-z])$', range_str)):
+            first_letter = matches.group(1)
+            last_letter = matches.group(2)
+            if ord(first_letter) <= ord(last_letter):
+                family_indices = [chr(i) for i in range(ord(first_letter), ord(last_letter) + 1)]
         if family_indices is None:
             self._add_warning(f'valeurs [{range_str}] non valides, famille ignorée', section, key)
             return


### PR DESCRIPTION
The [documentation for ConfigParser](https://docs.python.org/3/library/configparser.html) recommends using the mapping protocol for all new projects instead of the legacy API.

This PR aims to change all cases of this pattern:
```py
section = 'XXX'
# here self is a `ConfigParser` subclass instance
if self.has_section(section):
  key = 'YYY' 
  if self.has_option(section, key):
    var = self.get(section, key)
    # do something with var
  else:
    # log
else:
  # log and return
```

The goal is to use the following pattern instead:
```py
section_key = 'XXX'
try:
  section = self[section_key]
except KeyError:
  # log and return

key = 'YYY'
try:
  var = section[key]
except TypeError:
  # log and return : not a section
except KeyError:
  # log: no option YYY
# use var
```

I have also added several comments on parts of the code that could (theoretically) lead to a crash or security vulnerability
