### PR TITLE
Add two-way support for TRF

### DIFF
--- a/data/pairing.py
+++ b/data/pairing.py
@@ -2,6 +2,8 @@ from logging import Logger
 from common.logger import get_logger
 from dataclasses import dataclass
 from data.util import Result
+# from trf.Player import Game
+import trf.Player as trf
 
 logger: Logger = get_logger()
 
@@ -18,3 +20,10 @@ class Pairing:
 
     def __iter__(self):
         yield from (self.color, self.opponent_id, self.result)
+
+    def to_trf(self, round_number) -> trf.Game:
+        return trf.Game(
+                self.opponent_id,
+                self.color,
+                self.result.to_trf(),
+                round_number)

--- a/data/player.py
+++ b/data/player.py
@@ -7,6 +7,7 @@ import warnings
 from data.pairing import Pairing
 from common.logger import get_logger
 from data.util import PlayerGender, PlayerTitle, Color
+import trf
 
 logger: Logger = get_logger()
 
@@ -160,6 +161,10 @@ class Player:
             self.title == other.title and self.last_name == other.last_name and
             self.first_name == other.first_name
         )
+
+    def to_trf(self) -> trf.Player.Player:
+        pass
+
 
     def __repr__(self):
         if self.id == 1:

--- a/data/util.py
+++ b/data/util.py
@@ -13,9 +13,12 @@ logger: Logger = get_logger()
 class Result(IntEnum):
     """An enum representing the results in the database.
     Should be subclassed if the point value is not the default"""
+    # TODO(Amaras) differentiate between draw (=) and HPB (H);
+    # between PAB (U), forfeit gain (+) and Full-point Bye (F);
+    # between Zero-point Bye (Z) and a round not paired yet.
     NOT_PAIRED = 0
     LOSS = 1
-    DRAW_OR_HPB = 2  # HPB = Halp Point Bye
+    DRAW_OR_HPB = 2  # HPB = Half Point Bye
     GAIN = 3
     FORFEIT_LOSS = 4
     DOUBLE_FORFEIT = 5
@@ -138,6 +141,28 @@ class Result(IntEnum):
     @classmethod
     def imputable_results(cls) -> tuple[Self, Self, Self]:
         return cls.GAIN, cls.DRAW_OR_HPB, cls.LOSS
+
+    # TODO(Amaras) see todo item at top of class: it is not yet possible to
+    # correctly differentiate between several possible results
+    def to_trf(self, unrated: bool = False) -> str:
+        match self:
+            case Result.LOSS:
+                return 'L' if unrated else '0'
+            case Result.GAIN:
+                return 'W' if unrated else '1'
+            case Result.DRAW_OR_HPB:
+                # TODO(Amaras) this should take into account HPB or not
+                return '=' if unrated else 'D'
+            case Result.FORFEIT_LOSS:
+                return '-'
+            case Result.PAB_OR_FORFEIT_GAIN_OR_FPB:
+                return '+'
+            case Result.DOUBLE_FORFEIT:
+                return '-'
+            case Result.NOT_PAIRED:
+                return 'Z'
+            case _:
+                raise ValueError(f"Unknown value: {self}")
 
 
 class TournamentType(IntEnum):

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ QueryableList~=3.1.0
 pyodbc~=4.0.39
 django-mathfilters~=1.0.0
 chardet~=5.2.0
+trf @ https://github.com/papi-web-org/TRF/archive/refs/tags/v1.1.2-unofficial.zip


### PR DESCRIPTION
I opened this PR to focus efforts on the TRF support.

This is meant to bypass the papi database, especially by converting back and forth between the papi-web Tournament and TRF Tournament objects.

Further commits will follow when I'm more available.