### PR TITLE
Fix typos and inconsistencies in docs files

### DIFF
--- a/docs/06-use.md
+++ b/docs/06-use.md
@@ -7,7 +7,7 @@ L'utilisation de Papi-web nécessite un peu d'apprentissage : il vous sera très
 ## Configuration (`papi-web.ini`)
 La configuration fournie par défaut dans le fichier `papi-web.ini` est suffisante pour la très grande majorité des cas.
 
-### Messages (`[loggin]`)
+### Messages (`[logging]`)
 #### level
 ```
 [logging]
@@ -20,7 +20,7 @@ Pour obtenir plus de messages utiliser `level = DEBUG`.
 [web]
 host = 0.0.0.0
 ```
-La valeur `0.0.0.0` rend Papi-web accessible depuis tous les clients de votrer réseau local (consulter votre administrateur·trice réseau pour restreindre les plages IP autorisées).
+La valeur `0.0.0.0` rend Papi-web accessible depuis tous les clients de votre réseau local (consulter votre administrateur·trice réseau pour restreindre les plages IP autorisées).
 #### port
 ```
 [web]
@@ -30,7 +30,7 @@ La valeur par défaut `80` est celle classiquement utilisée par les serveurs we
 #### launch_browser
 ```
 [web]
-launch_brower = on
+launch_browser = on
 ```
 Par défaut, le navigateur web ouvre la page d'accueil au démarrage du serveur (pour ne pas ouvrir automatiquement la page d'accueil, utilisez `launch_browser = off`).
 

--- a/docs/12-qualified.md
+++ b/docs/12-qualified.md
@@ -11,8 +11,8 @@ name = Tournoi homologué 17 juin 2023
 ffe_id = 57777
 ffe_password = KJGYREIOBZ
 ```
-[!NOTE]
-Lorsque l'on précise le numéro d'homologation (`ffe_id`), si `filename` n'est pas précisé alors Papi-web cherchera un fichier dont le nom est le numéro d'homologation (ici `57777.papi`), dans le répertoire précisé par `path` ou dans le répertoire `papi/` par défaut.
+> [!NOTE]
+> Lorsque l'on précise le numéro d'homologation (`ffe_id`), si `filename` n'est pas précisé alors Papi-web cherchera un fichier dont le nom est le numéro d'homologation (ici `57777.papi`), dans le répertoire précisé par `path` ou dans le répertoire `papi/` par défaut.
 
 En précisant simplement `ffe_id` et `ffe_password`, les opérations sur le site fédéral seront accessibles en lançant le script `ffe.bat`.
 

--- a/docs/22-pairings-by-board.md
+++ b/docs/22-pairings-by-board.md
@@ -4,7 +4,7 @@
 
 Les écrans d'affichage des appariements par échiquier ne sont ni plus ni moins que des [écrans de saisie](21-update.md) sur lesquels la saisie est invalidée.
 
-Leur déclaration est exactement la même sur tous les points, à l'exception de l'option `update_password` qui doit être positionnée à `off` (ou simplement omise car `off` est la valeur par défaut).
+Leur déclaration est exactement la même sur tous les points, à l'exception de l'option `update` qui doit être positionnée à `off` (ou simplement omise car `off` est la valeur par défaut).
 
 On utilisera donc par exemple simplement (avec un seul tournoi) :
 ```

--- a/docs/23-pairings-by-player.md
+++ b/docs/23-pairings-by-player.md
@@ -35,7 +35,7 @@ Si vous n'avez qu'un seul tournoi dans votre évènement (`default`), alors vous
 
 Si vous avez plusieurs tournois dans votre évènement, vous devez préciser celui qui sera affiché en ajoutant une rubrique `[screen.<screen_id>.players]` de la manière suivante :
 ```
-[screen.saisie.players]
+[screen.alpha.players]
 tournament = principal
 ```
 

--- a/docs/24-last-results.md
+++ b/docs/24-last-results.md
@@ -6,7 +6,7 @@ Dans les évènements avec plusieurs tournois, il peut être utile de suivre l'i
 
 Tous les résultats saisis via les écrans de saisie sont automatiquement répertoriés et affichés en commençant par les plus récents sur les écrans de résultats.
 
-Comme dit dans la partie [Gestion d'un petit tournoi amical](11-friendly.md), la simple déclaration d'un tournoi crée automatiquement plusieurs écrans, dont un écran d'affichage par ordre alphabétique. Pour personnaliser son ou ses écrans de résultats, il faut le ou les déclarer manuellement.
+Comme dit dans la partie [Gestion d'un petit tournoi amical](11-friendly.md), la simple déclaration d'un tournoi crée automatiquement plusieurs écrans, dont un écran de résultats. Pour personnaliser son ou ses écrans de résultats, il faut le ou les déclarer manuellement.
 
 ## Déclaration d'un écran de résultats (`type = results`)
 

--- a/docs/31-timer.md
+++ b/docs/31-timer.md
@@ -2,7 +2,7 @@
 
 # Papi-web - Utilisation d'un chronomètre
 
-L'article 4.4 des règles générales pour les compétitions Fide mentionne à l'article 4.4 concernant la préparation de la salle de jeu :
+L'article 4.4 des règles générales pour les compétitions FIDE mentionne concernant la préparation de la salle de jeu :
 
 > _Pour les événements FIDE de type L1 avec 30 joueurs ou plus, pour toute la compétition, un grand chronomètre numérique ou une horloge doit être installé dans l'aire de jeu. Pour les événements FIDE inférieurs à 30 joueurs, une annonce en bonne et due forme doit être faite 5 minutes avant le début des parties puis une autre 1 minute avant le début des parties._ 
 
@@ -53,7 +53,7 @@ date = 2023-07-09 09:30
 date = 13:30
 ```
 
-Les horaires dont les identifiants sont des numéros correspondent aux horaires de début des rondes. Pour ces horaires particuliers, les textes affichés sur le bandeau du chronomètre sont par défaut `text_before = Début de la ronde <round_id> dans %s` et `text_after = Ronde <round_id>> commencée depuis %s`.
+Les horaires dont les identifiants sont des numéros correspondent aux horaires de début des rondes. Pour ces horaires particuliers, les textes affichés sur le bandeau du chronomètre sont par défaut `text_before = Début de la ronde <round_id> dans %s` et `text_after = Ronde <round_id> commencée depuis %s`.
 
 ```
 [timer.hour.remise-des-prix]

--- a/docs/32-handicap.md
+++ b/docs/32-handicap.md
@@ -15,7 +15,7 @@ penalty_value = 30
 min_time = 60
 ```
 
-Lorsqu'un évènement ne comprend qu'un seul évènement alors l'identifiant `<tournament_id>` peut être omis (on utilise simplement `[tournament.handicap]`).
+Lorsqu'un évènement ne comprend qu'un seul tournoi alors l'identifiant `<tournament_id>` peut être omis (on utilise simplement `[tournament.handicap]`).
 
 ![Affichage des appariements d'un tournoi à handicap](images/handicap.jpg)
 

--- a/docs/33-templates-families.md
+++ b/docs/33-templates-families.md
@@ -117,7 +117,6 @@ part = 5
 ```
 [template.alpha]
 type = players
-update = on
 columns = 2
 menu = alpha-1,alpha-2,alpha-3,alpha-4,alpha-5
 menu_text = [%f - %l]
@@ -160,7 +159,7 @@ part = 5
 
 Les familles servent à générer tout un ensemble d'écrans à partir d'un modèle, en se basant sur une plage de valeurs. Le bénéfice de l'utilisation des familles réside en la facilité d'ajouter et modifier des écrans basés sur un même modèle, de les personnaliser (nom et menus).
 
-Une famille d'écrans se déclare à l'aide d'une rubrique `[family.<family_id>]`, où `family_id` sera l'identifiant du modèle. Dans la rubrique `[family.<family_id>]` doivent se trouver :
+Une famille d'écrans se déclare à l'aide d'une rubrique `[family.<family_id>]`, où `family_id` sera l'identifiant de la famille. Dans la rubrique `[family.<family_id>]` doivent se trouver :
 - le modèle sur lequel sont basés les écrans (option `template`) ;
 - la plage de valeurs à partir de laquelle seront construits les écrans (option `range`) peuvent être des entiers ou des lettres.
 
@@ -179,7 +178,7 @@ type = boards
 update = on
 menu = family
 menu_text = Tournoi ?
-[screen.saisie.boards]
+[template.saisie.boards]
 tournament = ?
 name = %t
 ```
@@ -243,7 +242,6 @@ Dans ce cas Papi-web calcule automatiquement le nombre d'écrans nécessaires.
 ```
 [template.alpha]
 type = players
-update = on
 columns = 2
 menu = family
 menu_text = [%f - %l]
@@ -266,7 +264,7 @@ Cette déclaration crée automatiquement les écrans alpha-1 à alpha-5, chaque 
 
 ##### 3.2 Distribution des appariements sur des écrans de taille donnée
 
-On peut également préciser manuellement le nombre dde joueur·euses par écran, en utilisant l'option `number` :
+On peut également préciser manuellement le nombre de joueur·euses par écran, en utilisant l'option `number` :
 
 ```
 [family.alpha]

--- a/docs/34-menus.md
+++ b/docs/34-menus.md
@@ -14,30 +14,30 @@ L'option `menu` peut avoir les valeurs suivantes :
 
 ### Aucun menu : `menu = none`
 
-aucun menu ne sera affiché sur cet écran (par exemple, il n'est en général pas nécessaire d'afficher des liens hypertextes puisque la navigation entre les écrans est automatique). `menu = none` est la valeur par défaut.
+Aucun menu ne sera affiché sur cet écran (par exemple, il n'est en général pas nécessaire d'afficher des liens hypertextes puisque la navigation entre les écrans est automatique). `menu = none` est la valeur par défaut.
 
 ### Visualisation : `menu = view`
 
-le menu contiendra des liens vers tous les écrans de l'évènement :
+Le menu contiendra des liens vers tous les écrans de l'évènement :
 - affichage des appariements par échiquier
 - affichage des appariements par ordre alphabétique
 - affichage des résultats
 
 ### Saisie : `menu = update`
 
-le menu contiendra des liens vers tous les écrans de saisie de l'évènement.
+Le menu contiendra des liens vers tous les écrans de saisie de l'évènement.
 
 ### Famille (de l'écran) : `menu = family`
 
-le menu contiendra des liens vers tous les écrans de la famille de l'écran (cette valeur n'est autorisée que pour les écrans d'une famille).
+Le menu contiendra des liens vers tous les écrans de la famille de l'écran (cette valeur n'est autorisée que pour les écrans d'une famille).
 
 ### Liste d'écrans : `menu = <écran n°1, ...>`
 
-le menu contiendra des liens vers les écrans dont on indique la liste des identifiants, séparés par des virgules.
+Le menu contiendra des liens vers les écrans dont on indique la liste des identifiants, séparés par des virgules.
 
 ## Définition du lien hypertexte d'un écran
 
-L'option `menu_text` est uen chaîne de caractère libre.
+L'option `menu_text` est une chaîne de caractère libre.
 
 Avant d'être affichée à l'écran, les remplacements suivants sont effectués :
 - `%t` est remplacé par le nom du tournoi concerné par l'écran
@@ -45,7 +45,7 @@ Avant d'être affichée à l'écran, les remplacements suivants sont effectués 
 - `%l` (l = last) est remplacé par le numéro du dernier échiquier ou les trois premières lettres du nom du·de la dernier·ère joueur·euse
 
 > [!NOTE]
-- Si l'écran présente plusieurs ensembles concernant plusieurs tournois, le tournoi du premier ensemble sera considéré pour les remplacements.
+> Si l'écran présente plusieurs ensembles concernant plusieurs tournois, le tournoi du premier ensemble sera considéré pour les remplacements.
 
 ### Exemples
 
@@ -84,7 +84,7 @@ part = ?
 
 [screen.j]
 template = commun
-[screen.b.boards]
+[screen.j.boards]
 tournament = j
 ```
 

--- a/docs/35-rotators.md
+++ b/docs/35-rotators.md
@@ -19,7 +19,7 @@ Deux options permettent de spécifier les écrans qui seront projetés alternati
 [template.appariements]
 type = boards
 menu_text = Tournoi ?
-[template.saisie.boards]
+[template.appariements.boards]
 tournament = domloup-fide-?
 
 # 6 écrans d'affichage des appariements pour les tournois A à F
@@ -38,8 +38,8 @@ families = appariements
 [template.tournoi]
 type = boards
 menu_text = Tournoi ?
-[template.saisie.boards]
-tournament = domloup-fide-?
+[template.tournoi.boards]
+tournament = tournoi-?
 
 # 6 écrans d'affichage des appariements pour les tournois A à F (tournois nommés tournoi-A à tournoi-F)
 [family.tournoi]

--- a/docs/37-chessevent.md
+++ b/docs/37-chessevent.md
@@ -18,9 +18,9 @@ La plateforme d'inscription en ligne Chess Event permet :
 - aux arbitres/organisateur·trices de gérer le pointage en ligne ;
 - aux arbitres de télécharger les fichiers Papi des tournois sur leur ordinateur à la fin du pointage.
 
-Le téléchargement des fichiers Papi des tournois depuis la plateforme Chess Event est possible mais nécessite l'installation d'un logiciel tiers (un moteur PHP, par exemple celui de XAMPP).
+Le téléchargement des fichiers Papi des tournois depuis la plateforme Chess Event nécessite l'installation d'un logiciel tiers (un moteur PHP, par exemple celui de XAMPP) pour les versions antérieures à 2.1.
 
-A partir de la version 2.1, les fichiers Papi des tournois peuvent être téléchargés sur l'ordinateur de l'arbitre sans installation supplémentaire. 
+À partir de la version 2.1, les fichiers Papi des tournois peuvent être téléchargés sur l'ordinateur de l'arbitre sans installation supplémentaire. 
 
 ## Configuration de l'accès à la plateforme Chess Event
 

--- a/docs/40-ref.md
+++ b/docs/40-ref.md
@@ -165,10 +165,11 @@ L'identifiant de la famille (`<family_id>`) est obligatoire et peut-être utilis
 | `number`   | Le nombre fixe d'échiquiers ou de joueur·euses à afficher sur chaque écran (Papi-web calcule automatiquement le nombre d'écrans nécessaires).                                                                                                                                  |
 
 > [!NOTE]
-> Si l'option `template` n'est par définie, on utilise par défaut :
-> - le modèle de même nom (`<family_id>`)
+> Si l'option `template` n'est pas définie, on utilise par défaut :
+> - le modèle de même nom (`<family_id>`) ;
 > - l'unique modèle de l'évènement si c'est le cas
-> Sinon la famille est ignorée.
+>
+> Si aucun de ces critères n'est rempli, la famille est ignorée.
 
 ## Écrans rotatifs (`[rotator.<rotator_id>]`)
 
@@ -182,9 +183,10 @@ L'identifiant de l'écran (`<rotator_id>`) est obligatoire.
 
 > [!NOTE]
 > Si aucune des deux options `screens` ou `families` n'est définie, on utilise par défaut :
-> - la famille de même nom (`<rotator_id>`)
+> - la famille de même nom (`<rotator_id>`) ;
 > - l'unique famille de l'évènement si c'est le cas
-> Sinon l'écran rotatif est ignoré.
+>
+> Si aucun de ces critères n'est rempli, l'écran rotatif est ignoré.
 
 ## Chronomètre
 


### PR DESCRIPTION
This PR addresses a few typos/errors I found while reading the docs for the first time, as I wanted to understand better how this application is working.

Please check carefully my changes because I might have overlooked some details/done some mistakes, since I didn't use this application on a real scale yet.

I also take the opportunity to list some suggestions for amelioration, don't hesitate to tell me if I should convert them to a single issue, a bunch of issues or even fix some in this PR.

- Default `papi-web.ini` content specifies `host` and `port` properties with `:` instead of `=`, which looks like the standard according to docs.
- Menus section (34) doesn't specify that `menu_text` is required for the screen to be displayed as a menu, it was misleading for me at first, since `menu` property is introduced first, but adding only it to my screens for testing was not changing anything in the application, nor displaying any warning/error in the dedicated space. This information is specified in ref section (40) though.  
- I feel like template & families section (33) could be inverted with menus section (34), since templating is an harder concept to understand (imo) and this section rely heavily on stuff from menus section (not only menu and menu_text, but also %t, %f and %l). Though menus section also rely on templating through examples, but these examples could be adapted maybe.
- Not directly related to docs, but why not providing meaningful labels for the different steps of a timer (section 31), like `before`, `soon` and `after` (instead of `1`, `2` and `3`).
- Rotators section (35) doesn't emphase that `families` property can take a list of families, I thought `families` was just a misleading name,  and noticed later (in ref section 40) that it can be also a list.

PS: These are just some neat pickings, it's truly amazing you built such a dense, clean and easy to follow documentation, lots of softwares should take example on this, thank you!