### PR TITLE
Tournament export to TRF(bx) format

### DIFF
--- a/locale/de/LC_MESSAGES/messages.po
+++ b/locale/de/LC_MESSAGES/messages.po
@@ -4788,11 +4788,15 @@ msgstr "Bearbeiten Sie die Eigenschaften des Turniers."
 
 #: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
-msgid "Export tournament to the TRF format."
-msgstr "Fügen Sie dem Event ein Turnier hinzu."
+msgid "Export"
+msgstr "Hafen"
 
 #: src/web/templates/admin_tournament_card.html
-msgid "Download"
+msgid "Export to TRF16 (rating)"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Export to TRF(bx) (pairing)"
 msgstr ""
 
 #: src/web/templates/admin_tournament_card.html

--- a/locale/de/LC_MESSAGES/messages.po
+++ b/locale/de/LC_MESSAGES/messages.po
@@ -4787,6 +4787,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Bearbeiten Sie die Eigenschaften des Turniers."
 
 #: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Export tournament to the TRF format."
+msgstr "Fügen Sie dem Event ein Turnier hinzu."
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Download"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation
 msgid "Clone the tournament."
 msgstr "Klonen Sie das Turnier."

--- a/locale/el/LC_MESSAGES/messages.po
+++ b/locale/el/LC_MESSAGES/messages.po
@@ -4787,6 +4787,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Επεξεργασία των ιδιοτήτων του τουρνουά."
 
 #: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Export tournament to the TRF format."
+msgstr "Προσθέστε ένα τουρνουά στην εκδήλωση."
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Download"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation
 msgid "Clone the tournament."
 msgstr "Κλώνε το τουρνουά."

--- a/locale/el/LC_MESSAGES/messages.po
+++ b/locale/el/LC_MESSAGES/messages.po
@@ -4788,11 +4788,15 @@ msgstr "Επεξεργασία των ιδιοτήτων του τουρνουά
 
 #: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
-msgid "Export tournament to the TRF format."
-msgstr "Προσθέστε ένα τουρνουά στην εκδήλωση."
+msgid "Export"
+msgstr "Λιμένας"
 
 #: src/web/templates/admin_tournament_card.html
-msgid "Download"
+msgid "Export to TRF16 (rating)"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Export to TRF(bx) (pairing)"
 msgstr ""
 
 #: src/web/templates/admin_tournament_card.html

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -3964,6 +3964,14 @@ msgid "Edit the properties of the tournament."
 msgstr ""
 
 #: src/web/templates/admin_tournament_card.html
+msgid "Export tournament to the TRF format."
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Download"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
 msgid "Clone the tournament."
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -3964,11 +3964,15 @@ msgid "Edit the properties of the tournament."
 msgstr ""
 
 #: src/web/templates/admin_tournament_card.html
-msgid "Export tournament to the TRF format."
+msgid "Export"
 msgstr ""
 
 #: src/web/templates/admin_tournament_card.html
-msgid "Download"
+msgid "Export to TRF16 (rating)"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Export to TRF(bx) (pairing)"
 msgstr ""
 
 #: src/web/templates/admin_tournament_card.html

--- a/locale/es/LC_MESSAGES/messages.po
+++ b/locale/es/LC_MESSAGES/messages.po
@@ -4768,6 +4768,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Edite las propiedades del torneo."
 
 #: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Export tournament to the TRF format."
+msgstr "Añade un torneo al evento."
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Download"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation
 msgid "Clone the tournament."
 msgstr "Clonó el torneo."

--- a/locale/es/LC_MESSAGES/messages.po
+++ b/locale/es/LC_MESSAGES/messages.po
@@ -4769,11 +4769,15 @@ msgstr "Edite las propiedades del torneo."
 
 #: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
-msgid "Export tournament to the TRF format."
-msgstr "Añade un torneo al evento."
+msgid "Export"
+msgstr "Puerto"
 
 #: src/web/templates/admin_tournament_card.html
-msgid "Download"
+msgid "Export to TRF16 (rating)"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Export to TRF(bx) (pairing)"
 msgstr ""
 
 #: src/web/templates/admin_tournament_card.html

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -3966,6 +3966,14 @@ msgid "Edit the properties of the tournament."
 msgstr "Éditer les propriétés du tournoi."
 
 #: src/web/templates/admin_tournament_card.html
+msgid "Export tournament to the TRF format."
+msgstr "Exporter le tournoi au format TRF."
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Download"
+msgstr "Télécharger"
+
+#: src/web/templates/admin_tournament_card.html
 msgid "Clone the tournament."
 msgstr "Dupliquer le tournoi"
 

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -3966,12 +3966,16 @@ msgid "Edit the properties of the tournament."
 msgstr "Éditer les propriétés du tournoi."
 
 #: src/web/templates/admin_tournament_card.html
-msgid "Export tournament to the TRF format."
-msgstr "Exporter le tournoi au format TRF."
+msgid "Export"
+msgstr "Exporter"
 
 #: src/web/templates/admin_tournament_card.html
-msgid "Download"
-msgstr "Télécharger"
+msgid "Export to TRF16 (rating)"
+msgstr "Exporter en TRF16 (classement)"
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Export to TRF(bx) (pairing)"
+msgstr "Exporter en TRF(bx) (appariements)"
 
 #: src/web/templates/admin_tournament_card.html
 msgid "Clone the tournament."

--- a/locale/it/LC_MESSAGES/messages.po
+++ b/locale/it/LC_MESSAGES/messages.po
@@ -4788,11 +4788,15 @@ msgstr "Modifica le proprietà del torneo."
 
 #: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
-msgid "Export tournament to the TRF format."
-msgstr "Aggiungi un torneo all'evento."
+msgid "Export"
+msgstr "Porta"
 
 #: src/web/templates/admin_tournament_card.html
-msgid "Download"
+msgid "Export to TRF16 (rating)"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Export to TRF(bx) (pairing)"
 msgstr ""
 
 #: src/web/templates/admin_tournament_card.html

--- a/locale/it/LC_MESSAGES/messages.po
+++ b/locale/it/LC_MESSAGES/messages.po
@@ -4787,6 +4787,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Modifica le proprietà del torneo."
 
 #: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Export tournament to the TRF format."
+msgstr "Aggiungi un torneo all'evento."
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Download"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation
 msgid "Clone the tournament."
 msgstr "Clonate il torneo."

--- a/locale/nl/LC_MESSAGES/messages.po
+++ b/locale/nl/LC_MESSAGES/messages.po
@@ -4787,6 +4787,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Bewerk de eigenschappen van het toernooi."
 
 #: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Export tournament to the TRF format."
+msgstr "Voeg een toernooi toe aan het evenement."
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Download"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation
 msgid "Clone the tournament."
 msgstr "Kloon het toernooi."

--- a/locale/nl/LC_MESSAGES/messages.po
+++ b/locale/nl/LC_MESSAGES/messages.po
@@ -4788,11 +4788,15 @@ msgstr "Bewerk de eigenschappen van het toernooi."
 
 #: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
-msgid "Export tournament to the TRF format."
-msgstr "Voeg een toernooi toe aan het evenement."
+msgid "Export"
+msgstr "Poort"
 
 #: src/web/templates/admin_tournament_card.html
-msgid "Download"
+msgid "Export to TRF16 (rating)"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Export to TRF(bx) (pairing)"
 msgstr ""
 
 #: src/web/templates/admin_tournament_card.html

--- a/locale/sv/LC_MESSAGES/messages.po
+++ b/locale/sv/LC_MESSAGES/messages.po
@@ -4787,6 +4787,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Redigera egenskaperna hos turneringen."
 
 #: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Export tournament to the TRF format."
+msgstr "Lägg till en turnering i evenemanget."
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Download"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation
 msgid "Clone the tournament."
 msgstr "-Klara turneringen."

--- a/locale/sv/LC_MESSAGES/messages.po
+++ b/locale/sv/LC_MESSAGES/messages.po
@@ -4788,11 +4788,15 @@ msgstr "Redigera egenskaperna hos turneringen."
 
 #: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
-msgid "Export tournament to the TRF format."
-msgstr "Lägg till en turnering i evenemanget."
+msgid "Export"
+msgstr "Hamn"
 
 #: src/web/templates/admin_tournament_card.html
-msgid "Download"
+msgid "Export to TRF16 (rating)"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Export to TRF(bx) (pairing)"
 msgstr ""
 
 #: src/web/templates/admin_tournament_card.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "pywin32-ctypes ~= 0.2.3",
   "requests ~= 2.32.3",
   "transformers ~= 4.47.1",
+  "trf @ https://github.com/papi-web-org/TRF/archive/refs/tags/v1.1.2-unofficial.zip",
   "uvicorn ~= 0.34.0",
   "validators ~= 0.34.0",
   "wheel ~= 0.45.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "pywin32-ctypes ~= 0.2.3",
   "requests ~= 2.32.3",
   "transformers ~= 4.47.1",
-  "trf @ https://github.com/papi-web-org/TRF/archive/refs/tags/v1.1.2-unofficial.zip",
+  "trf @ https://github.com/papi-web-org/TRF/archive/refs/tags/v1.1.3-unofficial.zip",
   "uvicorn ~= 0.34.0",
   "validators ~= 0.34.0",
   "wheel ~= 0.45.1",

--- a/src/data/pairing.py
+++ b/src/data/pairing.py
@@ -1,4 +1,6 @@
 from logging import Logger
+from typing import Callable
+
 from trf.Player import Game as TrfGame
 from common.logger import get_logger
 from dataclasses import dataclass
@@ -63,16 +65,10 @@ class Pairing:
     def forfeit_gain(self) -> bool:
         return self.result == Result.FORFEIT_GAIN
 
-    def to_trf(self, round_number: int) -> TrfGame:
-        from data.player import Player
-
-        opponent_papi_id = (
-            Player.player_papi_id_from_papi_web_id(self.opponent_id)
-            if self.opponent_id else None
-        )
+    def to_trf(self, round_number: int, player_id_to_trf_id: Callable[[int], int]) -> TrfGame:
         return TrfGame(
-            startrank=' ' if opponent_papi_id == 1 else opponent_papi_id,
-            color=self.color.to_trf if self.color and not self.result.is_bye else ' ',
+            startrank=player_id_to_trf_id(self.opponent_id) if self.opponent_id else '',
+            color=self.color.to_trf if self.color and not self.result.is_bye else '',
             result=self.result.to_trf,
             round=round_number)
 

--- a/src/data/pairing.py
+++ b/src/data/pairing.py
@@ -64,13 +64,17 @@ class Pairing:
         return self.result == Result.FORFEIT_GAIN
 
     def to_trf(self, round_number: int) -> TrfGame:
+        from data.player import Player
+
+        opponent_papi_id = (
+            Player.player_papi_id_from_papi_web_id(self.opponent_id)
+            if self.opponent_id else None
+        )
         return TrfGame(
-            ' ' if self.opponent_id == 1 else self.opponent_id,
+            ' ' if opponent_papi_id == 1 else opponent_papi_id,
             self.color.to_trf if self.color and not self.result.is_bye else ' ',
             self.result.to_trf,
             round_number)
 
     def __repr__(self):
         return f'{self.__class__.__name__}({self.color} {self.opponent_id} {self.result})'
-
-

--- a/src/data/pairing.py
+++ b/src/data/pairing.py
@@ -1,4 +1,5 @@
 from logging import Logger
+from trf.Player import Game as TrfGame
 from common.logger import get_logger
 from dataclasses import dataclass
 
@@ -62,5 +63,14 @@ class Pairing:
     def forfeit_gain(self) -> bool:
         return self.result == Result.FORFEIT_GAIN
 
+    def to_trf(self, round_number: int) -> TrfGame:
+        return TrfGame(
+            ' ' if self.opponent_id == 1 else self.opponent_id,
+            self.color.to_trf if self.color and not self.result.is_bye else ' ',
+            self.result.to_trf,
+            round_number)
+
     def __repr__(self):
         return f'{self.__class__.__name__}({self.color} {self.opponent_id} {self.result})'
+
+

--- a/src/data/pairing.py
+++ b/src/data/pairing.py
@@ -71,10 +71,10 @@ class Pairing:
             if self.opponent_id else None
         )
         return TrfGame(
-            ' ' if opponent_papi_id == 1 else opponent_papi_id,
-            self.color.to_trf if self.color and not self.result.is_bye else ' ',
-            self.result.to_trf,
-            round_number)
+            startrank=' ' if opponent_papi_id == 1 else opponent_papi_id,
+            color=self.color.to_trf if self.color and not self.result.is_bye else ' ',
+            result=self.result.to_trf,
+            round=round_number)
 
     def __repr__(self):
         return f'{self.__class__.__name__}({self.color} {self.opponent_id} {self.result})'

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -1,10 +1,11 @@
 import base64
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from functools import total_ordering, cached_property
 from logging import Logger
 from typing import TYPE_CHECKING, Self
+from trf import Player as TrfPlayer
 
 if TYPE_CHECKING:
     from data.tournament import Tournament
@@ -257,6 +258,23 @@ class Player:
         Otherwise, leave `self.points` as None."""
         with suppress(TypeError):
             self.points += points
+
+    @property
+    def to_trf(self) -> TrfPlayer:
+        self.compute_points(len(self.pairings))
+        return TrfPlayer(
+            self.ref_id,
+            f'{self.last_name}, {self.first_name}',
+            self.gender.to_trf,
+            self.title.to_trf,
+            self.rating,
+            self.federation,
+            self.fide_id,
+            self.date_of_birth.strftime('%Y/%m/%d') if self.date_of_birth else '',
+            self.points,
+            None,
+            [result.to_trf(round_nb) for round_nb, result in self.pairings.items()]
+        )
 
     @property
     def points_str(self) -> str:

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -231,13 +231,13 @@ class Player:
     def federation_tuple(self) -> FederationTuple:
         return FederationTuple(self.federation)
 
-    def compute_points(self, max_round: int):
-        """Computes and stores the points of the player,
-        from round 1 to round `max_round` (returns None)"""
+    def compute_points(self, max_round: int) -> float:
+        """Computes and returns the points of the player,
+        from round 1 to round `max_round`"""
         # NOTE(Amaras) this does not rely on the fact that insertion order
         # is preserved in 3.6+ dict, because I can't be sure insertion order
         # is the correct (increasing) round order
-        self.points = sum(
+        return sum(
                 pairing.result.point_value
                 for round_index, pairing in self.pairings.items()
                 # NOTE(Amaras) if you were to include the current round
@@ -260,7 +260,6 @@ class Player:
             self.points += points
 
     def to_trf(self, player_id_to_trf_id: Callable[[int], int]) -> TrfPlayer:
-        self.compute_points(len(self.pairings))
         return TrfPlayer(
             startrank=player_id_to_trf_id(self.id),
             name=f'{self.last_name}, {self.first_name}',
@@ -270,7 +269,7 @@ class Player:
             fed=self.federation,
             id=self.fide_id,
             birthdate=self.date_of_birth.strftime('%Y/%m/%d') if self.date_of_birth else '',
-            points=self.points,
+            points=self.compute_points(max(self.pairings.keys())+1),
             games=[result.to_trf(round_nb, player_id_to_trf_id) for round_nb, result in self.pairings.items()]
         )
 

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from datetime import date
 from functools import total_ordering, cached_property
 from logging import Logger
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Self, Callable
 from trf import Player as TrfPlayer
 
 if TYPE_CHECKING:
@@ -259,11 +259,10 @@ class Player:
         with suppress(TypeError):
             self.points += points
 
-    @property
-    def to_trf(self) -> TrfPlayer:
+    def to_trf(self, player_id_to_trf_id: Callable[[int], int]) -> TrfPlayer:
         self.compute_points(len(self.pairings))
         return TrfPlayer(
-            startrank=self.ref_id,
+            startrank=player_id_to_trf_id(self.id),
             name=f'{self.last_name}, {self.first_name}',
             sex=self.gender.to_trf,
             title=self.title.to_trf,
@@ -272,7 +271,7 @@ class Player:
             id=self.fide_id,
             birthdate=self.date_of_birth.strftime('%Y/%m/%d') if self.date_of_birth else '',
             points=self.points,
-            games=[result.to_trf(round_nb) for round_nb, result in self.pairings.items()]
+            games=[result.to_trf(round_nb, player_id_to_trf_id) for round_nb, result in self.pairings.items()]
         )
 
     @property
@@ -354,6 +353,11 @@ class Player:
         self.time_control_initial_time = initial_time
         self.time_control_increment = increment
         self.time_control_modified = modified
+
+    def starting_rank_comparison(self, other: "Player") -> bool:
+        return (
+            (self.rating, self.title, other.last_name, other.first_name) <=
+            (other.rating, other.title, self.last_name, self.first_name))
 
     def __le__(self, other):
         # p1 <= p2 calls p1.__le__(p2)

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -263,17 +263,16 @@ class Player:
     def to_trf(self) -> TrfPlayer:
         self.compute_points(len(self.pairings))
         return TrfPlayer(
-            self.ref_id,
-            f'{self.last_name}, {self.first_name}',
-            self.gender.to_trf,
-            self.title.to_trf,
-            self.rating,
-            self.federation,
-            self.fide_id,
-            self.date_of_birth.strftime('%Y/%m/%d') if self.date_of_birth else '',
-            self.points,
-            None,
-            [result.to_trf(round_nb) for round_nb, result in self.pairings.items()]
+            startrank=self.ref_id,
+            name=f'{self.last_name}, {self.first_name}',
+            sex=self.gender.to_trf,
+            title=self.title.to_trf,
+            rating=self.rating,
+            fed=self.federation,
+            id=self.fide_id,
+            birthdate=self.date_of_birth.strftime('%Y/%m/%d') if self.date_of_birth else '',
+            points=self.points,
+            games=[result.to_trf(round_nb) for round_nb, result in self.pairings.items()]
         )
 
     @property

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -231,19 +231,25 @@ class Player:
     def federation_tuple(self) -> FederationTuple:
         return FederationTuple(self.federation)
 
-    def compute_points(self, max_round: int) -> float:
-        """Computes and returns the points of the player,
-        from round 1 to round `max_round`"""
+    def compute_points(self, max_round: int):
+        """Computes and stores the points of the player,
+        from round 1 to round `max_round` (returns None)"""
         # NOTE(Amaras) this does not rely on the fact that insertion order
         # is preserved in 3.6+ dict, because I can't be sure insertion order
         # is the correct (increasing) round order
+        # NOTE(Amaras) if you were to include the current round
+        # in the computation, boards regularly change their ordering
+        # during the current round as results are added
+        self.points = self.points_before(max_round)
+
+    def points_before(self, max_round: int) -> float:
         return sum(
-                pairing.result.point_value
-                for round_index, pairing in self.pairings.items()
-                # NOTE(Amaras) if you were to include the current round
-                # in the computation, boards regularly change their ordering
-                # during the current round as results are added
-                if round_index < max_round)
+            pairing.result.point_value
+            for round_index, pairing in self.pairings.items()
+            if round_index < max_round)
+
+    def points_total(self) -> float:
+        return sum(pairing.result.point_value for pairing in self.pairings.values())
 
     @staticmethod
     def _points_str(points: float | None) -> str:
@@ -269,7 +275,7 @@ class Player:
             fed=self.federation,
             id=self.fide_id,
             birthdate=self.date_of_birth.strftime('%Y/%m/%d') if self.date_of_birth else '',
-            points=self.compute_points(max(self.pairings.keys())+1),
+            points=self.points_total(),
             games=[result.to_trf(round_nb, player_id_to_trf_id) for round_nb, result in self.pairings.items()]
         )
 

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -411,18 +411,27 @@ class Tournament:
 
     @property
     def to_trf(self) -> TrfTournament:
+        players = [player for id_, player in self.players_by_id.items() if id_ != 1]
+        xx_fields: dict[str, str] = {}
+        for player in players:
+            xx_fields[f'XXA {player.ref_id:>4}'] = self._trf_player_acceleration(player)
         return TrfTournament(
-            self.name,
-            self.location,
-            '',
-            self.start_date,
-            self.end_date,
-            len(self.players_by_id),
-            0, 0, '',
-            self.arbiter,
-            '', '', [],
-            [player.to_trf for id, player in self.players_by_id.items() if id != 1],
+            name=self.name,
+            city=self.location,
+            startdate=self.start_date,
+            enddate=self.end_date,
+            numplayers=len(self.players_by_id),
+            chiefarbiter=self.arbiter,
+            players=[player.to_trf for player in players],
+            xx_fields=xx_fields
         )
+
+    def _trf_player_acceleration(self, player: Player) -> str:
+        acceleration_history = [
+            f'{self._calculate_player_virtual_points(player, round_nb):>4}'
+            for round_nb in range(1, self._current_round+1)
+        ]
+        return ' '.join(acceleration_history)
 
     def read_papi(self):
         """Fetch tournament information from the Papi database, as well
@@ -498,60 +507,62 @@ class Tournament:
         for player in self._players_by_id.values():
             if player.ref_id == 1:
                 continue
-            # real points
+            vpoints = self._calculate_player_virtual_points(player, self._current_round)
             player.compute_points(self._current_round)
-            # virtual points
-            player.vpoints = 0.0
-            vpoints: float = 0.0
-            if self._pairing == TournamentPairing.HALEY:
-                if self._current_round <= 2 and player.rating >= self._rating_limit1:
-                    vpoints = 1.0
-            elif self._pairing == TournamentPairing.HALEY_SOFT:
-                # Round 1: All players above rating_limit1 get 1 vpoint
-                # Round 2: All players above rating_limit1 get 1 vpoint
-                # Round 2: All other players get .5 vpoints
-                # bottom of page #138 on
-                # https://dna.ffechecs.fr/wp-content/uploads/sites/2/2023/10/Livre-arbitre-octobre-2023.pdf,
-                # please remove if OK
-                if self._current_round <= 2 and player.rating >= self.rating_limit1:
-                    vpoints = 1.0
-                elif self._current_round == 2 and player.rating < self.rating_limit1:
-                    vpoints = 0.5
-            elif self._pairing == TournamentPairing.SAD:
-                # Before the second to last round, we remove the virtual
-                # points, and use a simple Swiss Dutch system.
-                if self._current_round <= self._rounds - 2:
-                    # Each 1.5 points earned, virtual points go up by 0.5
-                    # No player can have more than 2 points.
-                    # At the start, players are sorted in three groups
-                    # based on their rating.
-                    # Group A players start with 2 points
-                    # Group B players start with 1 point
-                    # Group C players start with 0 points.
-                    # If a player reaches more than half of the possible score,
-                    # their virtual points capital is raised to 2 points.
-
-                    # NOTE(Amaras): // is implemented on float as well, so it's
-                    # way simpler to implement than by applying the algorithm
-                    # step by step.
-                    potential_vpoints = 0.5 * (player.points // 1.5)
-                    if player.rating >= self.rating_limit1:
-                        # Group A players get 2 virtual points
-                        vpoints = 2.0
-                    elif player.rating >= self.rating_limit2:
-                        # Group B players start with 1 point
-                        # Players cannot have more than 2 points
-                        vpoints = min(2.0, 1.0 + potential_vpoints)
-                    else:
-                        # Group C players start with 0 points
-                        # Players cannot have more than 2 points
-                        vpoints = min(2.0, potential_vpoints)
-                    if 2 * player.points >= self._rounds:
-                        # If a player gets at least half the possible score,
-                        # their capital is set at 2 points.
-                        # Assumes a 0-0.5-1 scoring system.
-                        vpoints = 2.0
             player.vpoints = player.points + vpoints
+
+    def _calculate_player_virtual_points(self, player: Player, round_number: int) -> float:
+        vpoints = 0.0
+        if self._pairing == TournamentPairing.HALEY:
+            if round_number <= 2 and player.rating >= self._rating_limit1:
+                vpoints = 1.0
+        elif self._pairing == TournamentPairing.HALEY_SOFT:
+            # Round 1: All players above rating_limit1 get 1 vpoint
+            # Round 2: All players above rating_limit1 get 1 vpoint
+            # Round 2: All other players get .5 vpoints
+            # bottom of page #138 on
+            # https://dna.ffechecs.fr/wp-content/uploads/sites/2/2023/10/Livre-arbitre-octobre-2023.pdf,
+            # please remove if OK
+            if round_number <= 2 and player.rating >= self.rating_limit1:
+                vpoints = 1.0
+            elif round_number == 2 and player.rating < self.rating_limit1:
+                vpoints = 0.5
+        elif self._pairing == TournamentPairing.SAD:
+            # Before the second to last round, we remove the virtual
+            # points, and use a simple Swiss Dutch system.
+            if round_number <= self._rounds - 2:
+                # Each 1.5 points earned, virtual points go up by 0.5
+                # No player can have more than 2 points.
+                # At the start, players are sorted in three groups
+                # based on their rating.
+                # Group A players start with 2 points
+                # Group B players start with 1 point
+                # Group C players start with 0 points.
+                # If a player reaches more than half of the possible score,
+                # their virtual points capital is raised to 2 points.
+
+                # NOTE(Amaras): // is implemented on float as well, so it's
+                # way simpler to implement than by applying the algorithm
+                # step by step.
+                potential_vpoints = 0.5 * (player.points // 1.5)
+                if player.rating >= self.rating_limit1:
+                    # Group A players get 2 virtual points
+                    vpoints = 2.0
+                elif player.rating >= self.rating_limit2:
+                    # Group B players start with 1 point
+                    # Players cannot have more than 2 points
+                    vpoints = min(2.0, 1.0 + potential_vpoints)
+                else:
+                    # Group C players start with 0 points
+                    # Players cannot have more than 2 points
+                    vpoints = min(2.0, potential_vpoints)
+                player.compute_points(round_number)
+                if 2 * player.points >= self._rounds:
+                    # If a player gets at least half the possible score,
+                    # their capital is set at 2 points.
+                    # Assumes a 0-0.5-1 scoring system.
+                    vpoints = 2.0
+        return vpoints
 
     def store_illegal_move(self, player: Player):
         """Store an illegal move for the given `player`, for the current

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -456,13 +456,13 @@ class Tournament:
         }
 
         # Acceleration
-        for player in [player for id_, player in self.players_by_id.items() if id_ != 1]:
+        for trf_id, player in self.players_by_trf_id.items():
             vpoints_history = [
                 self._calculate_player_virtual_points(player, round_nb)
                 for round_nb in range(1, self._current_round+1)
             ]
             if sum(vpoints_history) > 0:
-                xx_fields[f'XXA {player.ref_id:>4}'] = ' '.join(
+                xx_fields[f'XXA {trf_id:>4}'] = ' '.join(
                     [f'{vpoints:>4}' for vpoints in vpoints_history]
                 )
 

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -4,6 +4,7 @@ from functools import cached_property
 from logging import Logger
 from operator import attrgetter
 from pathlib import Path
+from trf import Tournament as TrfTournament
 from typing import TYPE_CHECKING
 
 from common import format_timestamp_date_time
@@ -62,6 +63,10 @@ class Tournament:
         self._playing: bool = False
         self._rating_limit1: int = 0
         self._rating_limit2: int = 0
+        self._location: str = ''
+        self._start_date: str = ''
+        self._end_date: str = ''
+        self._arbiter: str = ''
         self._boards: list[Board] | None = None
         self._unpaired_players: list[Player] | None = None
         self._papi_read = False
@@ -260,6 +265,26 @@ class Tournament:
         return self._rating_limit2
 
     @property
+    def location(self) -> str:
+        self.read_papi()
+        return self._location
+
+    @property
+    def start_date(self) -> str:
+        self.read_papi()
+        return self._start_date
+
+    @property
+    def end_date(self) -> str:
+        self.read_papi()
+        return self._end_date
+
+    @property
+    def arbiter(self) -> str:
+        self.read_papi()
+        return self._arbiter
+
+    @property
     def players_by_id(self) -> dict[int, Player]:
         self.read_papi()
         return self._players_by_id
@@ -384,6 +409,21 @@ class Tournament:
             case _:
                 return False
 
+    @property
+    def to_trf(self) -> TrfTournament:
+        return TrfTournament(
+            self.name,
+            self.location,
+            '',
+            self.start_date,
+            self.end_date,
+            len(self.players_by_id),
+            0, 0, '',
+            self.arbiter,
+            '', '', [],
+            [player.to_trf for id, player in self.players_by_id.items() if id != 1],
+        )
+
     def read_papi(self):
         """Fetch tournament information from the Papi database, as well
         as the player information."""
@@ -396,7 +436,11 @@ class Tournament:
                     self._pairing,
                     self._rating,
                     self._rating_limit1,
-                    self._rating_limit2
+                    self._rating_limit2,
+                    self._location,
+                    self._start_date,
+                    self._end_date,
+                    self._arbiter,
                 ) = papi_database.read_info()
                 self._players_by_id = papi_database.read_players(self.id, self._rounds)
             for player in self._players_by_id.values():
@@ -407,6 +451,10 @@ class Tournament:
             self._current_round = 0
             self._rating_limit1 = None
             self._rating_limit2 = None
+            self._location = ''
+            self._start_date = ''
+            self._end_date = ''
+            self._arbiter = ''
             self._boards = []
             self._unpaired_players = []
         self._papi_read = True

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -437,7 +437,10 @@ class Tournament:
                 player.to_trf(self._player_id_to_trf_id)
                 for id_, player in self.players_by_trf_id.items()],
             xx_fields=(
-                self._trf_extra_fields(first_round_pairing)
+                self._trf_xx_fields(first_round_pairing)
+                if trf_type == TrfType.PAIRING else {}),
+            bb_fields=(
+                self._trf_bb_fields()
                 if trf_type == TrfType.PAIRING else {}),
         )
 
@@ -447,26 +450,24 @@ class Tournament:
                 return trf_id
         raise KeyError(f"Id of unknown player: {player_id}")
 
-    def _trf_extra_fields(
-        self, first_round_pairing: BoardColor, result_class: type[Result] = Result
-    ) -> dict[str, str]:
-        xx_fields: dict[str, str] = {
+    def _trf_xx_fields(self, first_round_pairing: BoardColor):
+        fields: dict[str, str] = {
             'XXR': str(self.rounds),
             'XXC': first_round_pairing.to_trf_first_round_pairing,
         }
-
-        # Acceleration
         for trf_id, player in self.players_by_trf_id.items():
             vpoints_history = [
                 self._calculate_player_virtual_points(player, round_nb)
-                for round_nb in range(1, self._current_round+1)
+                for round_nb in range(1, self._current_round + 1)
             ]
             if sum(vpoints_history) > 0:
-                xx_fields[f'XXA {trf_id:>4}'] = ' '.join(
+                fields[f'XXA {trf_id:>4}'] = ' '.join(
                     [f'{vpoints:>4}' for vpoints in vpoints_history]
                 )
+        return fields
 
-        # BBP fields
+    def _trf_bb_fields(self, result_class: type[Result] = Result) -> dict[str, str]:
+        fields: dict[str, str] = {}
         for result in [
             result_class.GAIN,
             result_class.DRAW,
@@ -475,8 +476,8 @@ class Tournament:
             result_class.PAIRING_ALLOCATED_BYE,
             result_class.ZERO_POINT_BYE,
         ]:
-            xx_fields[result.bbp_field] = f'{result.point_value:>4}'
-        return xx_fields
+            fields[result.bbp_field] = f'{result.point_value:>4}'
+        return fields
 
     def read_papi(self):
         """Fetch tournament information from the Papi database, as well
@@ -552,9 +553,9 @@ class Tournament:
         for player in self._players_by_id.values():
             if player.ref_id == 1:
                 continue
-            player.points = player.compute_points(self._current_round)
-            player.vpoints = player.points + self._calculate_player_virtual_points(
-                player, self._current_round)
+            vpoints = self._calculate_player_virtual_points(player, self._current_round)
+            player.compute_points(self._current_round)
+            player.vpoints = player.points + vpoints
 
     def _calculate_player_virtual_points(self, player: Player, round_number: int) -> float:
         vpoints = 0.0
@@ -589,7 +590,7 @@ class Tournament:
                 # NOTE(Amaras): // is implemented on float as well, so it's
                 # way simpler to implement than by applying the algorithm
                 # step by step.
-                points = player.compute_points(round_number)
+                points = player.points_before(round_number)
                 potential_vpoints = 0.5 * (points // 1.5)
                 if player.rating >= self.rating_limit1:
                     # Group A players get 2 virtual points

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -11,6 +11,7 @@ from common import format_timestamp_date_time
 from common.i18n import _
 from common.papi_web_config import PapiWebConfig
 from data.pairing import Pairing
+from data.util import TrfType
 
 if TYPE_CHECKING:
     from data.event import Event
@@ -420,7 +421,11 @@ class Tournament:
             case _:
                 return False
 
-    def to_trf(self, first_round_pairing: BoardColor = BoardColor.WHITE) -> TrfTournament:
+    def to_trf(
+        self, 
+        trf_type: TrfType,
+        first_round_pairing: BoardColor = BoardColor.WHITE,
+    ) -> TrfTournament:
         return TrfTournament(
             name=self.name,
             city=self.location,
@@ -431,7 +436,9 @@ class Tournament:
             players=[
                 player.to_trf(self._player_id_to_trf_id)
                 for id_, player in self.players_by_trf_id.items()],
-            xx_fields=self._trf_extra_fields(first_round_pairing)
+            xx_fields=(
+                self._trf_extra_fields(first_round_pairing)
+                if trf_type == TrfType.PAIRING else {}),
         )
 
     def _player_id_to_trf_id(self, player_id: int) -> int:
@@ -456,7 +463,7 @@ class Tournament:
             ]
             if sum(vpoints_history) > 0:
                 xx_fields[f'XXA {player.ref_id:>4}'] = ' '.join(
-                    [f'{vpoints}:>4' for vpoints in vpoints_history]
+                    [f'{vpoints:>4}' for vpoints in vpoints_history]
                 )
 
         # BBP fields

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -552,9 +552,9 @@ class Tournament:
         for player in self._players_by_id.values():
             if player.ref_id == 1:
                 continue
-            vpoints = self._calculate_player_virtual_points(player, self._current_round)
-            player.compute_points(self._current_round)
-            player.vpoints = player.points + vpoints
+            player.points = player.compute_points(self._current_round)
+            player.vpoints = player.points + self._calculate_player_virtual_points(
+                player, self._current_round)
 
     def _calculate_player_virtual_points(self, player: Player, round_number: int) -> float:
         vpoints = 0.0
@@ -589,8 +589,8 @@ class Tournament:
                 # NOTE(Amaras): // is implemented on float as well, so it's
                 # way simpler to implement than by applying the algorithm
                 # step by step.
-                player.compute_points(round_number)
-                potential_vpoints = 0.5 * (player.points // 1.5)
+                points = player.compute_points(round_number)
+                potential_vpoints = 0.5 * (points // 1.5)
                 if player.rating >= self.rating_limit1:
                     # Group A players get 2 virtual points
                     vpoints = 2.0
@@ -602,7 +602,7 @@ class Tournament:
                     # Group C players start with 0 points
                     # Players cannot have more than 2 points
                     vpoints = min(2.0, potential_vpoints)
-                if 2 * player.points >= self._rounds:
+                if 2 * points >= self._rounds:
                     # If a player gets at least half the possible score,
                     # their capital is set at 2 points.
                     # Assumes a 0-0.5-1 scoring system.

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -304,6 +304,17 @@ class Tournament:
         return {player.fide_id: player for player in self.players_by_id.values() if player.fide_id}
 
     @cached_property
+    def players_by_trf_id(self) -> dict[int, Player]:
+        players = [player for id_, player in self.players_by_id.items() if id_ != 1]
+        le_method = Player.__le__
+        try:
+            Player.__le__ = lambda self_, other: self_.starting_rank_comparison(other)
+            ordered_players = sorted(players, reverse=True)
+            return {index + 1: player for index, player in enumerate(ordered_players)}
+        finally:
+            Player.__le__ = le_method
+
+    @cached_property
     def players_by_name_with_unpaired(self) -> list[Player]:
         return sorted(list(self.players_by_id.values()), key=lambda player: (player.last_name, player.first_name))
 
@@ -409,12 +420,7 @@ class Tournament:
             case _:
                 return False
 
-    @property
-    def to_trf(self) -> TrfTournament:
-        players = [player for id_, player in self.players_by_id.items() if id_ != 1]
-        xx_fields: dict[str, str] = {}
-        for player in players:
-            xx_fields[f'XXA {player.ref_id:>4}'] = self._trf_player_acceleration(player)
+    def to_trf(self, first_round_pairing: BoardColor = BoardColor.WHITE) -> TrfTournament:
         return TrfTournament(
             name=self.name,
             city=self.location,
@@ -422,16 +428,48 @@ class Tournament:
             enddate=self.end_date,
             numplayers=len(self.players_by_id),
             chiefarbiter=self.arbiter,
-            players=[player.to_trf for player in players],
-            xx_fields=xx_fields
+            players=[
+                player.to_trf(self._player_id_to_trf_id)
+                for id_, player in self.players_by_trf_id.items()],
+            xx_fields=self._trf_extra_fields(first_round_pairing)
         )
 
-    def _trf_player_acceleration(self, player: Player) -> str:
-        acceleration_history = [
-            f'{self._calculate_player_virtual_points(player, round_nb):>4}'
-            for round_nb in range(1, self._current_round+1)
-        ]
-        return ' '.join(acceleration_history)
+    def _player_id_to_trf_id(self, player_id: int) -> int:
+        for trf_id, player in self.players_by_trf_id.items():
+            if player.id == player_id:
+                return trf_id
+        raise KeyError(f"Id of unknown player: {player_id}")
+
+    def _trf_extra_fields(
+        self, first_round_pairing: BoardColor, result_class: type[Result] = Result
+    ) -> dict[str, str]:
+        xx_fields: dict[str, str] = {
+            'XXR': str(self.rounds),
+            'XXC': first_round_pairing.to_trf_first_round_pairing,
+        }
+
+        # Acceleration
+        for player in [player for id_, player in self.players_by_id.items() if id_ != 1]:
+            vpoints_history = [
+                self._calculate_player_virtual_points(player, round_nb)
+                for round_nb in range(1, self._current_round+1)
+            ]
+            if sum(vpoints_history) > 0:
+                xx_fields[f'XXA {player.ref_id:>4}'] = ' '.join(
+                    [f'{vpoints}:>4' for vpoints in vpoints_history]
+                )
+
+        # BBP fields
+        for result in [
+            result_class.GAIN,
+            result_class.DRAW,
+            result_class.LOSS,
+            result_class.FORFEIT_LOSS,
+            result_class.PAIRING_ALLOCATED_BYE,
+            result_class.ZERO_POINT_BYE,
+        ]:
+            xx_fields[result.bbp_field] = f'{result.point_value:>4}'
+        return xx_fields
 
     def read_papi(self):
         """Fetch tournament information from the Papi database, as well

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -589,6 +589,7 @@ class Tournament:
                 # NOTE(Amaras): // is implemented on float as well, so it's
                 # way simpler to implement than by applying the algorithm
                 # step by step.
+                player.compute_points(round_number)
                 potential_vpoints = 0.5 * (player.points // 1.5)
                 if player.rating >= self.rating_limit1:
                     # Group A players get 2 virtual points
@@ -601,7 +602,6 @@ class Tournament:
                     # Group C players start with 0 points
                     # Players cannot have more than 2 points
                     vpoints = min(2.0, potential_vpoints)
-                player.compute_points(round_number)
                 if 2 * player.points >= self._rounds:
                     # If a player gets at least half the possible score,
                     # their capital is set at 2 points.

--- a/src/data/util.py
+++ b/src/data/util.py
@@ -238,6 +238,24 @@ class Result(IntEnum):
                 raise ValueError(f"Unknown value: {self}")
 
     @property
+    def bbp_field(self) -> str:
+        match self:
+            case Result.LOSS:
+                return 'BBL'
+            case Result.DRAW:
+                return 'BBD'
+            case Result.GAIN:
+                return 'BBW'
+            case Result.FORFEIT_LOSS:
+                return 'BBF'
+            case Result.PAIRING_ALLOCATED_BYE:
+                return 'BBU'
+            case Result.ZERO_POINT_BYE:
+                return 'BBZ'
+            case _:
+                raise ValueError(f"Result with no matching BBP field: {self}")
+
+    @property
     def is_bye(self) -> bool:
         return self in (Result.HALF_POINT_BYE, Result.FULL_POINT_BYE, Result.PAIRING_ALLOCATED_BYE)
 
@@ -1022,6 +1040,16 @@ class BoardColor(StrEnum):
                 return 'w'
             case BoardColor.BLACK:
                 return 'b'
+            case _:
+                raise ValueError(f'Unknown value:  {self}')
+
+    @property
+    def to_trf_first_round_pairing(self) -> str:
+        match self:
+            case BoardColor.WHITE:
+                return 'white1'
+            case BoardColor.BLACK:
+                return 'black1'
             case _:
                 raise ValueError(f'Unknown value:  {self}')
 

--- a/src/data/util.py
+++ b/src/data/util.py
@@ -950,17 +950,17 @@ class PlayerTitle(IntEnum):
             case PlayerTitle.NONE:
                 return ''
             case PlayerTitle.WOMAN_FIDE_MASTER:
-                return 'WFM'
+                return 'ff'
             case PlayerTitle.FIDE_MASTER:
-                return 'FM'
+                return 'f'
             case PlayerTitle.WOMAN_INTERNATIONAL_MASTER:
-                return 'WIM'
+                return 'mf'
             case PlayerTitle.INTERNATIONAL_MASTER:
-                return 'IM'
+                return 'm'
             case PlayerTitle.WOMAN_GRANDMASTER:
-                return 'WGM'
+                return 'gf'
             case PlayerTitle.GRANDMASTER:
-                return 'GM'
+                return 'g'
             case _:
                 raise ValueError(f'Unknown title: {self}')
 

--- a/src/data/util.py
+++ b/src/data/util.py
@@ -584,7 +584,7 @@ class PlayerGender(IntEnum):
             case PlayerGender.NONE:
                 return ''
             case PlayerGender.FEMALE:
-                return 'f'
+                return 'w'
             case PlayerGender.MALE:
                 return 'm'
             case _:

--- a/src/data/util.py
+++ b/src/data/util.py
@@ -230,7 +230,9 @@ class Result(IntEnum):
                 return 'F'
             case Result.PAIRING_ALLOCATED_BYE:
                 return 'U'
-            case Result.NOT_PAIRED:
+            case Result.ZERO_POINT_BYE:
+                return 'Z'
+            case Result.NO_RESULT:
                 return ' '
             case _:
                 raise ValueError(f"Unknown value: {self}")
@@ -1016,9 +1018,9 @@ class BoardColor(StrEnum):
     @property
     def to_trf(self) -> str:
         match self:
-            case Color.WHITE:
+            case BoardColor.WHITE:
                 return 'w'
-            case Color.BLACK:
+            case BoardColor.BLACK:
                 return 'b'
             case _:
                 raise ValueError(f'Unknown value:  {self}')

--- a/src/data/util.py
+++ b/src/data/util.py
@@ -205,6 +205,40 @@ class Result(IntEnum):
             case _:
                 raise ValueError(f"Unknown value: {self}")
 
+    @property
+    def to_trf(self) -> str:
+        match self:
+            case Result.LOSS:
+                return '0'
+            case Result.DRAW:
+                return '='
+            case Result.GAIN:
+                return '1'
+            case Result.UNRATED_LOSS:
+                return 'L'
+            case Result.UNRATED_DRAW:
+                return 'D'
+            case Result.UNRATED_GAIN:
+                return 'W'
+            case Result.FORFEIT_LOSS | Result.DOUBLE_FORFEIT:
+                return '-'
+            case Result.FORFEIT_GAIN:
+                return '+'
+            case Result.HALF_POINT_BYE:
+                return 'H'
+            case Result.FULL_POINT_BYE:
+                return 'F'
+            case Result.PAIRING_ALLOCATED_BYE:
+                return 'U'
+            case Result.NOT_PAIRED:
+                return ' '
+            case _:
+                raise ValueError(f"Unknown value: {self}")
+
+    @property
+    def is_bye(self) -> bool:
+        return self in (Result.HALF_POINT_BYE, Result.FULL_POINT_BYE, Result.PAIRING_ALLOCATED_BYE)
+
     @classmethod
     def user_imputable_results(cls) -> tuple[Self, ...]:
         """Imputable results are the ones that a player can
@@ -521,6 +555,18 @@ class PlayerGender(IntEnum):
                 return 'F'
             case PlayerGender.MALE:
                 return 'M'
+            case _:
+                raise ValueError(f'Unknown value: {self}')
+
+    @property
+    def to_trf(self) -> str:
+        match self:
+            case PlayerGender.NONE:
+                return ''
+            case PlayerGender.FEMALE:
+                return 'f'
+            case PlayerGender.MALE:
+                return 'm'
             case _:
                 raise ValueError(f'Unknown value: {self}')
 
@@ -879,6 +925,26 @@ class PlayerTitle(IntEnum):
                 raise ValueError(f'Unknown title: {self}')
 
     @property
+    def to_trf(self) -> str:
+        match self:
+            case PlayerTitle.NONE:
+                return ''
+            case PlayerTitle.WOMAN_FIDE_MASTER:
+                return 'WFM'
+            case PlayerTitle.FIDE_MASTER:
+                return 'FM'
+            case PlayerTitle.WOMAN_INTERNATIONAL_MASTER:
+                return 'WIM'
+            case PlayerTitle.INTERNATIONAL_MASTER:
+                return 'IM'
+            case PlayerTitle.WOMAN_GRANDMASTER:
+                return 'WGM'
+            case PlayerTitle.GRANDMASTER:
+                return 'GM'
+            case _:
+                raise ValueError(f'Unknown title: {self}')
+
+    @property
     def name(self) -> str:
         match self:
             case PlayerTitle.NONE:
@@ -944,6 +1010,16 @@ class BoardColor(StrEnum):
                 return 'B'
             case BoardColor.BLACK:
                 return 'N'
+            case _:
+                raise ValueError(f'Unknown value:  {self}')
+
+    @property
+    def to_trf(self) -> str:
+        match self:
+            case Color.WHITE:
+                return 'w'
+            case Color.BLACK:
+                return 'b'
             case _:
                 raise ValueError(f'Unknown value:  {self}')
 

--- a/src/data/util.py
+++ b/src/data/util.py
@@ -1146,3 +1146,18 @@ class NeedsUpload(Enum):
                 return False
             case _:
                 raise ValueError(f"Unknown value: {self}")
+
+
+class TrfType(StrEnum):
+    PAIRING = 'PAIRING'
+    RATING = 'RATING'
+
+    @property
+    def file_extension(self) -> str:
+        match self:
+            case TrfType.RATING:
+                return 'trf'
+            case TrfType.PAIRING:
+                return 'trfx'
+            case _:
+                raise ValueError(f"Unknown value: {self}")

--- a/src/database/papi.py
+++ b/src/database/papi.py
@@ -184,7 +184,7 @@ class PapiDatabase(AccessDatabase):
                 pairings[round_] = Pairing(
                     color,
                     Player.player_papi_web_id_from_papi_id(tournament_id, opponent_papi_id)
-                    if opponent_papi_id else None,
+                    if opponent_papi_id and opponent_papi_id != 1 else None,
                     Result.from_papi_value(
                         row[f'{round_str}Res'],
                         opponent_papi_id is None,

--- a/src/database/papi.py
+++ b/src/database/papi.py
@@ -25,6 +25,10 @@ class TournamentInfo(NamedTuple):
     rating: TournamentRating
     rating_limit1: int
     rating_limit2: int
+    location: str
+    start_date: str
+    end_date: str
+    arbiter: str
 
 
 class PapiDatabase(AccessDatabase):
@@ -51,7 +55,13 @@ class PapiDatabase(AccessDatabase):
         rating: TournamentRating = TournamentRating.from_papi_value(self._read_var('ClassElo'))
         rating_limit1: int = int(self._read_var('EloBase1'))
         rating_limit2: int = int(self._read_var('EloBase2'))
-        return TournamentInfo(rounds, pairing, rating, rating_limit1, rating_limit2)
+        location: str = self._read_var('Lieu')
+        start_date: str = self._read_var('DateDebut')
+        end_date: str = self._read_var('DateFin')
+        arbiter: str = self._read_var('Arbitre')
+        return TournamentInfo(
+            rounds, pairing, rating, rating_limit1, rating_limit2,
+            location, start_date, end_date, arbiter)
 
     def read_player_dict(
             self, player_papi_id: int

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -17,6 +17,7 @@ from common.logger import get_logger
 from data.event import Event
 from data.loader import EventLoader
 from data.tournament import Tournament
+from data.util import TrfType
 from database.sqlite import EventDatabase
 from database.store import StoredTournament, StoredScreen
 from web.controllers.admin.event_admin_controller import EventAdminWebContext, AbstractEventAdminController
@@ -313,14 +314,18 @@ class TournamentAdminController(AbstractEventAdminController):
         name='admin-tournament-trf-export',
     )
     async def admin_tournament_trf_export(
-            self, request: HTMXRequest, event_uniq_id: str, tournament_id: int
+            self,
+            request: HTMXRequest,
+            event_uniq_id: str,
+            tournament_id: int,
+            usage: TrfType = TrfType.PAIRING,
     ) -> File:
         context = TournamentAdminWebContext(request, event_uniq_id, None, tournament_id, None)
         tournament = context.admin_tournament
         temp_file = NamedTemporaryFile(delete=False, mode="w", suffix=".trf")
         with temp_file as file:
-            trf.dump(file, tournament.to_trf())
-        return File(path=temp_file.name, filename=f'{tournament.name}.trf')
+            trf.dump(file, tournament.to_trf(usage))
+        return File(path=temp_file.name, filename=f'{tournament.name}.{usage.file_extension}')
 
     def _admin_tournament_update(
             self, request: HTMXRequest,

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -1,13 +1,15 @@
 import re
 from logging import Logger
+from tempfile import NamedTemporaryFile
 from typing import Annotated, Any
 
+import trf
 from litestar import post, get, delete, patch
 from litestar.contrib.htmx.request import HTMXRequest
 from litestar.contrib.htmx.response import ClientRedirect
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
-from litestar.response import Template
+from litestar.response import Template, File
 from litestar.status_codes import HTTP_200_OK
 
 from common.i18n import _
@@ -305,6 +307,20 @@ class TournamentAdminController(AbstractEventAdminController):
     ) -> Template | ClientRedirect:
         return self._admin_event_tournaments_render(
             request, event_uniq_id=event_uniq_id, modal='tournament', action=action, tournament_id=tournament_id)
+
+    @get(
+        path='/admin/tournament-trf-export/{event_uniq_id:str}/{tournament_id:int}',
+        name='admin-tournament-trf-export',
+    )
+    async def admin_tournament_trf_export(
+            self, request: HTMXRequest, event_uniq_id: str, tournament_id: int
+    ) -> File:
+        context = TournamentAdminWebContext(request, event_uniq_id, None, tournament_id, None)
+        tournament = context.admin_tournament
+        temp_file = NamedTemporaryFile(delete=False, mode="w", suffix=".trf")
+        with temp_file as file:
+            trf.dump(file, tournament.to_trf)
+        return File(path=temp_file.name, filename=f'{tournament.name}.trf')
 
     def _admin_tournament_update(
             self, request: HTMXRequest,

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -319,7 +319,7 @@ class TournamentAdminController(AbstractEventAdminController):
         tournament = context.admin_tournament
         temp_file = NamedTemporaryFile(delete=False, mode="w", suffix=".trf")
         with temp_file as file:
-            trf.dump(file, tournament.to_trf)
+            trf.dump(file, tournament.to_trf())
         return File(path=temp_file.name, filename=f'{tournament.name}.trf')
 
     def _admin_tournament_update(

--- a/src/web/templates/admin_tournament_card.html
+++ b/src/web/templates/admin_tournament_card.html
@@ -136,18 +136,24 @@
             {{ _('Edit') }}
         </button>
     </span>
-    <span {{ tooltip_attributes('info', _('Export tournament to the TRF format.'), 'top') }}>
-        <form
-                method="get"
-                class="d-inline"
-                action="{{ url_for('admin-tournament-trf-export', event_uniq_id=admin_event.uniq_id, tournament_id=tournament.id) }}"
-        >
-            <button type="submit" class="btn btn-sm btn-primary p-1 text-nowrap">
-                <i class="bi-download"></i>
-                {{ _('Download') }}
-            </button>
-        </form>
-    </span>
+
+    <div class="dropdown d-inline">
+        <button class="btn btn-sm btn-primary dropdown-toggle mx-auto" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <i class="bi-download"></i> {{ _('Export') }}
+        </button>
+        <ul class="dropdown-menu locale">
+            <li
+                    class="dropdown-item text-start cursor-pointer"
+                    onclick="window.open('{{ url_for('admin-tournament-trf-export', event_uniq_id=admin_event.uniq_id, tournament_id=tournament.id) }}?usage=RATING', '_blank')">
+                {{ _('Export to TRF16 (rating)') }}
+            </li>
+            <li
+                    class="dropdown-item text-start cursor-pointer"
+                    onclick="window.open('{{ url_for('admin-tournament-trf-export', event_uniq_id=admin_event.uniq_id, tournament_id=tournament.id) }}?usage=PAIRING', '_blank')">
+                {{ _('Export to TRF(bx) (pairing)') }}
+            </li>
+        </ul>
+    </div>
 {% endblock %}
 
 {% block card_buttons_right %}

--- a/src/web/templates/admin_tournament_card.html
+++ b/src/web/templates/admin_tournament_card.html
@@ -136,6 +136,17 @@
             {{ _('Edit') }}
         </button>
     </span>
+    <span {{ tooltip_attributes('info', 'Exporter le tournoi au format TRF.', 'top') }}>
+        <form
+                method="get"
+                class="d-inline"
+                action="{{ url_for('admin-tournament-trf-export', event_uniq_id=admin_event.uniq_id, tournament_id=tournament.id) }}"
+        >
+            <button type="submit" class="btn btn-sm btn-primary p-1 text-nowrap">
+                <i class="bi-download"></i> Télécharger
+            </button>
+        </form>
+    </span>
 {% endblock %}
 
 {% block card_buttons_right %}

--- a/src/web/templates/admin_tournament_card.html
+++ b/src/web/templates/admin_tournament_card.html
@@ -136,14 +136,15 @@
             {{ _('Edit') }}
         </button>
     </span>
-    <span {{ tooltip_attributes('info', 'Exporter le tournoi au format TRF.', 'top') }}>
+    <span {{ tooltip_attributes('info', _('Export tournament to the TRF format.'), 'top') }}>
         <form
                 method="get"
                 class="d-inline"
                 action="{{ url_for('admin-tournament-trf-export', event_uniq_id=admin_event.uniq_id, tournament_id=tournament.id) }}"
         >
             <button type="submit" class="btn btn-sm btn-primary p-1 text-nowrap">
-                <i class="bi-download"></i> Télécharger
+                <i class="bi-download"></i>
+                {{ _('Download') }}
             </button>
         </form>
     </span>


### PR DESCRIPTION
Related to #18 
Export of a tournament in the TRF format ([TRF guidelines](https://www.fide.com/FIDE/handbook/C04Annex2_TRF16.pdf)).  
From the fields defined in the guidelines, I tried including all the fields that were mandatory or that triggered a warning for either pairing or rating purposes. All the pairing fields are included (which should then work for bbp), but a few mandatory fields for rating are still missing:
- tournament federation (not found in Papi, could easily be added to papi-web)
- player rank in the tournament (not present in papi, I haven't yet dug into how to generate it)

On the web side, I added a download button to the tournament card in the admin part:
![image](https://github.com/user-attachments/assets/95b6fa31-a5d5-4fa9-993b-26eaefb1a0c2)

Files are downloaded in the format `{tournament name}.trf`
example of export: [TRF_export_example.txt](https://github.com/user-attachments/files/18444188/TRF_export_example.txt)