### PR TITLE
fix: pyproject.toml typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "Jinja2 ~= 3.1.5",
   "litestar ~= 2.13.0",
   "pefile >= 2024.8.26",
-  "phonenumbers ~8.13.52",
+  "phonenumbers ~= 8.13.52",
   "pyodbc ~= 5.2.0",
   "pywin32-ctypes ~= 0.2.3",
   "requests ~= 2.32.3",


### PR DESCRIPTION
typo in `pyproject.toml` introduced in #60 causing a failure during install