### PR TITLE
feat: pairings generation with bbpPairings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 /test/
 /export-test/
 /utils/i18n/models
+/resources/
 
 *.egg-info/
 

--- a/locale/de/LC_MESSAGES/messages.po
+++ b/locale/de/LC_MESSAGES/messages.po
@@ -4903,6 +4903,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Bearbeiten Sie die Eigenschaften des Turniers."
 
 #: src/web/templates/admin_tournament_card.html
+msgid "Generate pairings for the next round."
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Pair"
+msgstr "Paarungen"
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
 msgid "Export"
 msgstr "Hafen"

--- a/locale/el/LC_MESSAGES/messages.po
+++ b/locale/el/LC_MESSAGES/messages.po
@@ -4905,6 +4905,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Επεξεργασία των ιδιοτήτων του τουρνουά."
 
 #: src/web/templates/admin_tournament_card.html
+msgid "Generate pairings for the next round."
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Pair"
+msgstr "Ζευγάρωμα"
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
 msgid "Export"
 msgstr "Λιμένας"

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -4045,6 +4045,14 @@ msgid "Edit the properties of the tournament."
 msgstr ""
 
 #: src/web/templates/admin_tournament_card.html
+msgid "Generate pairings for the next round."
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Pair"
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
 msgid "Export"
 msgstr ""
 

--- a/locale/es/LC_MESSAGES/messages.po
+++ b/locale/es/LC_MESSAGES/messages.po
@@ -4884,6 +4884,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Edite las propiedades del torneo."
 
 #: src/web/templates/admin_tournament_card.html
+msgid "Generate pairings for the next round."
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Pair"
+msgstr "Maridajes"
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
 msgid "Export"
 msgstr "Puerto"

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -4047,6 +4047,14 @@ msgid "Edit the properties of the tournament."
 msgstr "Éditer les propriétés du tournoi."
 
 #: src/web/templates/admin_tournament_card.html
+msgid "Generate pairings for the next round."
+msgstr "Générer les appariements de la prochaine ronde."
+
+#: src/web/templates/admin_tournament_card.html
+msgid "Pair"
+msgstr "Apparier"
+
+#: src/web/templates/admin_tournament_card.html
 msgid "Export"
 msgstr "Exporter"
 

--- a/locale/it/LC_MESSAGES/messages.po
+++ b/locale/it/LC_MESSAGES/messages.po
@@ -4903,6 +4903,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Modifica le proprietà del torneo."
 
 #: src/web/templates/admin_tournament_card.html
+msgid "Generate pairings for the next round."
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Pair"
+msgstr "Abbinamenti"
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
 msgid "Export"
 msgstr "Porta"

--- a/locale/nl/LC_MESSAGES/messages.po
+++ b/locale/nl/LC_MESSAGES/messages.po
@@ -4903,6 +4903,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Bewerk de eigenschappen van het toernooi."
 
 #: src/web/templates/admin_tournament_card.html
+msgid "Generate pairings for the next round."
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Pair"
+msgstr "met een gewicht van niet meer dan 150 g/m2"
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
 msgid "Export"
 msgstr "Poort"

--- a/locale/sv/LC_MESSAGES/messages.po
+++ b/locale/sv/LC_MESSAGES/messages.po
@@ -4903,6 +4903,15 @@ msgid "Edit the properties of the tournament."
 msgstr "Redigera egenskaperna hos turneringen."
 
 #: src/web/templates/admin_tournament_card.html
+msgid "Generate pairings for the next round."
+msgstr ""
+
+#: src/web/templates/admin_tournament_card.html
+#, ai_translation, fuzzy
+msgid "Pair"
+msgstr "Paraplyer"
+
+#: src/web/templates/admin_tournament_card.html
 #, ai_translation, fuzzy
 msgid "Export"
 msgstr "Hamn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 75.5.0"]
+requires = ["setuptools >= 75.5.0", "requests ~= 2.32.3",]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+import os
+import shutil
+import platform
+
+import requests
+from setuptools import setup
+from setuptools.command.install import install
+
+
+class BbpInstallCommand(install):
+    PROJECT_URL = "https://github.com/BieremaBoyzProgramming/bbpPairings"
+    VERSION = "v5.0.1"
+    WINDOWS_BUILD = "x86_64-pc-windows.zip"
+    LINUX_BUILD = "x86_64-pc-linux.tar.gz"
+
+    def run(self):
+        build = self.WINDOWS_BUILD if platform.system() == 'Windows' else self.LINUX_BUILD
+        build_url = f'{self.PROJECT_URL}/releases/download/{self.VERSION}/bbpPairings-{self.VERSION}-{build}'
+        target_dir = os.path.join('resources')
+        os.makedirs(target_dir, exist_ok=True)
+        archive_path = os.path.join(
+            target_dir, "build.zip" if build == self.WINDOWS_BUILD else "build.tar.gz")
+
+        response = requests.get(build_url, stream=True)
+        response.raise_for_status()
+        with open(archive_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+        shutil.unpack_archive(archive_path, target_dir)
+        os.remove(archive_path)
+        super().run()
+
+
+setup(
+    dynamic=["version", "name", "packages"],
+    cmdclass={"install": BbpInstallCommand},
+)

--- a/src/common/bbp_pairings.py
+++ b/src/common/bbp_pairings.py
@@ -13,7 +13,7 @@ EXEMPT_ID = 0
 
 def generate_pairings(tournament: Tournament):
     """Generate the pairings of a tournament's next round"""
-    if tournament.started and (tournament.finished or tournament.playing):
+    if tournament.finished or tournament.playing:
         raise ValueError(
             'Impossible to generate pairings '
             'if tournament is finished '

--- a/src/common/bbp_pairings.py
+++ b/src/common/bbp_pairings.py
@@ -1,0 +1,51 @@
+import os.path
+import subprocess
+from typing import TextIO
+
+import trf
+from data.board import Board
+from data.pairing import Pairing
+from data.tournament import Tournament
+from data.util import TrfType, Result, BoardColor
+
+BBP_PATH = os.path.join('resources', 'bbpPairings-v5.0.1', 'bbpPairings.exe')
+EXEMPT_ID = 0
+
+def generate_pairings(tournament: Tournament):
+    """Generate the pairings of a tournament's next round"""
+    if tournament.started and (tournament.finished or tournament.playing):
+        raise ValueError(
+            'Impossible to generate pairings '
+            'if tournament is finished '
+            'or if a round is ongoing.')
+    trf_file_path = os.path.join('tmp', 'tournament.trfx')
+    pairings_file_path = os.path.join('tmp', 'pairings.txt')
+    with open(trf_file_path, 'w') as trf_file:
+        trf.dump(trf_file, tournament.to_trf(TrfType.PAIRING))
+    try:
+        subprocess.run([BBP_PATH, "--dutch", trf_file_path, "-p", pairings_file_path], check=True)
+    finally:
+        os.remove(trf_file_path)
+    try:
+        with open(pairings_file_path) as pairing_file:
+            _pairings_from_file(pairing_file, tournament)
+    finally:
+        os.remove(pairings_file_path)
+    tournament.update_round_pairings(tournament.current_round + 1)
+
+
+def _pairings_from_file(file: TextIO, tournament: Tournament):
+    file.readline()  # table_count
+    next_round = tournament.current_round + 1
+    for raw_pairing in file.readlines():
+        (white_trf_id, black_trf_id) = map(int, raw_pairing.split(' '))
+        white_player = tournament.players_by_trf_id[white_trf_id]
+        if black_trf_id != EXEMPT_ID:
+            black_player = tournament.players_by_trf_id[black_trf_id]
+            white_player.pairings[next_round] = Pairing(
+                BoardColor.WHITE, black_player.id, Result.NO_RESULT)
+            black_player.pairings[next_round] = Pairing(
+                BoardColor.BLACK, white_player.id, Result.NO_RESULT)
+        else:
+            white_player.pairings[next_round] = Pairing(
+                BoardColor.WHITE, 1, Result.PAIRING_ALLOCATED_BYE)

--- a/src/data/pairing.py
+++ b/src/data/pairing.py
@@ -73,8 +73,13 @@ class Pairing:
 
     def to_trf(self, round_number: int, player_id_to_trf_id: Callable[[int], int]) -> TrfGame:
         return TrfGame(
-            startrank=player_id_to_trf_id(self.opponent_id) if self.opponent_id else '',
-            color=self.color.to_trf if self.color and not self.result.is_bye else '',
+            startrank=(
+                '0000' if self.result.is_bye else
+                player_id_to_trf_id(self.opponent_id)
+                if self.opponent_id else ''),
+            color=(
+                '-' if self.result.is_bye else
+                self.color.to_trf if self.color else ''),
             result=self.result.to_trf,
             round=round_number)
 

--- a/src/data/pairing.py
+++ b/src/data/pairing.py
@@ -65,6 +65,12 @@ class Pairing:
     def forfeit_gain(self) -> bool:
         return self.result == Result.FORFEIT_GAIN
 
+    @property
+    def color_papi_value(self) -> str:
+        if self.color:
+            return self.color.to_papi_value
+        return 'F' if self.result.is_bye else 'R'
+
     def to_trf(self, round_number: int, player_id_to_trf_id: Callable[[int], int]) -> TrfGame:
         return TrfGame(
             startrank=player_id_to_trf_id(self.opponent_id) if self.opponent_id else '',

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -265,7 +265,9 @@ class Player:
         with suppress(TypeError):
             self.points += points
 
-    def to_trf(self, player_id_to_trf_id: Callable[[int], int]) -> TrfPlayer:
+    def to_trf(
+        self, player_id_to_trf_id: Callable[[int], int], max_round: int
+    ) -> TrfPlayer:
         return TrfPlayer(
             startrank=player_id_to_trf_id(self.id),
             name=f'{self.last_name}, {self.first_name}',
@@ -276,7 +278,10 @@ class Player:
             id=self.fide_id,
             birthdate=self.date_of_birth.strftime('%Y/%m/%d') if self.date_of_birth else '',
             points=self.points_total(),
-            games=[result.to_trf(round_nb, player_id_to_trf_id) for round_nb, result in self.pairings.items()]
+            games=[
+                result.to_trf(round_nb, player_id_to_trf_id)
+                for round_nb, result in self.pairings.items()
+                if round_nb <= max_round]
         )
 
     @property

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -434,7 +434,11 @@ class Tournament:
             numplayers=len(self.players_by_id),
             chiefarbiter=self.arbiter,
             players=[
-                player.to_trf(self._player_id_to_trf_id)
+                player.to_trf(
+                    self._player_id_to_trf_id,
+                    self.current_round + 1
+                    if trf_type == TrfType.PAIRING
+                    else self.rounds)
                 for id_, player in self.players_by_trf_id.items()],
             xx_fields=(
                 self._trf_xx_fields(first_round_pairing)
@@ -451,14 +455,20 @@ class Tournament:
         raise KeyError(f"Id of unknown player: {player_id}")
 
     def _trf_xx_fields(self, first_round_pairing: BoardColor):
+        next_round = self.current_round + 1
         fields: dict[str, str] = {
             'XXR': str(self.rounds),
             'XXC': first_round_pairing.to_trf_first_round_pairing,
+            'XXZ': ' '.join([
+                str(trf_id) for trf_id, player
+                in self.players_by_trf_id.items()
+                if next_round in player.pairings
+                and player.pairings[next_round].result.is_bye]),
         }
         for trf_id, player in self.players_by_trf_id.items():
             vpoints_history = [
                 self._calculate_player_virtual_points(player, round_nb)
-                for round_nb in range(1, self._current_round + 1)
+                for round_nb in range(1, next_round)
             ]
             if sum(vpoints_history) > 0:
                 fields[f'XXA {trf_id:>4}'] = ' '.join(

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -532,7 +532,7 @@ class Tournament:
             for player in self._players_by_id.values():
                 if player.ref_id != 1:
                     pairing: Pairing = player.pairings[round_]
-                    if pairing.color in ('W', 'B', ):
+                    if pairing.color in (BoardColor.WHITE, BoardColor.BLACK, ):
                         round_infos[round_]['pairings_found'] = True
                         paired_rounds.append(round_)
                     if pairing.result == Result.NO_RESULT and pairing.opponent_id is not None:
@@ -859,6 +859,15 @@ class Tournament:
         """Updates a player."""
         with PapiDatabase(self.file, write=True) as papi_database:
             papi_database.update_player(player)
+            papi_database.commit()
+
+    def update_round_pairings(self, round_nb: int):
+        """Updates the pairings of all players for a round."""
+        with PapiDatabase(self.file, write=True) as papi_database:
+            for player in self.players_by_id.values():
+                if round_nb in player.pairings:
+                    papi_database.update_player_pairing(
+                        player, round_nb, player.pairings[round_nb])
             papi_database.commit()
 
     def open_check_in(self):

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -489,10 +489,10 @@ class Tournament:
             fields[result.bbp_field] = f'{result.point_value:>4}'
         return fields
 
-    def read_papi(self):
+    def read_papi(self, update: bool = False):
         """Fetch tournament information from the Papi database, as well
         as the player information."""
-        if self._papi_read:
+        if self._papi_read and not update:
             return
         if self.file_exists:
             with PapiDatabase(self.file) as papi_database:

--- a/src/data/util.py
+++ b/src/data/util.py
@@ -257,7 +257,11 @@ class Result(IntEnum):
 
     @property
     def is_bye(self) -> bool:
-        return self in (Result.HALF_POINT_BYE, Result.FULL_POINT_BYE, Result.PAIRING_ALLOCATED_BYE)
+        return self in (
+            Result.ZERO_POINT_BYE,
+            Result.HALF_POINT_BYE,
+            Result.FULL_POINT_BYE,
+            Result.PAIRING_ALLOCATED_BYE)
 
     @classmethod
     def user_imputable_results(cls) -> tuple[Self, ...]:

--- a/src/database/access/papi/papi_database.py
+++ b/src/database/access/papi/papi_database.py
@@ -154,6 +154,19 @@ class PapiDatabase(AccessDatabase):
         field_sets = (f"`{f}` = ?" for f in fields)
         self._execute(f'UPDATE `joueur` SET {", ".join(field_sets)} WHERE `Ref` = ?', tuple(params))
 
+    def update_player_pairing(self, player: Player, round_nb: int, pairing: Pairing):
+        field_sets = [f'`Rd{round_nb:0>2}{field}` = ?' for field in ('Cl', 'Adv', 'Res')]
+        opponent_id = (
+            Player.player_papi_id_from_papi_web_id(pairing.opponent_id)
+            if pairing.opponent_id else None)
+        result = (
+            pairing.result.to_papi_value if pairing.result
+            else Result.NO_RESULT.to_papi_value)
+        self._execute(
+            f'UPDATE `joueur` SET {", ".join(field_sets)} WHERE `Ref` = ?',
+            (pairing.color_papi_value, opponent_id, result, player.ref_id))
+
+
     def read_players(self, tournament_id: int, rounds: int) -> dict[int, Player]:
         """Reads the database and fetches the Player identification, pairings and results.
         The tournament_id is used to make the players' id unique for an event. """

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -12,6 +12,7 @@ from litestar.params import Body
 from litestar.response import Template, File
 from litestar.status_codes import HTTP_200_OK
 
+from common.bbp_pairings import generate_pairings
 from common.i18n import _
 from common.logger import get_logger
 from data.event import Event
@@ -326,6 +327,21 @@ class TournamentAdminController(AbstractEventAdminController):
         with temp_file as file:
             trf.dump(file, tournament.to_trf(usage))
         return File(path=temp_file.name, filename=f'{tournament.name}.{usage.file_extension}')
+
+    @post(
+        path='/admin/tournament-generate-pairings/{event_uniq_id:str}/{tournament_id:int}',
+        name='admin-tournament-generate-pairings',
+    )
+    async def admin_tournament_generate_pairings(
+        self, request: HTMXRequest, event_uniq_id: str, tournament_id: int
+    ) -> ClientRedirect:
+        context = TournamentAdminWebContext(request, event_uniq_id, None, tournament_id, None)
+        tournament = context.admin_tournament
+        generate_pairings(tournament)
+        return ClientRedirect(context.request.app.route_reverse(
+            'admin-event-tab',
+            event_uniq_id=event_uniq_id,
+            admin_event_tab='tournaments'))
 
     def _admin_tournament_update(
             self, request: HTMXRequest,

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -334,14 +334,12 @@ class TournamentAdminController(AbstractEventAdminController):
     )
     async def admin_tournament_generate_pairings(
         self, request: HTMXRequest, event_uniq_id: str, tournament_id: int
-    ) -> ClientRedirect:
+    ) -> Template | ClientRedirect:
         context = TournamentAdminWebContext(request, event_uniq_id, None, tournament_id, None)
         tournament = context.admin_tournament
         generate_pairings(tournament)
-        return ClientRedirect(context.request.app.route_reverse(
-            'admin-event-tab',
-            event_uniq_id=event_uniq_id,
-            admin_event_tab='tournaments'))
+        tournament.read_papi(True)
+        return self._admin_event_tournaments_render(request, event_uniq_id)
 
     def _admin_tournament_update(
             self, request: HTMXRequest,

--- a/src/web/templates/admin_tournament_card.html
+++ b/src/web/templates/admin_tournament_card.html
@@ -137,6 +137,21 @@
         </button>
     </span>
 
+    {% if not tournament.finished and not tournament.playing %}
+        <span {{ tooltip_attributes('info', _('Generate pairings for the next round.'), 'top') }}>
+            <button
+                    class="btn btn-sm btn-primary p-1 text-nowrap"
+                    hx-post="{{ url_for('admin-tournament-generate-pairings', event_uniq_id=admin_event.uniq_id, tournament_id=tournament.id) }}"
+                    preload
+                    hx-target="body"
+                    hx-indicator="#please-wait"
+            >
+                <i class="bi-shuffle"></i>
+                {{ _('Pair') }}
+            </button>
+    </span>
+    {% endif %}
+
     <div class="dropdown d-inline">
         <button class="btn btn-sm btn-primary dropdown-toggle mx-auto" type="button" data-bs-toggle="dropdown" aria-expanded="false">
             <i class="bi-download"></i> {{ _('Export') }}


### PR DESCRIPTION
related to #18  

An implementation of pairings generation with the most minimal UI. BbpPairings is downloaded from the release when executing `pip install .`. The generated pairings are written back into the papi database.  
Pairings can only be generated if the tournament is ongoing and if the last round is over. In term of UI, a button appears if the pairings can be generated on the tournament card:  
![image](https://github.com/user-attachments/assets/e7c5cfb6-f0a3-4fe2-9c5b-e69b5d99bf56)
