### PR TITLE
Fix: Impossible to create tournament in a new event

### DIFF
--- a/src/database/sql/create_event.sql
+++ b/src/database/sql/create_event.sql
@@ -77,7 +77,7 @@ CREATE TABLE `tournament` (
     `chessevent_tournament_name` TEXT,
     `record_illegal_moves` INTEGER,
     `rules` TEXT,
-    `check_in_open` INTEGER NOT NULL,
+    `check_in_open` INTEGER NOT NULL DEFAULT 0,
     `last_update` FLOAT NOT NULL,
     `last_illegal_move_update` FLOAT NOT NULL DEFAULT 0.0,
     `last_result_update` FLOAT NOT NULL DEFAULT 0.0,


### PR DESCRIPTION
`tournaments` table definition has a problem that makes impossible the creation of a tournament in a newly created event. The field `check_in_open` is defined as `NOT NULL` without a default value, inserting a row in this table without defined `check_in_open` value creates the following error:  
![image](https://github.com/user-attachments/assets/d108c78d-8292-4468-9cd2-bfc69bdc51f9)
