### PR TITLE
Fixed FFE upload issue

### DIFF
--- a/src/database/access/papi/papi_database.py
+++ b/src/database/access/papi/papi_database.py
@@ -364,9 +364,10 @@ class PapiDatabase(AccessDatabase):
         self._execute(query, ('', '', ))
 
     def remove_forfeits_if_no_pairings(self):
-        """Delete all forfeits if no pairing is found (at round #1).
+        """Delete all forfeits if no pairings are found (at any round).
         This fixes a display issue on the FFE website."""
-        query: str = 'SELECT COUNT(`Ref`) FROM `joueur` WHERE `Rd01Adv` IS NOT NULL'
+        condition: str = ' OR '.join(f'`Rd{round_:0>2}Adv` IS NOT NULL' for round_ in range(1, 25))
+        query: str = f'SELECT COUNT(`Ref`) FROM `joueur` WHERE {condition}'
         self._execute(query)
         if self._fetchval() == 0:
             logger.info('Deleting forfeits...')


### PR DESCRIPTION
Check all the rounds before deleting forfeits when upload to the FFE website (previously all the results were deleted if not pairongs on first round but results on next rounds (important for multipart tournaments).