### PR TITLE
Fix missing estimation

### DIFF
--- a/src/data/player.py
+++ b/src/data/player.py
@@ -289,7 +289,7 @@ class Player(TournamentPlayer):
     def estimation(self) -> int:
         if not self.estimated:
             return self.ratings[self.tournament.rating]
-        return self._estimation
+        return self._estimation or 0
 
     @estimation.setter
     def estimation(self, value: int):

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -539,7 +539,10 @@ class Tournament:
         self,
         trf_type: TrfType,
         first_round_pairing: BoardColor = BoardColor.WHITE,
+        papi_legacy: bool = True,
     ) -> TrfTournament:
+        # Estimate pairings to ensure we have a defined rank for everyone
+        self.estimate_players(papi_legacy=papi_legacy)
         return TrfTournament(
             name=self.name,
             city=self.location,


### PR DESCRIPTION
When estimations are not set, TRF export does not work (`TypeError`).
This happens because players' estimation might be `None`, and papi estimation tries to do `400 - player.estimation`.

Two fixes for this:
  1. If `player.estimation` is not set, return 0 as a last resort;
  2. Compute estimations before exporting to TRF

- **Fix problem when estimation is not set**
- **Ensure all players are estimated before exporting**
