### PR TITLE
Uniformize StrEnum usage

### DIFF
--- a/src/data/event.py
+++ b/src/data/event.py
@@ -461,23 +461,23 @@ class Event:
 
     @property
     def input_screens_sorted_by_uniq_id(self) -> list[Screen]:
-        return self.screens_of_type_sorted_by_uniq_id[ScreenType.Input]
+        return self.screens_of_type_sorted_by_uniq_id[ScreenType.INPUT]
 
     @property
     def boards_screens_sorted_by_uniq_id(self) -> list[Screen]:
-        return self.screens_of_type_sorted_by_uniq_id[ScreenType.Boards]
+        return self.screens_of_type_sorted_by_uniq_id[ScreenType.BOARDS]
 
     @property
     def players_screens_sorted_by_uniq_id(self) -> list[Screen]:
-        return self.screens_of_type_sorted_by_uniq_id[ScreenType.Players]
+        return self.screens_of_type_sorted_by_uniq_id[ScreenType.PLAYERS]
 
     @property
     def results_screens_sorted_by_uniq_id(self) -> list[Screen]:
-        return self.screens_of_type_sorted_by_uniq_id[ScreenType.Results]
+        return self.screens_of_type_sorted_by_uniq_id[ScreenType.RESULTS]
 
     @property
     def image_screens_sorted_by_uniq_id(self) -> list[Screen]:
-        return self.screens_of_type_sorted_by_uniq_id[ScreenType.Image]
+        return self.screens_of_type_sorted_by_uniq_id[ScreenType.IMAGE]
 
     @cached_property
     def public_screens_sorted_by_uniq_id(self) -> list[Screen]:
@@ -496,23 +496,23 @@ class Event:
 
     @property
     def public_input_screens_sorted_by_uniq_id(self) -> list[Screen]:
-        return self.public_screens_of_type_sorted_by_uniq_id[ScreenType.Input]
+        return self.public_screens_of_type_sorted_by_uniq_id[ScreenType.INPUT]
 
     @property
     def public_boards_screens_sorted_by_uniq_id(self) -> list[Screen]:
-        return self.public_screens_of_type_sorted_by_uniq_id[ScreenType.Boards]
+        return self.public_screens_of_type_sorted_by_uniq_id[ScreenType.BOARDS]
 
     @property
     def public_players_screens_sorted_by_uniq_id(self) -> list[Screen]:
-        return self.public_screens_of_type_sorted_by_uniq_id[ScreenType.Players]
+        return self.public_screens_of_type_sorted_by_uniq_id[ScreenType.PLAYERS]
 
     @property
     def public_results_screens_sorted_by_uniq_id(self) -> list[Screen]:
-        return self.public_screens_of_type_sorted_by_uniq_id[ScreenType.Results]
+        return self.public_screens_of_type_sorted_by_uniq_id[ScreenType.RESULTS]
 
     @property
     def public_image_screens_sorted_by_uniq_id(self) -> list[Screen]:
-        return self.public_screens_of_type_sorted_by_uniq_id[ScreenType.Image]
+        return self.public_screens_of_type_sorted_by_uniq_id[ScreenType.IMAGE]
 
     @cached_property
     def rotators_sorted_by_uniq_id(self) -> list[Rotator]:

--- a/src/data/event.py
+++ b/src/data/event.py
@@ -664,7 +664,7 @@ class Event:
         assert base_uniq_id is not None or screen_type is not None
         return self._get_unused_item_uniq_id(
             base_uniq_id
-            or _('{screen_type}-screen').format(screen_type=screen_type.to_str()),
+            or _('{screen_type}-screen').format(screen_type=screen_type.value),
             self.basic_screens_by_uniq_id,
         )
 
@@ -677,7 +677,7 @@ class Event:
         base_name, or base_name (2), or base_name (n+1)...
         screen_type is used when the given name is empty to set a default name that corresponds to the screen type."""
         return self._get_unused_item_name(
-            base_name or screen_type.default_screen_name,
+            base_name or screen_type.name,
             [screen.name for screen in self.basic_screens_by_id.values()],
         )
 
@@ -709,7 +709,7 @@ class Event:
         family_type is used when the given ID is empty to set an ID that corresponds to the family type."""
         return self._get_unused_item_uniq_id(
             base_uniq_id
-            or _('{family_type}-family').format(family_type=family_type.to_str()),
+            or _('{family_type}-family').format(family_type=family_type.value),
             self.families_by_uniq_id,
         )
 
@@ -722,7 +722,7 @@ class Event:
         base_name, or base_name (2), or base_name (n+1)...
         family_type is used when the given name is empty to set a name that corresponds to the family type."""
         return self._get_unused_item_name(
-            base_name or family_type.default_screen_name,
+            base_name or family_type.name,
             [screen.name for screen in self.families_by_id.values()],
         )
 

--- a/src/data/family.py
+++ b/src/data/family.py
@@ -82,7 +82,7 @@ class Family:
             return self.menu_text
         single_tournament: bool = len(self.event.tournaments_by_id) == 1
         text: str
-        if self.type == ScreenType.Players or not self.tournament.current_round:
+        if self.type == ScreenType.PLAYERS or not self.tournament.current_round:
             text = Screen.default_players_screen_menu_text(
                 single_tournament=single_tournament, first_last=True
             )
@@ -170,7 +170,7 @@ class Family:
             return False
         players_instead_of_boards: bool
         match ScreenType(self.type):
-            case ScreenType.Boards | ScreenType.Input:
+            case ScreenType.BOARDS | ScreenType.INPUT:
                 if self.tournament.current_round:
                     players_instead_of_boards = False
                     total_items_number: int = len(self.tournament.boards)
@@ -202,7 +202,7 @@ class Family:
                     )
                     self._calculated_first = 1
                     self._calculated_last = cut_items_number
-            case ScreenType.Players:
+            case ScreenType.PLAYERS:
                 players_instead_of_boards = False
                 if self.tournament.current_round:
                     if self.players_show_unpaired:
@@ -299,7 +299,7 @@ class Family:
 
     @property
     def numbers_str(self):
-        if self.type in (ScreenType.Boards, ScreenType.Input):
+        if self.type in (ScreenType.BOARDS, ScreenType.INPUT):
             match (self.first, self.last, self.number, self.parts):
                 case (None, None, None, None):
                     return _('all the boards')

--- a/src/data/family.py
+++ b/src/data/family.py
@@ -35,7 +35,7 @@ class Family:
 
     @property
     def type(self) -> ScreenType:
-        return ScreenType.from_str(self.stored_family.type)
+        return ScreenType(self.stored_family.type)
 
     @property
     def public(self) -> bool:
@@ -169,7 +169,7 @@ class Family:
             self.event.add_warning(self.error, family=self)
             return False
         players_instead_of_boards: bool
-        match ScreenType.from_str(self.type):
+        match ScreenType(self.type):
             case ScreenType.Boards | ScreenType.Input:
                 if self.tournament.current_round:
                     players_instead_of_boards = False

--- a/src/data/screen.py
+++ b/src/data/screen.py
@@ -51,7 +51,7 @@ class Screen:
     @cached_property
     def screen_sets_by_id(self) -> dict[int | None, ScreenSet]:
         match self.type:
-            case ScreenType.Boards | ScreenType.Input | ScreenType.Players:
+            case ScreenType.BOARDS | ScreenType.INPUT | ScreenType.PLAYERS:
                 if self.stored_screen:
                     return {
                         stored_screen_set.id: ScreenSet(
@@ -65,7 +65,7 @@ class Screen:
                             self, family=self.family, family_part=self.family_part
                         )
                     }
-            case ScreenType.Results | ScreenType.Image:
+            case ScreenType.RESULTS | ScreenType.IMAGE:
                 return {}
             case _:
                 raise ValueError(f'type=[{self.type}]')
@@ -104,13 +104,13 @@ class Screen:
             if self.stored_screen.name:
                 return self.stored_screen.name
         match self.type:
-            case ScreenType.Boards | ScreenType.Input:
+            case ScreenType.BOARDS | ScreenType.INPUT:
                 return self.screen_sets_sorted_by_order[0].name_for_boards
-            case ScreenType.Players:
+            case ScreenType.PLAYERS:
                 return self.screen_sets_sorted_by_order[0].name_for_players
-            case ScreenType.Results:
+            case ScreenType.RESULTS:
                 return _('Last results')
-            case ScreenType.Image:
+            case ScreenType.IMAGE:
                 return _('Image')
             case _:
                 raise ValueError(f'type=[{self.type}]')
@@ -176,13 +176,13 @@ class Screen:
         if not self.menu_link:
             return None
         match self.type:
-            case ScreenType.Boards | ScreenType.Input | ScreenType.Players:
+            case ScreenType.BOARDS | ScreenType.INPUT | ScreenType.PLAYERS:
                 single_tournament = len(self.event.tournaments_by_id) == 1
                 screen_set: ScreenSet = self.screen_sets_sorted_by_order[0]
                 first_last = screen_set.first is not None or screen_set.last is not None
                 text: str
                 if (
-                    self.type == ScreenType.Players
+                    self.type == ScreenType.PLAYERS
                     or not screen_set.tournament.current_round
                 ):
                     text = self.menu_text or self.default_players_screen_menu_text(
@@ -194,7 +194,7 @@ class Screen:
                     )
                 text = text.replace('%t', screen_set.tournament.name)
                 if (
-                    self.type == ScreenType.Players
+                    self.type == ScreenType.PLAYERS
                     or not screen_set.tournament.current_round
                 ):
                     if screen_set.first_player_by_name:
@@ -213,7 +213,7 @@ class Screen:
                     if '%l' in text:
                         text = text.replace('%l', str(screen_set.last_board.id))
                 return text
-            case ScreenType.Results:
+            case ScreenType.RESULTS:
                 return self.stored_screen.menu_text or _('Last results')
             case _:
                 raise ValueError(f'type=[{self.type}]')
@@ -357,7 +357,7 @@ class Screen:
     @property
     def input_exit_button(self) -> bool:
         match self.type:
-            case ScreenType.Input:
+            case ScreenType.INPUT:
                 if self.stored_screen:
                     if self.stored_screen.input_exit_button is not None:
                         return self.stored_screen.input_exit_button
@@ -371,10 +371,10 @@ class Screen:
     @property
     def players_show_unpaired(self) -> bool:
         match self.type:
-            case ScreenType.Boards | ScreenType.Input:
+            case ScreenType.BOARDS | ScreenType.INPUT:
                 # Needed to display the players before the first round is paired
                 return True
-            case ScreenType.Players:
+            case ScreenType.PLAYERS:
                 if self.stored_screen:
                     if self.stored_screen.players_show_unpaired is not None:
                         return self.stored_screen.players_show_unpaired
@@ -396,7 +396,7 @@ class Screen:
     @cached_property
     def results_limit(self) -> int:
         match self.type:
-            case ScreenType.Results:
+            case ScreenType.RESULTS:
                 if not self.stored_screen.results_limit:
                     return PapiWebConfig.default_results_screen_limit
                 elif (
@@ -421,7 +421,7 @@ class Screen:
     @cached_property
     def results_max_age(self) -> int:
         match self.type:
-            case ScreenType.Results:
+            case ScreenType.RESULTS:
                 return (
                     self.stored_screen.results_max_age
                     or PapiWebConfig.default_results_screen_max_age
@@ -432,7 +432,7 @@ class Screen:
     @cached_property
     def results_tournament_ids(self) -> list[int]:
         match self.type:
-            case ScreenType.Results:
+            case ScreenType.RESULTS:
                 return [
                     tournament_id
                     for tournament_id in self.stored_screen.results_tournament_ids

--- a/src/data/screen.py
+++ b/src/data/screen.py
@@ -81,7 +81,7 @@ class Screen:
     @property
     def type(self) -> ScreenType:
         return (
-            ScreenType.from_str(self.stored_screen.type)
+            ScreenType(self.stored_screen.type)
             if self.stored_screen
             else self.family.type
         )

--- a/src/data/screen_set.py
+++ b/src/data/screen_set.py
@@ -45,7 +45,7 @@ class ScreenSet:
         self.uniq_id: str = f'{self.screen.uniq_id}_{self.stored_screen_set.order if self.stored_screen_set else self.family_part}'
         fixed_boards_str: str | None = (
             self.stored_screen_set.fixed_boards_str
-            if self.screen.type in [ScreenType.Boards, ScreenType.Input]
+            if self.screen.type in [ScreenType.BOARDS, ScreenType.INPUT]
             and self.stored_screen_set
             else None
         )
@@ -326,7 +326,7 @@ class ScreenSet:
             return _('boards {board_numbers}').format(
                 board_numbers=', '.join(map(str, self.fixed_board_numbers))
             )
-        if self.type in [ScreenType.Boards, ScreenType.Input]:
+        if self.type in [ScreenType.BOARDS, ScreenType.INPUT]:
             match (self.first, self.last):
                 case (None, None):
                     return _('all the boards')

--- a/src/data/util.py
+++ b/src/data/util.py
@@ -1160,7 +1160,6 @@ class BoardColor(StrEnum):
                 return 'black1'
             case _:
                 raise ValueError(f'Unknown value:  {self}')
-
     @property
     def to_rankings(self) -> str:
         match self:
@@ -1171,7 +1170,8 @@ class BoardColor(StrEnum):
             case _:
                 raise ValueError(f'Unknown value:  {self}')
 
-    def __str__(self) -> str:
+    @property
+    def name(self) -> str:
         match self:
             case BoardColor.WHITE:
                 return _('White')
@@ -1180,15 +1180,19 @@ class BoardColor(StrEnum):
             case _:
                 raise ValueError(f'Unknown value: {self}')
 
+    def __str__(self) -> str:
+        return self.name
+
 
 class ScreenType(StrEnum):
-    Boards = auto()
-    Input = auto()
-    Players = auto()
-    Results = auto()
-    Image = auto()
+    Boards = 'boards'
+    Input = 'input'
+    Players = 'players'
+    Results = 'results'
+    Image = 'image'
 
-    def __str__(self) -> str:
+    @property
+    def name(self) -> str:
         match self:
             case ScreenType.Boards:
                 return _('Pairings by board')
@@ -1203,40 +1207,8 @@ class ScreenType(StrEnum):
             case _:
                 raise ValueError(f'Invalid screen type: {self}')
 
-    @property
-    def default_screen_name(self) -> str:
-        return str(self)
-
-    @classmethod
-    def from_str(cls, value: str) -> Self:
-        match value:
-            case 'boards':
-                return cls.Boards
-            case 'input':
-                return cls.Input
-            case 'players':
-                return cls.Players
-            case 'results':
-                return cls.Results
-            case 'image':
-                return cls.Image
-            case _:
-                raise ValueError(f'Invalid screen type: {value}')
-
-    def to_str(self) -> Self:
-        match self:
-            case self.Boards:
-                return 'boards'
-            case self.Input:
-                return 'input'
-            case self.Players:
-                return 'players'
-            case self.Results:
-                return 'results'
-            case self.Image:
-                return 'image'
-            case _:
-                raise ValueError(f'Invalid screen type: {self}')
+    def __str__(self) -> str:
+        return self.name
 
     @property
     def icon_str(self) -> str:
@@ -1271,8 +1243,8 @@ class NeedsUpload(Enum):
 
 
 class TrfType(StrEnum):
-    PAIRING = 'PAIRING'
-    RATING = 'RATING'
+    PAIRING = 'pairing'
+    RATING = 'rating'
 
     @property
     def file_extension(self) -> str:
@@ -1327,55 +1299,25 @@ def performance_bonus(
 
 
 class PrintSplit(StrEnum):
-    NoSplit = auto()
-    Category = auto()
-    Club = auto()
-    League = auto()
-    Federation = auto()
+    NO_SPLIT = 'no-split'
+    CATEGORY = 'category'
+    CLUB = 'club'
+    LEAGUE = 'league'
+    FEDERATION = 'federation'
 
-    def __str__(self) -> str:
+    @property
+    def name(self) -> str:
         match self:
-            case PrintSplit.NoSplit:
+            case PrintSplit.NO_SPLIT:
                 return _('No split')
-            case PrintSplit.Category:
+            case PrintSplit.CATEGORY:
                 return _('Category')
-            case PrintSplit.Club:
+            case PrintSplit.CLUB:
                 return _('Club')
-            case PrintSplit.League:
+            case PrintSplit.LEAGUE:
                 return _('League')
-            case PrintSplit.Federation:
+            case PrintSplit.FEDERATION:
                 return _('Federation')
-            case _:
-                raise ValueError(f'Invalid print split type: {self}')
-
-    @classmethod
-    def from_str(cls, value: str) -> Self:
-        match value:
-            case 'no-split':
-                return cls.NoSplit
-            case 'category':
-                return cls.Category
-            case 'club':
-                return cls.Club
-            case 'league':
-                return cls.League
-            case 'federation':
-                return cls.Federation
-            case _:
-                raise ValueError(f'Invalid print split type: {value}')
-
-    def to_str(self) -> Self:
-        match self:
-            case self.NoSplit:
-                return 'no-split'
-            case self.Category:
-                return 'category'
-            case self.Club:
-                return 'club'
-            case self.League:
-                return 'league'
-            case self.Federation:
-                return 'federation'
             case _:
                 raise ValueError(f'Invalid print split type: {self}')
 

--- a/src/data/util.py
+++ b/src/data/util.py
@@ -1185,24 +1185,24 @@ class BoardColor(StrEnum):
 
 
 class ScreenType(StrEnum):
-    Boards = 'boards'
-    Input = 'input'
-    Players = 'players'
-    Results = 'results'
-    Image = 'image'
+    BOARDS = 'boards'
+    INPUT = 'input'
+    PLAYERS = 'players'
+    RESULTS = 'results'
+    IMAGE = 'image'
 
     @property
     def name(self) -> str:
         match self:
-            case ScreenType.Boards:
+            case ScreenType.BOARDS:
                 return _('Pairings by board')
-            case ScreenType.Input:
+            case ScreenType.INPUT:
                 return _('Results entry')
-            case ScreenType.Players:
+            case ScreenType.PLAYERS:
                 return _('Parings by player')
-            case ScreenType.Results:
+            case ScreenType.RESULTS:
                 return _('Last results')
-            case ScreenType.Image:
+            case ScreenType.IMAGE:
                 return _('Image')
             case _:
                 raise ValueError(f'Invalid screen type: {self}')
@@ -1213,15 +1213,15 @@ class ScreenType(StrEnum):
     @property
     def icon_str(self) -> str:
         match self:
-            case self.Boards:
+            case self.BOARDS:
                 return 'bi-card-list'
-            case self.Input:
+            case self.INPUT:
                 return 'bi-pencil'
-            case self.Players:
+            case self.PLAYERS:
                 return 'bi-people'
-            case self.Results:
+            case self.RESULTS:
                 return 'bi-trophy'
-            case self.Image:
+            case self.IMAGE:
                 return 'bi-image'
             case _:
                 raise ValueError(f'Invalid screen type: {self}')

--- a/src/web/controllers/admin/event_admin_controller.py
+++ b/src/web/controllers/admin/event_admin_controller.py
@@ -83,7 +83,7 @@ class EventAdminWebContext(AdminWebContext):
         
     def get_print_split_options(self) -> dict[str, str]:
         return {
-            self.value_to_form_data(split.to_str()): str(split)
+            self.value_to_form_data(split): PrintSplit(split).name
             for split in PrintSplit
         }
 
@@ -626,7 +626,7 @@ class EventAdminController(AbstractEventAdminController):
                                 tournament_id
                             ),
                             'split': WebContext.value_to_form_data(
-                                PrintSplit.NoSplit.to_str()
+                                PrintSplit.NO_SPLIT
                             ),
                             'document': WebContext.value_to_form_data(
                                 PrintDocument.PLAYER_LIST

--- a/src/web/controllers/admin/family_admin_controller.py
+++ b/src/web/controllers/admin/family_admin_controller.py
@@ -363,11 +363,11 @@ class FamilyAdminController(AbstractEventAdminController):
                             first = web_context.admin_family.stored_family.first
                             last = web_context.admin_family.stored_family.last
                             match web_context.admin_family.type:
-                                case ScreenType.Boards:
+                                case ScreenType.BOARDS:
                                     pass
-                                case ScreenType.Input:
+                                case ScreenType.INPUT:
                                     input_exit_button = web_context.admin_family.stored_family.input_exit_button
-                                case ScreenType.Players:
+                                case ScreenType.PLAYERS:
                                     players_show_unpaired = web_context.admin_family.stored_family.players_show_unpaired
                                 case _:
                                     raise ValueError(
@@ -388,11 +388,11 @@ class FamilyAdminController(AbstractEventAdminController):
                                 web_context.admin_event.tournaments_by_id.keys()
                             )[0]
                             match family_type:
-                                case ScreenType.Boards:
+                                case ScreenType.BOARDS:
                                     menu = '@boards'
-                                case ScreenType.Input:
+                                case ScreenType.INPUT:
                                     menu = '@input'
-                                case ScreenType.Players:
+                                case ScreenType.PLAYERS:
                                     menu = '@players'
                                 case _:
                                     raise ValueError(f'family_type={family_type}')

--- a/src/web/controllers/admin/family_admin_controller.py
+++ b/src/web/controllers/admin/family_admin_controller.py
@@ -320,7 +320,7 @@ class FamilyAdminController(AbstractEventAdminController):
                             name = web_context.admin_family.stored_family.name
                         case 'create':
                             uniq_id = web_context.admin_event.get_unused_family_uniq_id(
-                                family_type=ScreenType.from_str(family_type)
+                                family_type=ScreenType(family_type)
                             )
                             # basic_name: str
                             # match family_type:
@@ -333,14 +333,14 @@ class FamilyAdminController(AbstractEventAdminController):
                             #     case _:
                             #         raise ValueError(f'family_type=[{family_type}]')
                             name = web_context.admin_event.get_unused_family_name(
-                                family_type=ScreenType.from_str(family_type)
+                                family_type=ScreenType(family_type)
                             )
                         case 'clone':
                             uniq_id = web_context.admin_event.get_unused_family_uniq_id(
                                 base_uniq_id=web_context.admin_family.stored_family.uniq_id
                             )
                             name = web_context.admin_event.get_unused_family_name(
-                                family_type=ScreenType.from_str(
+                                family_type=ScreenType(
                                     web_context.admin_family.type
                                 ),
                                 base_name=web_context.admin_family.stored_family.name,

--- a/src/web/controllers/admin/screen_admin_controller.py
+++ b/src/web/controllers/admin/screen_admin_controller.py
@@ -170,7 +170,7 @@ class ScreenAdminController(AbstractEventAdminController):
                     columns = WebContext.form_data_to_int(data, field, minimum=1)
                 except ValueError:
                     errors[field] = _('A positive integer is expected.')
-                if type_ != ScreenType.Image:
+                if type_ != ScreenType.IMAGE:
                     menu_link = WebContext.form_data_to_bool(data, 'menu_link', False)
                     menu_text = WebContext.form_data_to_str(data, 'menu_text', '')
                     menu = WebContext.form_data_to_str(data, 'menu', '')
@@ -187,17 +187,17 @@ class ScreenAdminController(AbstractEventAdminController):
                 except ValueError:
                     errors[field] = _('A positive integer is expected.')
                 match type_:
-                    case ScreenType.Boards:
+                    case ScreenType.BOARDS:
                         pass
-                    case ScreenType.Input:
+                    case ScreenType.INPUT:
                         input_exit_button = WebContext.form_data_to_bool(
                             data, 'input_exit_button'
                         )
-                    case ScreenType.Players:
+                    case ScreenType.PLAYERS:
                         players_show_unpaired = WebContext.form_data_to_bool(
                             data, 'players_show_unpaired'
                         )
-                    case ScreenType.Results:
+                    case ScreenType.RESULTS:
                         field = 'results_limit'
                         try:
                             results_limit = WebContext.form_data_to_int(data, field)
@@ -213,7 +213,7 @@ class ScreenAdminController(AbstractEventAdminController):
                             field = f'results_tournament_{tournament_id}'
                             if WebContext.form_data_to_bool(data, field):
                                 results_tournament_ids.append(tournament_id)
-                    case ScreenType.Image:
+                    case ScreenType.IMAGE:
                         field = 'background_image'
                         background_image = WebContext.form_data_to_str(data, field, '')
                         if not background_image:
@@ -337,7 +337,7 @@ class ScreenAdminController(AbstractEventAdminController):
             errors['first'] = error
             errors['last'] = error
         fixed_boards_str: str | None = None
-        if web_context.admin_screen.type in [ScreenType.Boards, ScreenType.Input]:
+        if web_context.admin_screen.type in [ScreenType.BOARDS, ScreenType.INPUT]:
             fixed_boards_str = WebContext.form_data_to_str(data, 'fixed_boards_str')
             if fixed_boards_str:
                 for fixed_board_str in list(
@@ -451,7 +451,7 @@ class ScreenAdminController(AbstractEventAdminController):
                         case 'update' | 'clone':
                             public = web_context.admin_screen.stored_screen.public
                             columns = web_context.admin_screen.stored_screen.columns
-                            if web_context.admin_screen.type != ScreenType.Image:
+                            if web_context.admin_screen.type != ScreenType.IMAGE:
                                 menu_link = (
                                     web_context.admin_screen.stored_screen.menu_link
                                 )
@@ -461,17 +461,17 @@ class ScreenAdminController(AbstractEventAdminController):
                                 menu = web_context.admin_screen.stored_screen.menu
                             timer_id = web_context.admin_screen.stored_screen.timer_id
                             match web_context.admin_screen.type:
-                                case ScreenType.Boards:
+                                case ScreenType.BOARDS:
                                     pass
-                                case ScreenType.Input:
+                                case ScreenType.INPUT:
                                     input_exit_button = web_context.admin_screen.stored_screen.input_exit_button
-                                case ScreenType.Players:
+                                case ScreenType.PLAYERS:
                                     players_show_unpaired = web_context.admin_screen.stored_screen.players_show_unpaired
-                                case ScreenType.Results:
+                                case ScreenType.RESULTS:
                                     results_limit = web_context.admin_screen.stored_screen.results_limit
                                     results_max_age = web_context.admin_screen.stored_screen.results_max_age
                                     results_tournament_ids = web_context.admin_screen.stored_screen.results_tournament_ids
-                                case ScreenType.Image:
+                                case ScreenType.IMAGE:
                                     background_image = web_context.admin_screen.stored_screen.background_image
                                     background_color = (
                                         web_context.admin_screen.background_color
@@ -489,16 +489,16 @@ class ScreenAdminController(AbstractEventAdminController):
                         case 'create':
                             public = True
                             message_default = True
-                            if screen_type != ScreenType.Image:
+                            if screen_type != ScreenType.IMAGE:
                                 menu_link = True
                             match screen_type:
-                                case ScreenType.Boards:
+                                case ScreenType.BOARDS:
                                     menu = '@boards'
-                                case ScreenType.Input:
+                                case ScreenType.INPUT:
                                     menu = '@input'
-                                case ScreenType.Players:
+                                case ScreenType.PLAYERS:
                                     menu = '@players'
-                                case ScreenType.Results | ScreenType.Image:
+                                case ScreenType.RESULTS | ScreenType.IMAGE:
                                     pass
                                 case _:
                                     raise ValueError(f'screen_type={screen_type}')
@@ -589,8 +589,8 @@ class ScreenAdminController(AbstractEventAdminController):
                             ),
                         }
                         if web_context.admin_screen.type in [
-                            ScreenType.Boards,
-                            ScreenType.Input,
+                            ScreenType.BOARDS,
+                            ScreenType.INPUT,
                         ]:
                             data['fixed_boards_str'] = WebContext.value_to_form_data(
                                 web_context.admin_screen_set.stored_screen_set.fixed_boards_str
@@ -705,9 +705,9 @@ class ScreenAdminController(AbstractEventAdminController):
                     init_set_tournament_id: int = stored_screen.init_set_tournament_id
                     stored_screen = event_database.add_stored_screen(stored_screen)
                     if stored_screen.type in [
-                        ScreenType.Boards,
-                        ScreenType.Input,
-                        ScreenType.Players,
+                        ScreenType.BOARDS,
+                        ScreenType.INPUT,
+                        ScreenType.PLAYERS,
                     ]:
                         event_database.add_stored_screen_set(
                             stored_screen.id, init_set_tournament_id
@@ -722,9 +722,9 @@ class ScreenAdminController(AbstractEventAdminController):
                 case 'clone':
                     stored_screen = event_database.add_stored_screen(stored_screen)
                     if stored_screen.type in [
-                        ScreenType.Boards,
-                        ScreenType.Input,
-                        ScreenType.Players,
+                        ScreenType.BOARDS,
+                        ScreenType.INPUT,
+                        ScreenType.PLAYERS,
                     ]:
                         for (
                             screen_set

--- a/src/web/controllers/admin/screen_admin_controller.py
+++ b/src/web/controllers/admin/screen_admin_controller.py
@@ -431,7 +431,7 @@ class ScreenAdminController(AbstractEventAdminController):
                                 case _:
                                     raise ValueError(f'screen_type=[{screen_type}]')
                             name = web_context.admin_event.get_unused_screen_name(
-                                screen_type=ScreenType.from_str(screen_type)
+                                screen_type=ScreenType(screen_type)
                             )
                         case 'clone':
                             uniq_id = web_context.admin_event.get_unused_screen_uniq_id(
@@ -439,7 +439,7 @@ class ScreenAdminController(AbstractEventAdminController):
                             )
                             name = web_context.admin_event.get_unused_screen_name(
                                 base_name=web_context.admin_screen.name,
-                                screen_type=ScreenType.from_str(
+                                screen_type=ScreenType(
                                     web_context.admin_screen.type
                                 ),
                             )

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -767,18 +767,18 @@ class TournamentAdminController(AbstractEventAdminController):
             player for player in ordered_players
             if player.tournament.id == tournament_id
         ]
-        split_by = PrintSplit.from_str(split) if split else PrintSplit.NoSplit
-        if split_by == PrintSplit.NoSplit:
+        split_by = PrintSplit(split) if split else PrintSplit.NO_SPLIT
+        if split_by == PrintSplit.NO_SPLIT:
             split_players = {"": players_in_tournament}
         else:
             split_functions = {
-                PrintSplit.Category: lambda p: p.category.short_name,
-                PrintSplit.Club: lambda p: p.club_tuple.club,
-                PrintSplit.League: lambda p: p.league_tuple.league,
-                PrintSplit.Federation: lambda p: p.federation_tuple.federation,
+                PrintSplit.CATEGORY: lambda p: p.category.short_name,
+                PrintSplit.CLUB: lambda p: p.club_tuple.club,
+                PrintSplit.LEAGUE: lambda p: p.league_tuple.league,
+                PrintSplit.FEDERATION: lambda p: p.federation_tuple.federation,
             }
 
-            if split_by == PrintSplit.Category:
+            if split_by == PrintSplit.CATEGORY:
                 split_players = {
                     category.short_name: [] for category in PlayerCategory
                 }
@@ -789,7 +789,7 @@ class TournamentAdminController(AbstractEventAdminController):
             for player in players_in_tournament:
                 split_players[split_functions[split_by](player)].append(player)
 
-            if split_by == PrintSplit.Category:
+            if split_by == PrintSplit.CATEGORY:
                 # Filter out empty categories
                 split_players = {
                     key: split_players[key] for key in split_players.keys()

--- a/src/web/controllers/user/event_user_controller.py
+++ b/src/web/controllers/user/event_user_controller.py
@@ -190,8 +190,8 @@ class EventUserController(AbstractUserController):
                 if screen_set.tournament.last_update > date:
                     return True
                 if screen.type in [
-                    ScreenType.Boards,
-                    ScreenType.Input,
+                    ScreenType.BOARDS,
+                    ScreenType.INPUT,
                 ]:
                     if screen_set.tournament.last_illegal_move_update > date:
                         return True
@@ -201,7 +201,7 @@ class EventUserController(AbstractUserController):
                         return True
                 if screen_set.tournament.last_check_in_update > date:
                     return True
-            if screen.type == ScreenType.Results:
+            if screen.type == ScreenType.RESULTS:
                 results_tournament_ids: list[int] = (
                     screen.results_tournament_ids
                     if screen.results_tournament_ids
@@ -222,14 +222,14 @@ class EventUserController(AbstractUserController):
             if family.tournament.last_update > date:
                 return True
             match family.type:
-                case ScreenType.Boards | ScreenType.Input:
+                case ScreenType.BOARDS | ScreenType.INPUT:
                     if family.tournament.last_illegal_move_update > date:
                         return True
                     if family.tournament.last_result_update > date:
                         return True
                     if family.tournament.last_check_in_update > date:
                         return True
-                case ScreenType.Players:
+                case ScreenType.PLAYERS:
                     if family.tournament.last_check_in_update > date:
                         return True
                 case _:

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -59,7 +59,7 @@ class ScreenOrRotatorUserWebContext(EventUserWebContext):
                     f'Access denied for screen [{self.screen.uniq_id}].'
                 )
                 return
-            self.user_event_tab = self.screen.type.to_str()
+            self.user_event_tab = self.screen.type.value
         else:
             try:
                 self.rotator = self.user_event.rotators_by_id[rotator_id]

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -80,7 +80,7 @@ class ScreenOrRotatorUserWebContext(EventUserWebContext):
     @property
     def login_needed(self) -> bool:
         if self.screen is not None:
-            if self.screen.type != ScreenType.Input:
+            if self.screen.type != ScreenType.INPUT:
                 return False
         if not self.user_event.update_password:
             return False
@@ -300,12 +300,12 @@ class ScreenUserController(AbstractScreenUserController):
         if tournament.last_check_in_update > date:
             return True
         match screen_set.type:
-            case ScreenType.Boards | ScreenType.Input:
+            case ScreenType.BOARDS | ScreenType.INPUT:
                 if tournament.last_illegal_move_update > date:
                     return True
                 if tournament.last_result_update > date:
                     return True
-            case ScreenType.Players:
+            case ScreenType.PLAYERS:
                 pass
             case _:
                 raise ValueError(f'type={screen_set.type}')
@@ -326,13 +326,13 @@ class ScreenUserController(AbstractScreenUserController):
             if web_context.screen.last_update > date:
                 return True
             match web_context.screen.type:
-                case ScreenType.Image:
+                case ScreenType.IMAGE:
                     pass
-                case ScreenType.Boards | ScreenType.Input | ScreenType.Players:
+                case ScreenType.BOARDS | ScreenType.INPUT | ScreenType.PLAYERS:
                     for screen_set in web_context.screen.screen_sets_by_id.values():
                         if cls._user_screen_set_refresh_needed(screen_set, date):
                             return True
-                case ScreenType.Results:
+                case ScreenType.RESULTS:
                     results_tournament_ids: list[int] = (
                         web_context.screen.results_tournament_ids
                         if web_context.screen.results_tournament_ids

--- a/src/web/templates/admin/tournaments/tournament_card.html
+++ b/src/web/templates/admin/tournaments/tournament_card.html
@@ -165,13 +165,13 @@
             <ul class="dropdown-menu locale">
                 <li
                     class="dropdown-item text-start cursor-pointer"
-                    onclick="window.open('{{ url_for('admin-tournament-trf-export', event_uniq_id=admin_event.uniq_id, tournament_id=tournament.id) }}?usage=RATING', '_blank')"
+                    onclick="window.open('{{ url_for('admin-tournament-trf-export', event_uniq_id=admin_event.uniq_id, tournament_id=tournament.id) }}?usage=rating', '_blank')"
                 >
                     {{ _('Export to TRF16 (rating)') }}
                 </li>
                 <li
                     class="dropdown-item text-start cursor-pointer"
-                    onclick="window.open('{{ url_for('admin-tournament-trf-export', event_uniq_id=admin_event.uniq_id, tournament_id=tournament.id) }}?usage=PAIRING', '_blank')"
+                    onclick="window.open('{{ url_for('admin-tournament-trf-export', event_uniq_id=admin_event.uniq_id, tournament_id=tournament.id) }}?usage=pairing', '_blank')"
                 >
                     {{ _('Export to TRF(bx) (pairing)') }}
                 </li>


### PR DESCRIPTION
use the following pattern for all StrEnum classes:
```python
class PrintSplit(StrEnum):
    NO_SPLIT = 'no-split'

    @property
    def name(self) -> str:
    # Translated name
        match self:
            case PrintSplit.NO_SPLIT:
                return _('No split')
    
        def __str__(self) -> str:
            # If strong usage of this method, keep it as is to prevent generating issues 
            # --> usage hard to track (BoardColor / ScreenType)
            return self.name
```