### PR TITLE
Migration rollbacks for event databases

### DIFF
--- a/src/database/migrations/events/v2_04_22.py
+++ b/src/database/migrations/events/v2_04_22.py
@@ -18,3 +18,17 @@ class EventMigration(AbstractEventMigration):
         # Drop table chessevent since the SQL code of the creation of the table
         # had been left by error in create_event.sql
         self._execute('DROP TABLE IF EXISTS `chessevent`')
+
+    def backward(self):
+        self._execute(
+            'ALTER TABLE `tournament` DROP COLUMN `first_board_number`'
+        )
+        self._execute(
+            'ALTER TABLE `tournament` DROP COLUMN `paired_bye_points`'
+        )
+        self._execute(
+            'ALTER TABLE `tournament` DROP COLUMN `max_byes`'
+        )
+        self._execute(
+            'ALTER TABLE `tournament` DROP COLUMN `last_rounds_no_byes`'
+        )

--- a/src/database/migrations/events/v2_04_23.py
+++ b/src/database/migrations/events/v2_04_23.py
@@ -6,3 +6,8 @@ class EventMigration(AbstractEventMigration):
         self._execute(
             'ALTER TABLE `tournament` ADD `tie_breaks` TEXT'
         )
+
+    def backward(self):
+        self._execute(
+            'ALTER TABLE `tournament` DROP COLUMN `tie_breaks`'
+        )

--- a/src/database/sqlite/event_database.py
+++ b/src/database/sqlite/event_database.py
@@ -978,8 +978,7 @@ class EventDatabase(SQLiteDatabase):
         from database.sqlite.event_migration import EventMigrationManager
 
         initial_version = self.version
-        EventMigrationManager().migrate(self, PapiWebConfig.version)
-        if initial_version != self.version:
+        if EventMigrationManager().migrate(self, PapiWebConfig.version):
             logger.info(
                 'Database %s has been upgraded from version %s to version %s.',
                 self.file.name,

--- a/src/database/sqlite/event_database.py
+++ b/src/database/sqlite/event_database.py
@@ -49,11 +49,11 @@ class EventDatabase(SQLiteDatabase):
         self,
         uniq_id: str,
         write: bool = False,
-        database_initialized: bool = True,
+        auto_upgrade: bool = True,
     ):
         self.uniq_id = uniq_id
         self._version: Version | None = None
-        self._database_initialized: bool = database_initialized
+        self._auto_upgrade = auto_upgrade
         super().__init__(self.event_database_path(self.uniq_id), write)
 
     @staticmethod
@@ -161,6 +161,7 @@ class EventDatabase(SQLiteDatabase):
             with EventDatabase(self.uniq_id, True, False) as event_database:
                 from database.sqlite.event_migration import EventMigrationManager
 
+                event_database._version = EventMigrationManager.EMPTY_DATABASE_VERSION
                 version = PapiWebConfig.version
                 EventMigrationManager().migrate(event_database, version)
                 event_database._execute(
@@ -169,7 +170,7 @@ class EventDatabase(SQLiteDatabase):
                     "VALUES(?, ?, ?, ?, ?)",
                     (
                         f'{version.major}.{version.minor}.{version.micro}',
-                        self.uniq_id,
+                        event_database.uniq_id,
                         event_start,
                         event_stop,
                         time.time(),
@@ -879,11 +880,10 @@ class EventDatabase(SQLiteDatabase):
 
         from database.sqlite.event_migration import EventMigrationManager
 
-        migration_manager = EventMigrationManager()
-        if not self._database_initialized:
-            self._version = migration_manager.EMPTY_DATABASE_VERSION
-            return self
-        if self.version < migration_manager.last_migration_version:
+        if (
+            self._auto_upgrade and
+            self.version < EventMigrationManager().last_migration_version
+        ):
             if self.write:
                 self.upgrade()
             else:

--- a/src/database/sqlite/event_migration.py
+++ b/src/database/sqlite/event_migration.py
@@ -4,6 +4,7 @@ from pkgutil import iter_modules
 import re
 from abc import abstractmethod
 from logging import Logger
+from sqlite3 import OperationalError
 
 from packaging.version import Version
 
@@ -20,6 +21,11 @@ class AbstractEventMigration(EventDatabase):
     def forward(self):
         pass
 
+    def backward(self):
+        raise NotImplementedError(
+            "Rollback not implemented for this migration"
+        )
+
 
 class EventMigrationManager:
     EMPTY_DATABASE_VERSION: Version = Version('0.0.0')
@@ -29,6 +35,13 @@ class EventMigrationManager:
     def migration_modules(self) -> list[str]:
         return [
             f'{events.__name__}.{module}'
+            for module in self._migration_module_names
+        ]
+
+    @cached_property
+    def migration_versions(self) -> list[Version]:
+        return [
+            self._module_name_to_version(module)
             for module in self._migration_module_names
         ]
 
@@ -46,49 +59,98 @@ class EventMigrationManager:
 
     @cached_property
     def _ordered_migration_versions(self) -> list[Version]:
-        return sorted([
-            self._module_name_to_version(module)
-            for module in self._migration_module_names
-        ])
+        return sorted(self.migration_versions)
+
+    @cached_property
+    def _reverse_ordered_migration_versions(self) -> list[Version]:
+        return sorted(self.migration_versions, reverse=True)
 
     def migrate(
             self,
-            event_database: EventDatabase,
+            database: EventDatabase,
             target_version: Version,
             skip_commits: bool = False,
     ):
         if (
-            event_database.version != self.EMPTY_DATABASE_VERSION
-            and event_database.version < self.first_migration_version
+            database.version != self.EMPTY_DATABASE_VERSION
+            and database.version < self.first_migration_version
         ):
             logger.error(
                 'Database %s (%s) impossible to upgrade: version '
                 'is prior to the first upgradable version (%s)',
-                event_database.file.name,
-                event_database.version,
+                database.file.name,
+                database.version,
                 self.first_migration_version,
             )
             return
-        if event_database.version > target_version:
-            raise NotImplementedError('Migrations rollback not implemented')
+        if database.version > target_version:
+            self._rollback(database, target_version, skip_commits)
+        else:
+            self._upgrade(database, target_version, skip_commits)
+
+    def _upgrade(
+        self,
+        database: EventDatabase,
+        target_version: Version,
+        skip_commits: bool,
+    ):
         while migration_version := self._next_migration_version(
-            event_database.version, target_version
+            database.version, target_version
         ):
-            migration_class = self._version_to_migration_class(migration_version)
-            migration_class.forward(event_database)
-            event_database.set_version(migration_version)
-            if not skip_commits:
-                event_database.commit()
-            if event_database.version == migration_version:
+            migration_class = self._version_to_migration_class(
+                migration_version
+            )
+            try:
+                migration_class.forward(database)
+                database.set_version(migration_version)
+                if not skip_commits:
+                    database.commit()
                 logger.debug(
                     'Database %s has been upgraded to version %s.',
-                    event_database.file.name,
+                    database.file.name,
                     migration_version,
                 )
-            else:
+            except OperationalError as e:
                 raise PapiWebException(
-                    f'Database {event_database.file.name} ({event_database.version})'
-                    f' could not be upgraded to version {migration_version}.'
+                    f'Database {database.file.name} '
+                    f'({database.version}) could not be upgraded '
+                    f'to version {migration_version}: "{e}"'
+                )
+
+    def _rollback(
+        self,
+        database: EventDatabase,
+        target_version: Version,
+        skip_commits: bool,
+    ):
+        while database.version > target_version:
+            if database.version not in self.migration_versions:
+                raise PapiWebException(
+                    'No migration for current database version, '
+                    'impossible to rollback.'
+                )
+
+            migration_class = self._version_to_migration_class(
+                database.version
+            )
+            previous_version = self._previous_migration_version(
+                database.version
+            )
+            try:
+                migration_class.backward(database)
+                database.set_version(previous_version)
+                if not skip_commits:
+                    database.commit()
+                logger.debug(
+                    'Database %s has been downgraded to version %s.',
+                    database.file.name,
+                    previous_version,
+                )
+            except (OperationalError, NotImplementedError) as e:
+                raise PapiWebException(
+                    f'Database {database.file.name} '
+                    f'({database.version}) could not be downgraded '
+                    f'to version {previous_version}: "{e}"'
                 )
 
     def _next_migration_version(
@@ -100,6 +162,18 @@ class EventMigrationManager:
                 if current_version < version <= max_version
             ),
             None,
+        )
+
+    def _previous_migration_version(
+        self, current_version: Version
+    ) -> Version:
+        return next(
+            (
+                version for version in
+                self._reverse_ordered_migration_versions
+                if version < current_version
+            ),
+            self.EMPTY_DATABASE_VERSION,
         )
 
     def _version_to_migration_class(

--- a/src/database/sqlite/event_migration.py
+++ b/src/database/sqlite/event_migration.py
@@ -8,8 +8,7 @@ from sqlite3 import OperationalError
 
 from packaging.version import Version
 
-from common.exception import PapiWebException
-from common.logger import get_logger
+from common.logger import get_logger, print_interactive_error
 from database.migrations import events
 from database.sqlite.event_database import EventDatabase
 
@@ -30,6 +29,11 @@ class AbstractEventMigration(EventDatabase):
 class EventMigrationManager:
     EMPTY_DATABASE_VERSION: Version = Version('0.0.0')
     MIGRATION_CLASS_NAME: str = 'EventMigration'
+
+    def __init__(self, cli_usage: bool = False):
+        self._log_error = (
+            print_interactive_error if cli_usage else logger.error
+        )
 
     @property
     def migration_modules(self) -> list[str]:
@@ -66,34 +70,32 @@ class EventMigrationManager:
         return sorted(self.migration_versions, reverse=True)
 
     def migrate(
-            self,
-            database: EventDatabase,
-            target_version: Version,
-            skip_commits: bool = False,
-    ):
+        self,
+        database: EventDatabase,
+        target_version: Version,
+        skip_commits: bool = False,
+    ) -> bool:
         if (
             database.version != self.EMPTY_DATABASE_VERSION
             and database.version < self.first_migration_version
         ):
-            logger.error(
-                'Database %s (%s) impossible to upgrade: version '
-                'is prior to the first upgradable version (%s)',
-                database.file.name,
-                database.version,
-                self.first_migration_version,
+            self._log_error(
+                f'Database %{database.file.name} ({database.version}) '
+                'impossible to upgrade: version is prior to the first '
+                f'upgradable version ({self.first_migration_version})'
             )
-            return
+            return False
         if database.version > target_version:
-            self._rollback(database, target_version, skip_commits)
+            return self._rollback(database, target_version, skip_commits)
         else:
-            self._upgrade(database, target_version, skip_commits)
+            return self._upgrade(database, target_version, skip_commits)
 
     def _upgrade(
         self,
         database: EventDatabase,
         target_version: Version,
         skip_commits: bool,
-    ):
+    ) -> bool:
         while migration_version := self._next_migration_version(
             database.version, target_version
         ):
@@ -111,24 +113,27 @@ class EventMigrationManager:
                     migration_version,
                 )
             except OperationalError as e:
-                raise PapiWebException(
+                self._log_error(
                     f'Database {database.file.name} '
                     f'({database.version}) could not be upgraded '
                     f'to version {migration_version}: "{e}"'
                 )
+                return False
+        return True
 
     def _rollback(
         self,
         database: EventDatabase,
         target_version: Version,
         skip_commits: bool,
-    ):
+    ) -> bool:
         while database.version > target_version:
             if database.version not in self.migration_versions:
-                raise PapiWebException(
+                self._log_error(
                     'No migration for current database version, '
                     'impossible to rollback.'
                 )
+                return False
 
             migration_class = self._version_to_migration_class(
                 database.version
@@ -147,11 +152,13 @@ class EventMigrationManager:
                     previous_version,
                 )
             except (OperationalError, NotImplementedError) as e:
-                raise PapiWebException(
+                self._log_error(
                     f'Database {database.file.name} '
                     f'({database.version}) could not be downgraded '
                     f'to version {previous_version}: "{e}"'
                 )
+                return False
+        return True
 
     def _next_migration_version(
         self, current_version: Version, max_version: Version

--- a/utils/event_databases/migrate.py
+++ b/utils/event_databases/migrate.py
@@ -11,9 +11,8 @@ from database.sqlite.event_migration import EventMigrationManager
 if __name__ == '__main__':
     parser = ArgumentParser(
         description=(
-            'Command restoring the event database backups. '
-            'If there already exists an event database with the same id '
-            'as a restored event, the existing database is overwritten.'
+            'Command migrating one or more '
+            'event databases to a specific version.'
         )
     )
     parser.add_argument(

--- a/utils/event_databases/migrate.py
+++ b/utils/event_databases/migrate.py
@@ -1,0 +1,52 @@
+import sys
+from argparse import ArgumentParser
+
+from packaging.version import Version
+
+from data.loader import EventLoader
+from database.sqlite.event_database import EventDatabase
+from database.sqlite.event_migration import EventMigrationManager
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(
+        description=(
+            'Command restoring the event database backups. '
+            'If there already exists an event database with the same id '
+            'as a restored event, the existing database is overwritten.'
+        )
+    )
+    parser.add_argument(
+        '-v',
+        '--version',
+        type=str,
+        help=(
+            'Version of the database to migrate to. '
+            'Defaults to the last version.'
+        ),
+    )
+    parser.add_argument(
+        '-e',
+        '--event',
+        type=str,
+        help='ID of the event to migrate. Defaults to all the events.',
+    )
+
+    args = parser.parse_args()
+    migration_manager = EventMigrationManager()
+    version = (
+        Version(args.version) if args.version else
+        migration_manager.last_migration_version
+    )
+    event_ids = [args.event] if args.event else EventLoader().event_uniq_ids
+    for event_id in event_ids:
+        with EventDatabase(event_id, True, False) as event_database:
+            if event_database.version == version:
+                sys.stdout.write(
+                    f'Database [{event_id}] already at version {version}\n'
+                )
+            else:
+                migration_manager.migrate(event_database, version)
+                sys.stdout.write(
+                    f'Database [{event_id}] migrated to version {version}\n'
+                )

--- a/utils/event_databases/migrate.py
+++ b/utils/event_databases/migrate.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 
 from packaging.version import Version
 
+from common.logger import print_interactive_info, print_interactive_error, print_interactive_success
 from data.loader import EventLoader
 from database.sqlite.event_database import EventDatabase
 from database.sqlite.event_migration import EventMigrationManager
@@ -30,22 +31,44 @@ if __name__ == '__main__':
         type=str,
         help='ID of the event to migrate. Defaults to all the events.',
     )
-
+    parser.add_argument(
+        '-a',
+        '--all-events',
+        action='store_true',
+        help='Apply the migration to all the event databases.',
+    )
     args = parser.parse_args()
-    migration_manager = EventMigrationManager()
+
+    event_ids: list[str] = []
+    if not args.event and not args.all_events:
+        print_interactive_error(
+            'No event selected, use one of the options '
+            '"--event EVENT" or "--all-events"'
+        )
+        sys.exit(1)
+    elif args.event and args.all_events:
+        print_interactive_error(
+            'Options "--event EVENT" and "--all-events" '
+            'can\'t be used at the same time'
+        )
+        sys.exit(1)
+    elif args.event:
+        event_ids.append(args.event)
+    elif args.all_events:
+        event_ids = EventLoader().event_uniq_ids
+
+    migration_manager = EventMigrationManager(True)
     version = (
         Version(args.version) if args.version else
         migration_manager.last_migration_version
     )
-    event_ids = [args.event] if args.event else EventLoader().event_uniq_ids
     for event_id in event_ids:
         with EventDatabase(event_id, True, False) as event_database:
             if event_database.version == version:
-                sys.stdout.write(
-                    f'Database [{event_id}] already at version {version}\n'
+                print_interactive_info(
+                    f'Database [{event_id}] already at version {version}'
                 )
-            else:
-                migration_manager.migrate(event_database, version)
-                sys.stdout.write(
-                    f'Database [{event_id}] migrated to version {version}\n'
+            elif migration_manager.migrate(event_database, version):
+                print_interactive_success(
+                    f'Database [{event_id}] migrated to version {version}'
                 )

--- a/utils/event_databases/restore.py
+++ b/utils/event_databases/restore.py
@@ -3,11 +3,9 @@ from argparse import ArgumentParser
 
 from packaging.version import Version
 
-from common import get_logger
 from common.papi_web_config import PapiWebConfig
 from data.loader import EventBackup, EventBackupLoader
 
-logger = get_logger()
 
 if __name__ == '__main__':
     parser = ArgumentParser(
@@ -42,38 +40,38 @@ if __name__ == '__main__':
     if args.version:
         version = Version(args.version)
         if version > PapiWebConfig.version:
-            logger.error(
+            sys.stderr.write(
                 f'Impossible to restore: Version selected ({version}) is newer'
-                f' than the latest Papi Web version {PapiWebConfig.version}'
+                f' than the latest Papi Web version {PapiWebConfig.version}\n'
             )
             sys.exit(1)
     else:
         version = loader.latest_compatible_version(event_id)
         if not version:
-            logger.error('No compatible backup to restore')
+            sys.stderr.write('No compatible backup to restore\n')
             sys.exit(1)
 
     to_restore: list[EventBackup] = []
     if event_id:
         backup = EventBackup(event_id, version)
         if not backup.exists:
-            logger.error(
+            sys.stderr.write(
                 'No backup to restore for event '
-                f'{event_id} and version {version.public}'
+                f'{event_id} and version {version.public}\n'
             )
             sys.exit(1)
         to_restore.append(backup)
     else:
         to_restore = loader.version_backups(version)
         if not to_restore:
-            logger.error(
-                f'No backup to restore for version {version.public}'
+            sys.stderr.write(
+                f'No backup to restore for version {version.public}\n'
             )
             sys.exit(1)
 
     for backup in to_restore:
         backup.restore()
-        logger.info(
-            f'Database "{backup.name}" '
-            f'restored to version {backup.version.public}'
+        sys.stdout.write(
+            f'Database "{backup.name}" restored to '
+            f'version {backup.version.public}\n'
         )

--- a/utils/event_databases/restore.py
+++ b/utils/event_databases/restore.py
@@ -3,6 +3,7 @@ from argparse import ArgumentParser
 
 from packaging.version import Version
 
+from common.logger import print_interactive_error, print_interactive_info
 from common.papi_web_config import PapiWebConfig
 from data.loader import EventBackup, EventBackupLoader
 
@@ -40,38 +41,38 @@ if __name__ == '__main__':
     if args.version:
         version = Version(args.version)
         if version > PapiWebConfig.version:
-            sys.stderr.write(
+            print_interactive_error(
                 f'Impossible to restore: Version selected ({version}) is newer'
-                f' than the latest Papi Web version {PapiWebConfig.version}\n'
+                f' than the latest Papi Web version {PapiWebConfig.version}'
             )
             sys.exit(1)
     else:
         version = loader.latest_compatible_version(event_id)
         if not version:
-            sys.stderr.write('No compatible backup to restore\n')
+            print_interactive_error('No compatible backup to restore')
             sys.exit(1)
 
     to_restore: list[EventBackup] = []
     if event_id:
         backup = EventBackup(event_id, version)
         if not backup.exists:
-            sys.stderr.write(
+            print_interactive_error(
                 'No backup to restore for event '
-                f'{event_id} and version {version.public}\n'
+                f'{event_id} and version {version.public}'
             )
             sys.exit(1)
         to_restore.append(backup)
     else:
         to_restore = loader.version_backups(version)
         if not to_restore:
-            sys.stderr.write(
-                f'No backup to restore for version {version.public}\n'
+            print_interactive_error(
+                f'No backup to restore for version {version.public}'
             )
             sys.exit(1)
 
     for backup in to_restore:
         backup.restore()
-        sys.stdout.write(
+        print_interactive_info(
             f'Database "{backup.name}" restored to '
-            f'version {backup.version.public}\n'
+            f'version {backup.version.public}'
         )


### PR DESCRIPTION
add the command `python utils/event_databases/migrate.py`:
````sh
Command migrating one or more event databases to a specific version.

options:
  -h, --help            show this help message and exit
  -v VERSION, --version VERSION
                        Version of the database to migrate to. Defaults to the last version.
  -e EVENT, --event EVENT
                        ID of the event to migrate. Defaults to all the events.
````  

Migrating to a previous version uses the backward methods defined in the EventMigration classes. By default that method raises a `NotImplementedError`. This disables the rollback feature for migrations we don't want / can't implement the backward method of (ex: 2.4.21)