### PR TITLE
Fix Litestar warning on synchronous function call

### DIFF
--- a/src/web/controllers/admin/timer_admin_controller.py
+++ b/src/web/controllers/admin/timer_admin_controller.py
@@ -426,7 +426,7 @@ class TimerAdminController(BaseEventAdminController):
         path='/admin/default-timers-update/{event_uniq_id:str}',
         name='default-timers-update'
     )
-    def htmx_admin_default_timers_update(
+    async def htmx_admin_default_timers_update(
         self,
         request: HTMXRequest,
         event_uniq_id: str,


### PR DESCRIPTION
Currently on dev when launching the App:
```
LitestarWarning: Use of a synchronous callable <function TimerAdminController.htmx_admin_default_timers_update at 0x000002A7261ABBA0> without setting sync_to_thread is discouraged since synchronous callables can block the main thread if they perform blocking operations. If the callable is guaranteed to be non-blocking, you can set sync_to_thread=False to skip this warning, or set the environmentvariable LITESTAR_WARN_IMPLICIT_SYNC_TO_THREAD=0 to disable warnings of this type entirely.
````
endpoint works the same with or without the async keyword