### PR TITLE
Removed file reference from POT/PO files

### DIFF
--- a/utils/i18n/i18n_update.py
+++ b/utils/i18n/i18n_update.py
@@ -408,7 +408,7 @@ class I18nUpdater:
             [
                 f'--mapping-file={extract_config_file}',
                 f'--output-file={self.pot_file}',
-                '--add-location=file',
+                '--add-location=never',
                 '--no-wrap',
                 '--omit-header',
                 '.',


### PR DESCRIPTION
The aim of this PR is to limit the diff when moving strings from a file to another one.