### PR TITLE
Remove remaining deprecated ffe fields

### DIFF
--- a/src/plugins/ffe/__init__.py
+++ b/src/plugins/ffe/__init__.py
@@ -2,4 +2,4 @@ from packaging.version import Version
 
 PLUGIN_NAME = "ffe"
 
-PLUGIN_VERSION = Version('0.1.0')
+PLUGIN_VERSION = Version('0.1.1')

--- a/src/plugins/ffe/migrations/v0_01_01.py
+++ b/src/plugins/ffe/migrations/v0_01_01.py
@@ -1,0 +1,38 @@
+from database.sqlite.migration import AbstractMigration
+
+
+class Migration(AbstractMigration):
+    def forward(self):
+        self.database.execute(
+            'ALTER TABLE `tournament` DROP COLUMN `ffe_last_upload`'
+        )
+        self.database.execute(
+            'ALTER TABLE `tournament` DROP COLUMN `ffe_last_rules_upload`'
+        )
+        self.database.execute(
+            f'ALTER TABLE `tournament` RENAME COLUMN '
+            f'`deprecated_last_ffe_upload` TO `ffe_last_upload`'
+        )
+        self.database.execute(
+            f'ALTER TABLE `tournament` RENAME COLUMN '
+            f'`deprecated_last_ffe_rules_upload` TO `ffe_last_rules_upload`'
+        )
+
+    def backward(self):
+
+        self.database.execute(
+            f'ALTER TABLE `tournament` RENAME COLUMN '
+            f'`ffe_last_upload` TO `deprecated_last_ffe_upload`'
+        )
+        self.database.execute(
+            f'ALTER TABLE `tournament` RENAME COLUMN '
+            f'`ffe_last_rules_upload` TO `deprecated_last_ffe_rules_upload`'
+        )
+        self.database.execute(
+            'ALTER TABLE `tournament` ADD '
+            '`ffe_last_rules_upload` FLOAT NOT NULL DEFAULT 0.0'
+        )
+        self.database.execute(
+            'ALTER TABLE `tournament` ADD '
+            '`ffe_last_upload` FLOAT NOT NULL DEFAULT 0.0'
+        )


### PR DESCRIPTION
There was an error in the migration creating the ffe plugin, leading to a two deprecated fields remaining in the DB:  
- deprecated_last_ffe_rules_upload
- deprecated_last_ffe_upload  

This PR fixes it