### PR TITLE
Use Python 3.12

### DIFF
--- a/docs/86-i18n.md
+++ b/docs/86-i18n.md
@@ -7,6 +7,7 @@
 <!-- DO NOT EDIT! (START) -->
 | Locale | Messages | Empty | Empty mandatory | [ai_translation] | [fuzzy] | PO file | Translators |
 |--|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+<<<<<<< Updated upstream
 |<img src="../src/web/static/images/locales/en.svg" style="height: 1em;"/>&nbsp;``en``&nbsp;English | 1261 | 1172 | 0 | 0 | 0 | [messages.po](../locale/en/LC_MESSAGES/messages.po) | [Timothy ARMES](https://github.com/timothyarmes) |
 |<img src="../src/web/static/images/locales/fr.svg" style="height: 1em;"/>&nbsp;``fr``&nbsp;Français | 1261 | 10 | 0 | 0 | 0 | [messages.po](../locale/fr/LC_MESSAGES/messages.po) | [Pascal AUBRY](https://github.com/pascalaubry)<br/>[Sammy PLAT](https://github.com/Amaras) |
 |<img src="../src/web/static/images/locales/de.svg" style="height: 1em;"/>&nbsp;``de``&nbsp;Deutsch | 1261 | 78 | 2 | 1095 | 86 | [messages.po](../locale/de/LC_MESSAGES/messages.po) | AI (Opus-MT) |
@@ -16,6 +17,17 @@
 |<img src="../src/web/static/images/locales/nl.svg" style="height: 1em;"/>&nbsp;``nl``&nbsp;Nederlands | 1261 | 71 | 4 | 1102 | 84 | [messages.po](../locale/nl/LC_MESSAGES/messages.po) | AI (Opus-MT) |
 |<img src="../src/web/static/images/locales/sv.svg" style="height: 1em;"/>&nbsp;``sv``&nbsp;Svenska | 1261 | 78 | 4 | 1095 | 84 | [messages.po](../locale/sv/LC_MESSAGES/messages.po) | AI (Opus-MT) |
 Last update: 2025-03-16 16:39
+=======
+|<img src="../src/web/static/images/locales/en.svg" style="height: 1em;"/>&nbsp;``en``&nbsp;English | 1276 | 1188 | 0 | 0 | 0 | [messages.po](../locale/en/LC_MESSAGES/messages.po) | [Timothy ARMES](https://github.com/timothyarmes) |
+|<img src="../src/web/static/images/locales/fr.svg" style="height: 1em;"/>&nbsp;``fr``&nbsp;Français | 1276 | 3 | 0 | 0 | 0 | [messages.po](../locale/fr/LC_MESSAGES/messages.po) | [Pascal AUBRY](https://github.com/pascalaubry)<br/>[Sammy PLAT](https://github.com/Amaras) |
+|<img src="../src/web/static/images/locales/de.svg" style="height: 1em;"/>&nbsp;``de``&nbsp;Deutsch | 1276 | 97 | 11 | 76 | 1092 | [messages.po](../locale/de/LC_MESSAGES/messages.po) | AI (Opus-MT) |
+|<img src="../src/web/static/images/locales/el.svg" style="height: 1em;"/>&nbsp;``el``&nbsp;Ελληνικά | 1276 | 100 | 13 | 74 | 1089 | [messages.po](../locale/el/LC_MESSAGES/messages.po) | AI (Opus-MT) |
+|<img src="../src/web/static/images/locales/es.svg" style="height: 1em;"/>&nbsp;``es``&nbsp;Español | 1276 | 118 | 13 | 74 | 1071 | [messages.po](../locale/es/LC_MESSAGES/messages.po) | AI (Opus-MT) |
+|<img src="../src/web/static/images/locales/it.svg" style="height: 1em;"/>&nbsp;``it``&nbsp;Italiano | 1276 | 97 | 13 | 74 | 1092 | [messages.po](../locale/it/LC_MESSAGES/messages.po) | AI (Opus-MT) |
+|<img src="../src/web/static/images/locales/nl.svg" style="height: 1em;"/>&nbsp;``nl``&nbsp;Nederlands | 1276 | 90 | 13 | 74 | 1099 | [messages.po](../locale/nl/LC_MESSAGES/messages.po) | AI (Opus-MT) |
+|<img src="../src/web/static/images/locales/sv.svg" style="height: 1em;"/>&nbsp;``sv``&nbsp;Svenska | 1276 | 97 | 13 | 74 | 1092 | [messages.po](../locale/sv/LC_MESSAGES/messages.po) | AI (Opus-MT) |
+Last update: 2025-03-17 17:38
+>>>>>>> Stashed changes
 <!-- DO NOT EDIT! (END) -->
 
 Flags:

--- a/docs/86-i18n.md
+++ b/docs/86-i18n.md
@@ -7,7 +7,6 @@
 <!-- DO NOT EDIT! (START) -->
 | Locale | Messages | Empty | Empty mandatory | [ai_translation] | [fuzzy] | PO file | Translators |
 |--|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-<<<<<<< Updated upstream
 |<img src="../src/web/static/images/locales/en.svg" style="height: 1em;"/>&nbsp;``en``&nbsp;English | 1261 | 1172 | 0 | 0 | 0 | [messages.po](../locale/en/LC_MESSAGES/messages.po) | [Timothy ARMES](https://github.com/timothyarmes) |
 |<img src="../src/web/static/images/locales/fr.svg" style="height: 1em;"/>&nbsp;``fr``&nbsp;Français | 1261 | 10 | 0 | 0 | 0 | [messages.po](../locale/fr/LC_MESSAGES/messages.po) | [Pascal AUBRY](https://github.com/pascalaubry)<br/>[Sammy PLAT](https://github.com/Amaras) |
 |<img src="../src/web/static/images/locales/de.svg" style="height: 1em;"/>&nbsp;``de``&nbsp;Deutsch | 1261 | 78 | 2 | 1095 | 86 | [messages.po](../locale/de/LC_MESSAGES/messages.po) | AI (Opus-MT) |
@@ -17,17 +16,6 @@
 |<img src="../src/web/static/images/locales/nl.svg" style="height: 1em;"/>&nbsp;``nl``&nbsp;Nederlands | 1261 | 71 | 4 | 1102 | 84 | [messages.po](../locale/nl/LC_MESSAGES/messages.po) | AI (Opus-MT) |
 |<img src="../src/web/static/images/locales/sv.svg" style="height: 1em;"/>&nbsp;``sv``&nbsp;Svenska | 1261 | 78 | 4 | 1095 | 84 | [messages.po](../locale/sv/LC_MESSAGES/messages.po) | AI (Opus-MT) |
 Last update: 2025-03-16 16:39
-=======
-|<img src="../src/web/static/images/locales/en.svg" style="height: 1em;"/>&nbsp;``en``&nbsp;English | 1276 | 1188 | 0 | 0 | 0 | [messages.po](../locale/en/LC_MESSAGES/messages.po) | [Timothy ARMES](https://github.com/timothyarmes) |
-|<img src="../src/web/static/images/locales/fr.svg" style="height: 1em;"/>&nbsp;``fr``&nbsp;Français | 1276 | 3 | 0 | 0 | 0 | [messages.po](../locale/fr/LC_MESSAGES/messages.po) | [Pascal AUBRY](https://github.com/pascalaubry)<br/>[Sammy PLAT](https://github.com/Amaras) |
-|<img src="../src/web/static/images/locales/de.svg" style="height: 1em;"/>&nbsp;``de``&nbsp;Deutsch | 1276 | 97 | 11 | 76 | 1092 | [messages.po](../locale/de/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-|<img src="../src/web/static/images/locales/el.svg" style="height: 1em;"/>&nbsp;``el``&nbsp;Ελληνικά | 1276 | 100 | 13 | 74 | 1089 | [messages.po](../locale/el/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-|<img src="../src/web/static/images/locales/es.svg" style="height: 1em;"/>&nbsp;``es``&nbsp;Español | 1276 | 118 | 13 | 74 | 1071 | [messages.po](../locale/es/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-|<img src="../src/web/static/images/locales/it.svg" style="height: 1em;"/>&nbsp;``it``&nbsp;Italiano | 1276 | 97 | 13 | 74 | 1092 | [messages.po](../locale/it/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-|<img src="../src/web/static/images/locales/nl.svg" style="height: 1em;"/>&nbsp;``nl``&nbsp;Nederlands | 1276 | 90 | 13 | 74 | 1099 | [messages.po](../locale/nl/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-|<img src="../src/web/static/images/locales/sv.svg" style="height: 1em;"/>&nbsp;``sv``&nbsp;Svenska | 1276 | 97 | 13 | 74 | 1092 | [messages.po](../locale/sv/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-Last update: 2025-03-17 17:38
->>>>>>> Stashed changes
 <!-- DO NOT EDIT! (END) -->
 
 Flags:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "Papi-web"
 description = "An application to help chess arbiters and organizers manage their tournaments"
-requires-python = ">=3.11.0"
+requires-python = ">=3.12.0"
 version = "2.4.25"
 
 authors = [


### PR DESCRIPTION
Python 3.11 doesn't have any bugfix updates (with installer) since 3.11.9 released on 2024-04-02 (nearly a year ago), see [PEP 664: Pyhton 3.11 release schedule](https://peps.python.org/pep-0664/).
Only source-only security fixes are available.

This PR simply changes the required Python version to `>= 3.12.0` in our `pyproject.toml`.
Python 3.12 is expected to have one last bugfix version on 2025-04-08.
Here is the changelog for Python 3.12: https://docs.python.org/3.12/whatsnew/3.12.html

I also expect to change Python versions every year.
I am proposing to change to version 3.n+1 every October, after the last bugfix of version 3.n is released (when version 3.n+2 is released).

For users, this should be completely transparent.
For devs (us), this means we have to recreate our virtual environments, however we will have better features.

For future reference, this means in October this year (2025), we will change from Python 3.12 to Python 3.13, once Python 3.14 is released (even if the last bugfix release will be in April 2025).