### PR TITLE
Only define version once

### DIFF
--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -20,6 +20,21 @@ PAPI_WEB_VERSION: Version = Version(importlib.metadata.version(APP_NAME))
 # True when the program is running in a development environment, False if running as an EXE file.
 DEVEL_ENV: bool = not getattr(sys, 'frozen', False)
 
+logger: Logger = get_logger()
+
+if DEVEL_ENV:
+    import tomllib
+    from contextlib import suppress
+    with suppress(KeyError):
+        with open('pyproject.toml', 'rb') as f:
+            version = tomllib.load(f)['project']['version']
+        if Version(version) != PAPI_WEB_VERSION:
+            logger.critical(
+                'Installed %s version %s does not match defined version %s. Run `pip install -e .` then run %s again.',
+                APP_NAME, PAPI_WEB_VERSION, version, APP_NAME)
+            raise ValueError(f'{PAPI_WEB_VERSION=}, {version=}')
+
+
 # True when experimental features are enabled (relying on an environment variable), False otherwise.
 EXPERIMENTAL_FEATURES_ENV_VAR: str = 'PAPI_WEB_EXPERIMENTAL'
 EXPERIMENTAL_FEATURES: bool = os.environ.get(
@@ -36,7 +51,6 @@ REQUEST_TIMEOUT: int = 10
 RGB = namedtuple('RGB', ['red', 'green', 'blue'])
 
 
-logger: Logger = get_logger()
 
 
 """ The temporary directory. """

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import os
 import re
 import sys
@@ -14,6 +15,7 @@ from packaging.version import Version
 from common.logger import get_logger
 
 APP_NAME: str = 'papi-web'
+PAPI_WEB_VERSION: Version = Version(importlib.metadata.version(APP_NAME))
 
 # True when the program is running in a development environment, False if running as an EXE file.
 DEVEL_ENV: bool = not getattr(sys, 'frozen', False)
@@ -28,7 +30,6 @@ EXPERIMENTAL_FEATURES: bool = os.environ.get(
     '1',
 ]
 
-PAPI_WEB_VERSION: Version = Version("2.4.27")
 
 REQUEST_TIMEOUT: int = 10
 


### PR DESCRIPTION
Using importlib.metadata.version, we can get the installed version at runtime.

This avoids version desynchronizations I have observed **several times**, especially when there are dependency version updates.

There is a workflow adaptation expected:
  1. New version is decided by one author
  2. author updates the pyproject.toml version
  3. author runs  `pip install -e .`
  4. reviewers also update their installations before reviewing
  5. reviewers can install previous versions once they go back to other branches.

> [!CAUTION]
> There is now an error on dev when the installed version and the version defined in `pyproject.toml` do not match.
> This ensures we always have the appropriate version

