### PR TITLE
Remove refresh buttons

### DIFF
--- a/locale/de/LC_MESSAGES/messages.po
+++ b/locale/de/LC_MESSAGES/messages.po
@@ -3459,10 +3459,6 @@ msgid "Enable/disable the details of events on the cards below."
 msgstr "Aktivieren/deaktivieren Sie die Details der Ereignisse auf den Karten unten."
 
 #, ai_translation
-msgid "Refresh this page."
-msgstr "Aktualisieren Sie diese Seite."
-
-#, ai_translation
 msgid "Open/close check-in."
 msgstr "Check-in öffnen/schließen."
 
@@ -3945,6 +3941,10 @@ msgstr "Fügen Sie ein Turnier vor dem Hinzufügen von Spielern hinzu."
 
 msgid "Add player"
 msgstr ""
+
+#, ai_translation
+msgid "Refresh this page."
+msgstr "Aktualisieren Sie diese Seite."
 
 #, ai_translation
 msgid "Clear all the filters."

--- a/locale/el/LC_MESSAGES/messages.po
+++ b/locale/el/LC_MESSAGES/messages.po
@@ -3442,10 +3442,6 @@ msgid "Enable/disable the details of events on the cards below."
 msgstr "Ενεργοποιήστε/απενεργοποιήστε τις λεπτομέρειες των γεγονότων στις παρακάτω κάρτες."
 
 #, ai_translation
-msgid "Refresh this page."
-msgstr "Ανανέωση αυτής της σελίδας."
-
-#, ai_translation
 msgid "Open/close check-in."
 msgstr "Ανοίξτε/κλείστε το check-in."
 
@@ -3931,6 +3927,10 @@ msgstr "Προσθέστε ένα τουρνουά πριν από την προ
 
 msgid "Add player"
 msgstr ""
+
+#, ai_translation
+msgid "Refresh this page."
+msgstr "Ανανέωση αυτής της σελίδας."
 
 #, ai_translation
 msgid "Clear all the filters."

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -2636,9 +2636,6 @@ msgstr ""
 msgid "Enable/disable the details of events on the cards below."
 msgstr ""
 
-msgid "Refresh this page."
-msgstr ""
-
 msgid "Open/close check-in."
 msgstr ""
 
@@ -3010,6 +3007,9 @@ msgid "Add a tournament before adding players."
 msgstr ""
 
 msgid "Add player"
+msgstr ""
+
+msgid "Refresh this page."
 msgstr ""
 
 msgid "Clear all the filters."

--- a/locale/es/LC_MESSAGES/messages.po
+++ b/locale/es/LC_MESSAGES/messages.po
@@ -3406,10 +3406,6 @@ msgid "Enable/disable the details of events on the cards below."
 msgstr "Activar/desactivar los detalles de los eventos en las cartas de abajo."
 
 #, ai_translation
-msgid "Refresh this page."
-msgstr "Actualizar esta página."
-
-#, ai_translation
 msgid "Open/close check-in."
 msgstr "Abrir/cerrar el check-in."
 
@@ -3890,6 +3886,10 @@ msgstr "Añade un torneo antes de añadir jugadores."
 
 msgid "Add player"
 msgstr ""
+
+#, ai_translation
+msgid "Refresh this page."
+msgstr "Actualizar esta página."
 
 #, ai_translation
 msgid "Clear all the filters."

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -2636,9 +2636,6 @@ msgstr "Aucun message d'information"
 msgid "Enable/disable the details of events on the cards below."
 msgstr "Activer/désactiver l'affichage des détails des évènements sur les cartes ci-dessous."
 
-msgid "Refresh this page."
-msgstr "Actualiser la page."
-
 msgid "Open/close check-in."
 msgstr "Ouvrir/fermer le pointage."
 
@@ -3011,6 +3008,9 @@ msgstr "Ajoutez un tournoi pour pouvoir ajouter des joueur·euses."
 
 msgid "Add player"
 msgstr "Ajouter"
+
+msgid "Refresh this page."
+msgstr "Actualiser la page."
 
 msgid "Clear all the filters."
 msgstr "Effacer tous les filtres."

--- a/locale/it/LC_MESSAGES/messages.po
+++ b/locale/it/LC_MESSAGES/messages.po
@@ -3446,10 +3446,6 @@ msgid "Enable/disable the details of events on the cards below."
 msgstr "Abilita/Disabilita i dettagli degli eventi sulle carte sottostanti."
 
 #, ai_translation
-msgid "Refresh this page."
-msgstr "Aggiorna questa pagina."
-
-#, ai_translation
 msgid "Open/close check-in."
 msgstr "Apri/chiudi il check-in."
 
@@ -3930,6 +3926,10 @@ msgstr "Aggiungere un torneo prima di aggiungere i giocatori."
 
 msgid "Add player"
 msgstr ""
+
+#, ai_translation
+msgid "Refresh this page."
+msgstr "Aggiorna questa pagina."
 
 #, ai_translation
 msgid "Clear all the filters."

--- a/locale/nl/LC_MESSAGES/messages.po
+++ b/locale/nl/LC_MESSAGES/messages.po
@@ -3430,10 +3430,6 @@ msgid "Enable/disable the details of events on the cards below."
 msgstr "Schakel de details van de gebeurtenissen op de onderstaande kaarten in/uit."
 
 #, ai_translation
-msgid "Refresh this page."
-msgstr "Vernieuw deze pagina."
-
-#, ai_translation
 msgid "Open/close check-in."
 msgstr "Open/sluiten check-in."
 
@@ -3914,6 +3910,10 @@ msgstr "Voeg een toernooi toe voordat je spelers toevoegt."
 
 msgid "Add player"
 msgstr ""
+
+#, ai_translation
+msgid "Refresh this page."
+msgstr "Vernieuw deze pagina."
 
 #, ai_translation
 msgid "Clear all the filters."

--- a/locale/sv/LC_MESSAGES/messages.po
+++ b/locale/sv/LC_MESSAGES/messages.po
@@ -3451,10 +3451,6 @@ msgid "Enable/disable the details of events on the cards below."
 msgstr "Aktivera/inaktivera information om händelser på korten nedan."
 
 #, ai_translation
-msgid "Refresh this page."
-msgstr "Uppdatera den här sidan."
-
-#, ai_translation
 msgid "Open/close check-in."
 msgstr "Öppna/stänga incheckningen."
 
@@ -3935,6 +3931,10 @@ msgstr "Lägg till en turnering innan du lägger till spelare."
 
 msgid "Add player"
 msgstr ""
+
+#, ai_translation
+msgid "Refresh this page."
+msgstr "Uppdatera den här sidan."
 
 #, ai_translation
 msgid "Clear all the filters."

--- a/src/web/templates/admin/families/tab.html
+++ b/src/web/templates/admin/families/tab.html
@@ -22,17 +22,6 @@
                 {% if show %}checked{% endif %} /><label for="{{ id }}" class="form-check-label"> {{ _('Details') }}</label>
         </div>
     {% endwith %}
-    <span class="pe-3" {{ macros.tooltip_attributes('info', 'Refresh this page.', 'top') }}>
-        <button
-            class="btn btn-outline-primary text-nowrap"
-            hx-get="{{ url_for('admin-event-families-tab', event_uniq_id=admin_event.uniq_id) }}"
-            preload
-            hx-target="body"
-            hx-indicator="#please-wait"
-        >
-            <i class="bi-arrow-clockwise"></i>
-        </button>
-    </span>
     <span
             class="dropdown-end pe-0"
             {% if not admin_event.tournaments_by_id %}

--- a/src/web/templates/admin/index/events_tab.html
+++ b/src/web/templates/admin/index/events_tab.html
@@ -21,17 +21,6 @@
                 {% if show %}checked{% endif %} /><label for="{{ id }}" class="form-check-label"> {{ _('Details') }}</label>
         </div>
     {% endwith %}
-    <span {{ macros.tooltip_attributes('info', _('Refresh this page.'), 'top') }}>
-        <button
-            class="btn btn-outline-primary text-nowrap"
-            hx-get="{{ url_for('admin-tab', admin_tab=admin_tab) }}"
-            hx-target="body"
-            preload
-            hx-indicator="#please-wait"
-        >
-            <i class="bi-arrow-clockwise"></i>
-        </button>
-    </span>
     <span {{ macros.tooltip_attributes('info', _('Add an event.'), 'top') }}>
         <button
             class="btn btn-primary text-nowrap"

--- a/src/web/templates/admin/players/tab.html
+++ b/src/web/templates/admin/players/tab.html
@@ -17,17 +17,6 @@
                 {% include 'check_in_tournaments.html' %}
             {% endif %}
             {% include 'filter_columns.html' %}
-            <span {{ macros.tooltip_attributes('info', _('Refresh this page.'), 'top') }}>
-                <button
-                    class="btn btn-outline-primary text-nowrap ms-1"
-                    hx-get="{{ url }}"
-                    preload
-                    hx-target="body"
-                    hx-indicator="#please-wait"
-                >
-                    <i class="bi-arrow-clockwise"></i>
-                </button>
-            </span>
             <span
                 {% if admin_event.not_finished_tournaments_with_file_sorted_by_uniq_id %}
                     {{ macros.tooltip_attributes('info', _('Add a player to the event.'), 'top') }}

--- a/src/web/templates/admin/rotators/tab.html
+++ b/src/web/templates/admin/rotators/tab.html
@@ -24,17 +24,6 @@
             <label for="{{ id }}" class="form-check-label"> {{ _('Details') }}</label>
         </div>
     {% endwith %}
-    <span {{ macros.tooltip_attributes('info', 'Refresh this page.', 'top') }}>
-        <button
-            class="btn btn-outline-primary text-nowrap"
-            hx-get="{{ url_for('admin-event-rotators-tab', event_uniq_id=admin_event.uniq_id) }}"
-            preload
-            hx-target="body"
-            hx-indicator="#please-wait"
-        >
-            <i class="bi-arrow-clockwise"></i>
-        </button>
-    </span>
     <span
         {{ macros.tooltip_attributes(
             'info',

--- a/src/web/templates/admin/screens/tab.html
+++ b/src/web/templates/admin/screens/tab.html
@@ -42,17 +42,6 @@
             <label for="{{ id }}" class="form-check-label"> {{ _('Details') }}</label>
         </div>
     {% endwith %}
-    <span {{ macros.tooltip_attributes('info', _('Refresh this page.'), 'top') }}>
-        <button
-            class="btn btn-outline-primary text-nowrap"
-            hx-get="{{ url_for('admin-event-screens-tab', event_uniq_id=admin_event.uniq_id) }}"
-            preload
-            hx-target="body"
-            hx-indicator="#please-wait"
-        >
-            <i class="bi-arrow-clockwise"></i>
-        </button>
-    </span>
     <span
         class="dropdown-end"
         {% if not admin_event.tournaments_by_id %}

--- a/src/web/templates/admin/timers/tab.html
+++ b/src/web/templates/admin/timers/tab.html
@@ -6,17 +6,6 @@
 {% endblock %}
 
 {% block cards_container_right_buttons %}
-    <span {{ macros.tooltip_attributes('info', _('Refresh this page.'), 'top') }}>
-        <button
-            class="btn btn-outline-primary text-nowrap me-2"
-            hx-get="{{ url_for('admin-event-timers-tab', event_uniq_id=admin_event.uniq_id) }}"
-            preload
-            hx-target="body"
-            hx-indicator="#please-wait"
-        >
-            <i class="bi-arrow-clockwise"></i>
-        </button>
-    </span>
     <span {{ macros.tooltip_attributes('info', _('Add a timer to the event.'), 'top') }}>
         <button
             class="btn btn-primary text-nowrap"

--- a/src/web/templates/admin/tournaments/tab.html
+++ b/src/web/templates/admin/tournaments/tab.html
@@ -22,17 +22,6 @@
                 {% if show %}checked{% endif %} /><label for="{{ id }}" class="form-check-label"> {{ _('Details') }}</label>
         </div>
     {% endwith %}
-    <span {{ macros.tooltip_attributes('info', _('Refresh this page.'), 'top') }}>
-        <button
-            class="btn btn-outline-primary text-nowrap ms-1"
-            hx-get="{{ url_for('admin-event-tournaments-tab', event_uniq_id=admin_event.uniq_id) }}"
-            preload
-            hx-target="body"
-            hx-indicator="#please-wait"
-        >
-            <i class="bi-arrow-clockwise"></i>
-        </button>
-    </span>
     <span {{ macros.tooltip_attributes('info', _('Add a tournament to the event.'), 'top') }}>
         <button
             class="btn btn-primary text-nowrap ms-1"


### PR DESCRIPTION
Now that we have freed the URLs, global browser refresh works. I don't think we should keep refresh buttons, they take space in the interface for no reason (users won't make a difference between refreshing the body and refreshing the page). We'd need to rewrite some browser features if we go for a standalone app instead of a browser based one, and in that case refresh would need to be a global feature instead of a per-page feature.  

I left one: the one in the players table (makes sense to refresh a table, and page refresh is much longer)