### PR TITLE
Replace `from_id` methods by `by_id` dicts

### DIFF
--- a/src/data/tie_break.py
+++ b/src/data/tie_break.py
@@ -47,9 +47,21 @@ class TieBreakManager:
             plugin_manager.hook.get_extra_tie_break_classes()
         ))
 
-    @staticmethod
-    def option_types() -> list[type['AbstractTieBreakOption']]:
-        return OPTION_CLASSES
+    @classmethod
+    def tie_break_type_by_id(cls) -> dict[str, type['AbstractTieBreak']]:
+        return {
+            tie_break_type().id: tie_break_type
+            for tie_break_type in cls.tie_break_types()
+        }
+
+    @classmethod
+    def tie_break_by_papi_id(cls) -> dict[str, 'AbstractTieBreak']:
+        papi_tie_breaks: dict[str, 'AbstractTieBreak'] = {}
+        for tie_break_type in cls.tie_break_types():
+            tie_break = tie_break_type()
+            if tie_break.papi_id:
+                papi_tie_breaks[tie_break.papi_id] = tie_break
+        return papi_tie_breaks
 
     @classmethod
     def papi_compatible_tie_breaks(cls) -> list['AbstractTieBreak']:
@@ -59,50 +71,16 @@ class TieBreakManager:
             if tie_break_type().papi_id is not None
         ]
 
-    @classmethod
-    def tie_break_from_papi_id(
-        cls, papi_id: str
-    ) -> 'AbstractTieBreak | None':
-        return next(
-            (
-                tie_break_type()
-                for tie_break_type in cls.tie_break_types()
-                if tie_break_type().papi_id == papi_id
-            ),
-            None,
-        )
+    @staticmethod
+    def option_types() -> list[type['AbstractTieBreakOption']]:
+        return OPTION_CLASSES
 
     @classmethod
-    def tie_break_from_id(
-        cls,
-        tie_break_id: str,
-        options: list['AbstractTieBreakOption'] | None = None
-    ) -> 'AbstractTieBreak | None':
-        """Returns The tie-break matching the ID
-        or None if no tie-break is found for that ID"""
-        return next(
-            (
-                tie_break_type(options)
-                for tie_break_type in cls.tie_break_types()
-                if tie_break_type().id == tie_break_id
-            ),
-            None,
-        )
-
-    @classmethod
-    def option_from_id(
-        cls, option_id: str, value: Any | None = None
-    ) -> 'AbstractTieBreakOption | None':
-        """Returns The tie-break option matching the ID
-        or None if no option is found for that ID"""
-        return next(
-            (
-                option_type(value)
-                for option_type in cls.option_types()
-                if option_type().id == option_id
-            ),
-            None,
-        )
+    def option_type_by_id(cls) -> dict[str, type['AbstractTieBreakOption']]:
+        return {
+            option_type().id: option_type
+            for option_type in cls.option_types()
+        }
 
 
 class AbstractTieBreakOption(ABC):

--- a/src/database/access/papi/papi_database.py
+++ b/src/database/access/papi/papi_database.py
@@ -73,14 +73,12 @@ class PapiDatabase(AccessDatabase):
         )
         rating_limit1: int = int(self._read_var('EloBase1'))
         rating_limit2: int = int(self._read_var('EloBase2'))
-        tie_breaks: list[AbstractTieBreak] = [
-            tie_break for tie_break in [
-                TieBreakManager.tie_break_from_papi_id(
-                    self._read_var(f'Dep{index}')
-                )
-                for index in range(1, 4)
-            ] if tie_break is not None
-        ]
+        tie_break_by_id = TieBreakManager.tie_break_by_papi_id()
+        tie_breaks: list[AbstractTieBreak] = []
+        for index in range(1, 4):
+            papi_id = self._read_var(f'Dep{index}')
+            if tie_break := tie_break_by_id.get(papi_id, None):
+                tie_breaks.append(tie_break)
         point_value_type: PointValueType = PointValueType.from_papi_value(self._read_var('DecomptePoints'))
         location: str = self._read_var('Lieu')
         start_date: str = self._read_var('DateDebut')

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -1552,16 +1552,16 @@ class EventDatabase(SQLiteVersionedDatabase):
         if not tie_break_list:
             return None
         tie_breaks: list[AbstractTieBreak] = []
+        tie_break_type_by_id = TieBreakManager.tie_break_type_by_id()
+        option_type_by_id = TieBreakManager.option_type_by_id()
         for tie_break_dict in tie_break_list:
             tie_break_id = tie_break_dict['type']
             options: list[AbstractTieBreakOption] = []
             for option_id, value in tie_break_dict['options'].items():
-                if option := TieBreakManager.option_from_id(option_id, value):
-                    options.append(option)
-            if tie_break := TieBreakManager.tie_break_from_id(
-                tie_break_id, options
-            ):
-                tie_breaks.append(tie_break)
+                if option_type := option_type_by_id.get(option_id, None):
+                    options.append(option_type(value))
+            if tie_break_type := tie_break_type_by_id.get(tie_break_id, None):
+                tie_breaks.append(tie_break_type(options))
         return tie_breaks
 
     @classmethod

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -181,18 +181,21 @@ class TournamentAdminController(BaseEventAdminController):
 
         if action == 'update':
             tie_breaks = []
-            used_tie_break_types: list[type[AbstractTieBreak]] = []
+            tie_break_type_by_id = TieBreakManager.tie_break_type_by_id()
+            used_tie_break_ids: list[str] = []
             for index in range(1, 4):
                 field = f'tie_break_{index}'
                 tie_break_id = WebContext.form_data_to_str(data, field)
                 if not tie_break_id:
                     continue
-                tie_break = TieBreakManager.tie_break_from_id(tie_break_id)
-                if type(tie_break) in used_tie_break_types:
+                if tie_break_id in used_tie_break_ids:
                     errors[field] = _('Tie-break already in use.')
                     break
-                used_tie_break_types.append(type(tie_break))
-                tie_breaks.append(tie_break)
+                used_tie_break_ids.append(tie_break_id)
+                if tie_break_type := (
+                    tie_break_type_by_id.get(tie_break_id, None)
+                ):
+                    tie_breaks.append(tie_break_type())
 
         # Have plugins validate their fields and return private plugin data
         per_plugin_tournament_data = plugin_manager.hook.get_validated_tournament_form_fields(action=action, tournament=web_context.admin_tournament, data=data, errors=errors)


### PR DESCRIPTION
Small PR, from_id methods unnecessarly generate a lot of computation, using by_id reduces this a lot