### PR TITLE
Fix translations in tie-break short names

### DIFF
--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -331,10 +331,10 @@ msgid "Black"
 msgstr "Noirs"
 
 msgid "Black games"
-msgstr "Parties noires"
+msgstr "Parties Noirs"
 
 msgid "Black wins"
-msgstr "Victoires noires"
+msgstr "Victoires Noirs"
 
 msgid "Blitz *** BLITZ ELO FOR PRINT VIEW"
 msgstr "Blitz"


### PR DESCRIPTION
follow-up to #291, accidently merged due to auto-merge by @pascalaubry.  
- "... noires" -> Noirs
- dot notation being unclear: discussed orally, the full name is always included in the tooltip.   

a working example:  
![image](https://github.com/user-attachments/assets/183f888b-41d8-4aa2-ac5e-19c18a181daf)
 