### PR TITLE
Fix database badges

### DIFF
--- a/src/web/static/css/admin.css
+++ b/src/web/static/css/admin.css
@@ -24,14 +24,3 @@
 .fide-id-none {
     opacity: 0.3;
 }
-.database-badge {
-    bottom: 1px;
-    display: flex;
-    right: -3px;
-    font-size: 10px;
-    width: 14px;
-    height: 14px;
-    align-items: center;
-    justify-content: center;
-    line-height: 0;
-}

--- a/src/web/templates/admin/common/database/out_of_date_badge.html
+++ b/src/web/templates/admin/common/database/out_of_date_badge.html
@@ -1,6 +1,15 @@
 <span
-    class="database-badge position-absolute p-0 rounded-circle bg-danger"
-    style="font-size: 15px"
+    class="position-absolute p-0 rounded-circle bg-danger"
+    style="
+        bottom: 1px;
+        display: flex;
+        right: -3px;
+        font-size: 15px;
+        width: 14px;
+        height: 14px;
+        align-items: center;
+        justify-content: center;
+        line-height: 0;"
     hx-get="{{ url_for('admin-database-status-badge') }}"
     hx-trigger="database-update-launched from:body"
     hx-target="this"

--- a/src/web/templates/admin/common/database/settings_badge.html
+++ b/src/web/templates/admin/common/database/settings_badge.html
@@ -1,5 +1,15 @@
 <span
-    class="database-badge position-absolute p-0 rounded-circle bg-success"
+    class="position-absolute p-0 rounded-circle bg-success"
+    style="
+        bottom: 1px;
+        display: flex;
+        right: -3px;
+        font-size: 10px;
+        width: 14px;
+        height: 14px;
+        align-items: center;
+        justify-content: center;
+        line-height: 0;"
     hx-get="{{ url_for('admin-database-status-badge') }}"
     hx-trigger="database-update-launched from:body"
     hx-target="this"

--- a/src/web/templates/admin/common/database/updating_badge.html
+++ b/src/web/templates/admin/common/database/updating_badge.html
@@ -1,6 +1,15 @@
 <span
-    class="database-badge position-absolute p-0 rounded-circle bg-warning text-dark"
+    class="position-absolute p-0 rounded-circle bg-warning text-dark"
     style="
+        bottom: 1px;
+        display: flex;
+        right: -3px;
+        font-size: 10px;
+        width: 14px;
+        height: 14px;
+        align-items: center;
+        justify-content: center;
+        line-height: 0;
         animation: spin 1s infinite;
         animation-timing-function: linear;"
     hx-get="{{ url_for('admin-database-status-badge') }}"


### PR DESCRIPTION
database badges were broken by the style property refactor to the css class `database-badge`  
![image](https://github.com/user-attachments/assets/825bf84c-1df7-4d46-a263-ab8b48be20ea)
I'm convinced to have tested it and that it worked fine. Reverting it to before the refactor fixes it, @timothyarmes sorry for modifyng this part in the first place