### PR TITLE
Fix `Papi file not found` tooltip displayed when Papi file exists

### DIFF
--- a/src/web/templates/admin/tournaments/tournament_modal.html
+++ b/src/web/templates/admin/tournaments/tournament_modal.html
@@ -258,7 +258,17 @@
                     </h4>
                     <div class="row">
                         {% for index in [1, 2, 3] %}
-                            <div class="file-exists col-12 col-md-4 mb-3" {{ macros.tooltip_attributes('info', _('Fields relying on the Papi database can\'t be updated if the file does not exist.'), 'right') }}>
+                            <div
+                                class="file-exists col-12 col-md-4 mb-3"
+                                data-bs-toggle="{%if not file_exists %}tooltip{%endif%}"
+                                {{
+                                    macros.tooltip_attributes(
+                                        'info',
+                                        _('Fields relying on the Papi database can\'t be updated if the file does not exist.'),
+                                        'right'
+                                    )
+                                }}
+                            >
                                 {{ admin_macros.select_input(
                                     name='tie_break_' ~ index|string,
                                     label=_('Tie-break #%(index)d:', index=index),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8b92e7dc-834d-4114-a856-bc5fae14576b)
