### PR TITLE
Fix version problems that break dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,18 @@
 [build-system]
-requires = ["setuptools >= 75.5.0", "requests ~= 2.32.3",]
+requires = ["setuptools >= 75.5.0", "requests ~= 2.32.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "Papi-web"
 description = "An application to help chess arbiters and organizers manage their tournaments"
 requires-python = ">=3.12.0"
-version = "2.6.0alpha0"
+version = "2.6.0a0"
 
 authors = [
-  {name = "Pascal Aubry", email = "papi-web@echecs-bretagne.fr"},
-  {name = "Sammy Plat", email = "papi-web@echecs-bretagne.fr"},
-  {name = "Timothy Armes", email = "tim@timothyarmes.com"},
-  {name = "Youri Aubry"},
+  { name = "Pascal Aubry", email = "papi-web@echecs-bretagne.fr" },
+  { name = "Sammy Plat", email = "papi-web@echecs-bretagne.fr" },
+  { name = "Timothy Armes", email = "tim@timothyarmes.com" },
+  { name = "Youri Aubry" },
 ]
 license = { text = "AGPL v3.0" }
 readme = "README.md"
@@ -44,28 +44,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-lint = [
-  "ruff",
-  "validate-pyproject",
-  "pipdeptree",
-  "mypy",
-  "pre-commit",
-]
+lint = ["ruff", "validate-pyproject", "pipdeptree", "mypy", "pre-commit"]
 
-translate = [
-  "transformers",
-  "torch",
-  "sentencepiece",
-  "sacremoses",
-]
+translate = ["transformers", "torch", "sentencepiece", "sacremoses"]
 
-export = [
-  "PyInstaller",
-]
+export = ["PyInstaller"]
 
-tests = [
-  "pytest",
-]
+tests = ["pytest"]
 
 [tool.ruff.format]
 quote-style = "single"

--- a/src/common/engine.py
+++ b/src/common/engine.py
@@ -540,15 +540,27 @@ class Engine:
             return None
         if not (
             matches := re.match(
-                r'^(?P<major>\d+)\.(?P<minor>\d+)rc(?P<rc>\d+)$',
+                r'^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(a|b|rc)(?P<rc>\d+)$',
                 str(PAPI_WEB_VERSION),
             )
         ):
             raise ValueError(f'Invalid Papi-web version [{str(PAPI_WEB_VERSION)}]')
-        # 'release candidates' X.YrcN
-        if last_stable_matches.group('major') > matches.group(
-            'major'
-        ) or last_stable_matches.group('minor') > matches.group('minor'):
+        # alpha versions: X.Y.ZaN
+        # beta versions: X.Y.ZbN
+        # 'release candidates' X.Y.ZrcN
+        if (
+            (stable_major := last_stable_matches.group('major'))
+            > (current_major := matches.group('major'))
+            or (
+                stable_major == current_major
+                and (stable_minor := last_stable_matches.group('minor'))
+                > (current_minor := matches.group('minor'))
+            )
+            or (
+                (stable_major, stable_minor) == (current_major, current_minor)
+                and last_stable_matches.group('patch') > matches.group('patch')
+            )
+        ):
             print_interactive_warning(
                 _(
                     'A stable and more recent version is available ([{new_version}]) but upgrading unstable versions (like the one you are currently using: [{old_version}]) must be done manually (upgrade from the last stable version installed on your server).'


### PR DESCRIPTION
`dev` was broken because of an version format check that did not follow our new versioning scheme.

Versions can now in one of 4 formats:
1. "classic" versions: X.Y.Z
2. alpha versions: X.Y.ZaN
3. beta versions: X.Y.ZbN
4. release candidates: X.Y.ZrcN

This means, in particular, that X.YrcN is no longer valid.

I can launch the server with this code.