### PR TITLE
Add papi Info to database and forms

### DIFF
--- a/docs/86-i18n.md
+++ b/docs/86-i18n.md
@@ -7,9 +7,9 @@
 <!-- DO NOT EDIT! (START) -->
 | Locale | Messages | Empty | Empty mandatory | PO file | Translators |
 |--|:--:|:--:|:--:|:--:|:--:|
-|<img src="../src/web/static/images/locales/en.svg" style="height: 1em;"/>&nbsp;``en``&nbsp;English | 1386 | 1288 | 0 | [messages.po](../locale/en/LC_MESSAGES/messages.po) | [Timothy ARMES](https://github.com/timothyarmes) |
-|<img src="../src/web/static/images/locales/fr.svg" style="height: 1em;"/>&nbsp;``fr``&nbsp;Français | 1386 | 0 | 0 | [messages.po](../locale/fr/LC_MESSAGES/messages.po) | [Pascal AUBRY](https://github.com/pascalaubry)<br/>[Sammy PLAT](https://github.com/Amaras) |
-Last update: 2025-04-10 12:54
+|<img src="../src/web/static/images/locales/en.svg" style="height: 1em;"/>&nbsp;``en``&nbsp;English | 1393 | 1295 | 0 | [messages.po](../locale/en/LC_MESSAGES/messages.po) | [Timothy ARMES](https://github.com/timothyarmes) |
+|<img src="../src/web/static/images/locales/fr.svg" style="height: 1em;"/>&nbsp;``fr``&nbsp;Français | 1393 | 0 | 0 | [messages.po](../locale/fr/LC_MESSAGES/messages.po) | [Pascal AUBRY](https://github.com/pascalaubry)<br/>[Sammy PLAT](https://github.com/Amaras) |
+Last update: 2025-04-11 16:23
 <!-- DO NOT EDIT! (END) -->
 
 Flags:

--- a/docs/86-i18n.md
+++ b/docs/86-i18n.md
@@ -5,17 +5,11 @@
 ## Locales implemented and translation status
 
 <!-- DO NOT EDIT! (START) -->
-| Locale | Messages | Empty | Empty mandatory | [ai_translation] | [fuzzy] | PO file | Translators |
-|--|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-|<img src="../src/web/static/images/locales/en.svg" style="height: 1em;"/>&nbsp;``en``&nbsp;English | 1375 | 1277 | 0 | 0 | 0 | [messages.po](../locale/en/LC_MESSAGES/messages.po) | [Timothy ARMES](https://github.com/timothyarmes) |
-|<img src="../src/web/static/images/locales/fr.svg" style="height: 1em;"/>&nbsp;``fr``&nbsp;Français | 1375 | 0 | 0 | 0 | 0 | [messages.po](../locale/fr/LC_MESSAGES/messages.po) | [Pascal AUBRY](https://github.com/pascalaubry)<br/>[Sammy PLAT](https://github.com/Amaras) |
-|<img src="../src/web/static/images/locales/de.svg" style="height: 1em;"/>&nbsp;``de``&nbsp;Deutsch | 1375 | 11 | 0 | 1267 | 97 | [messages.po](../locale/de/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-|<img src="../src/web/static/images/locales/el.svg" style="height: 1em;"/>&nbsp;``el``&nbsp;Ελληνικά | 1375 | 14 | 0 | 1264 | 97 | [messages.po](../locale/el/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-|<img src="../src/web/static/images/locales/es.svg" style="height: 1em;"/>&nbsp;``es``&nbsp;Español | 1375 | 36 | 0 | 1242 | 97 | [messages.po](../locale/es/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-|<img src="../src/web/static/images/locales/it.svg" style="height: 1em;"/>&nbsp;``it``&nbsp;Italiano | 1375 | 11 | 0 | 1267 | 97 | [messages.po](../locale/it/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-|<img src="../src/web/static/images/locales/nl.svg" style="height: 1em;"/>&nbsp;``nl``&nbsp;Nederlands | 1375 | 1 | 0 | 1277 | 97 | [messages.po](../locale/nl/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-|<img src="../src/web/static/images/locales/sv.svg" style="height: 1em;"/>&nbsp;``sv``&nbsp;Svenska | 1375 | 9 | 0 | 1269 | 97 | [messages.po](../locale/sv/LC_MESSAGES/messages.po) | AI (Opus-MT) |
-Last update: 2025-04-10 02:48
+| Locale | Messages | Empty | Empty mandatory | PO file | Translators |
+|--|:--:|:--:|:--:|:--:|:--:|
+|<img src="../src/web/static/images/locales/en.svg" style="height: 1em;"/>&nbsp;``en``&nbsp;English | 1386 | 1288 | 0 | [messages.po](../locale/en/LC_MESSAGES/messages.po) | [Timothy ARMES](https://github.com/timothyarmes) |
+|<img src="../src/web/static/images/locales/fr.svg" style="height: 1em;"/>&nbsp;``fr``&nbsp;Français | 1386 | 0 | 0 | [messages.po](../locale/fr/LC_MESSAGES/messages.po) | [Pascal AUBRY](https://github.com/pascalaubry)<br/>[Sammy PLAT](https://github.com/Amaras) |
+Last update: 2025-04-10 12:54
 <!-- DO NOT EDIT! (END) -->
 
 Flags:

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -38,6 +38,10 @@ msgid "%(set_name)s (round %(round)d)"
 msgstr ""
 
 #, python-format
+msgid "%(title)s:"
+msgstr ""
+
+#, python-format
 msgid "%f to %l"
 msgstr ""
 
@@ -533,6 +537,9 @@ msgstr ""
 msgid "Chessevent: %(chessevent_user_id)s / %(chessevent_event_id)s / %(chessevent_tournament_name)s"
 msgstr ""
 
+msgid "Chief arbiter"
+msgstr ""
+
 msgid "Choose a custom image:"
 msgstr ""
 
@@ -1012,6 +1019,9 @@ msgid "E.g.: Check-in started for %%s"
 msgstr ""
 
 msgid "E.g.: DOE"
+msgstr ""
+
+msgid "E.g.: DOE John"
 msgstr ""
 
 msgid "E.g.: John"
@@ -1700,6 +1710,9 @@ msgstr ""
 msgid "Image: %(image)s"
 msgstr ""
 
+msgid "Impossible to set a round number lower than current round #{round}."
+msgstr ""
+
 msgid "Incorrect password."
 msgstr ""
 
@@ -1909,6 +1922,9 @@ msgid "Local URL: {local_url}"
 msgstr ""
 
 msgid "Local source databases settings have been updated."
+msgstr ""
+
+msgid "Location"
 msgstr ""
 
 msgid "Log level"
@@ -2330,6 +2346,9 @@ msgstr ""
 
 #, python-format
 msgid "Number of players : %(num)d"
+msgstr ""
+
+msgid "Number of rounds in the tournament."
 msgstr ""
 
 msgid "Number of wins"
@@ -2833,6 +2852,9 @@ msgstr ""
 msgid "Rating *** RATING FOR PLAYERS COLUMNS"
 msgstr "Rating"
 
+msgid "Rating:"
+msgstr ""
+
 msgid "Ratings"
 msgstr ""
 
@@ -2985,6 +3007,9 @@ msgid "Round: %(round)d"
 msgstr ""
 
 msgid "Round: the last finished round"
+msgstr ""
+
+msgid "Rounds"
 msgstr ""
 
 msgid "Rounds one Elected to Play"
@@ -3328,6 +3353,9 @@ msgstr ""
 msgid "The last set of a screen can not be deleted."
 msgstr ""
 
+msgid "The location of the event."
+msgstr ""
+
 msgid "The log level allows you to trace the behaviour of the application."
 msgstr ""
 
@@ -3366,6 +3394,9 @@ msgid "The name of the Papi file is not set, by default [{filename}]"
 msgstr ""
 
 msgid "The name of the Papi file without [.papi] extension (defaults to the unique ID)."
+msgstr ""
+
+msgid "The name of the chief arbiter of the event."
 msgstr ""
 
 msgid "The name of the event on the ChessEvent platform (by default, can be overridden by the tournaments)."
@@ -3577,6 +3608,9 @@ msgid "The tournament to print."
 msgstr ""
 
 msgid "The type of document to print."
+msgstr ""
+
+msgid "The type of rating to use for the tournament."
 msgstr ""
 
 msgid "This action can not be applied to the tournaments of this event."
@@ -3859,6 +3893,9 @@ msgid "USE AT YOUR OWN RISKS"
 msgstr ""
 
 msgid "Unable to create Papi files."
+msgstr ""
+
+msgid "Undefined"
 msgstr ""
 
 msgid "Under 10"

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -38,7 +38,7 @@ msgid "%(set_name)s (round %(round)d)"
 msgstr ""
 
 #, python-format
-msgid "%(title)s:"
+msgid "%(string)s:"
 msgstr ""
 
 #, python-format
@@ -537,9 +537,6 @@ msgstr ""
 msgid "Chessevent: %(chessevent_user_id)s / %(chessevent_event_id)s / %(chessevent_tournament_name)s"
 msgstr ""
 
-msgid "Chief arbiter"
-msgstr ""
-
 msgid "Choose a custom image:"
 msgstr ""
 
@@ -1021,9 +1018,6 @@ msgstr ""
 msgid "E.g.: DOE"
 msgstr ""
 
-msgid "E.g.: DOE John"
-msgstr ""
-
 msgid "E.g.: John"
 msgstr ""
 
@@ -1040,6 +1034,9 @@ msgid "E.g.: My screen"
 msgstr ""
 
 msgid "E.g.: My screen family"
+msgstr ""
+
+msgid "E.g.: Paris"
 msgstr ""
 
 #, python-format
@@ -1204,6 +1201,9 @@ msgid "Enable/disable the details of tournaments on the cards below."
 msgstr ""
 
 msgid "End of upload (Ctrl-C)"
+msgstr ""
+
+msgid "End time needs to be after start time."
 msgstr ""
 
 msgid "End:"
@@ -2348,9 +2348,6 @@ msgstr ""
 msgid "Number of players : %(num)d"
 msgstr ""
 
-msgid "Number of rounds in the tournament."
-msgstr ""
-
 msgid "Number of wins"
 msgstr ""
 
@@ -3326,6 +3323,10 @@ msgstr ""
 msgid "The end date and time of the event."
 msgstr ""
 
+#, python-format
+msgid "The end time of the tournament (defaults to %(datetime)s)."
+msgstr ""
+
 msgid "The federation that organizes the event."
 msgstr ""
 
@@ -3354,6 +3355,13 @@ msgid "The last set of a screen can not be deleted."
 msgstr ""
 
 msgid "The location of the event."
+msgstr ""
+
+#, python-format
+msgid "The location of the tournament (defaults to [%(location)s])."
+msgstr ""
+
+msgid "The location of the tournament."
 msgstr ""
 
 msgid "The log level allows you to trace the behaviour of the application."
@@ -3396,9 +3404,6 @@ msgstr ""
 msgid "The name of the Papi file without [.papi] extension (defaults to the unique ID)."
 msgstr ""
 
-msgid "The name of the chief arbiter of the event."
-msgstr ""
-
 msgid "The name of the event on the ChessEvent platform (by default, can be overridden by the tournaments)."
 msgstr ""
 
@@ -3435,6 +3440,9 @@ msgid "The number of players per screen, optional (the number of screens adapts 
 msgstr ""
 
 msgid "The number of points difference between the ranking of the players used to calculate the number of penalties applied to the highest ranked player."
+msgstr ""
+
+msgid "The number of rounds of the tournament."
 msgstr ""
 
 msgid "The number of screens on which the boards will be distributed, optional (the number of screens is always the same and the number of boards per screen adapts to the number of boards)."
@@ -3580,6 +3588,10 @@ msgstr ""
 msgid "The start date and time of the event."
 msgstr ""
 
+#, python-format
+msgid "The start time of the tournament (defaults to %(datetime)s)."
+msgstr ""
+
 msgid "The text colour of the alert messages."
 msgstr ""
 
@@ -3669,6 +3681,9 @@ msgid "Time control"
 msgstr ""
 
 msgid "Time is not defined."
+msgstr ""
+
+msgid "Time outside of event time range ({start} - {stop})."
 msgstr ""
 
 msgid "Timer [{timer_id}] not found."
@@ -4311,10 +4326,4 @@ msgstr[1] ""
 
 msgid "{screen_type}-screen"
 msgstr ""
-
-#~ msgid "Do you want to recover the configuration of version [{version}] [{y_uc}/{n_lc}]?"
-#~ msgstr ""
-
-#~ msgid "Papi-web project"
-#~ msgstr ""
 

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -38,8 +38,8 @@ msgid "%(set_name)s (round %(round)d)"
 msgstr "%(set_name)s (ronde %(round)d)"
 
 #, python-format
-msgid "%(title)s:"
-msgstr "%(title)s :"
+msgid "%(string)s:"
+msgstr "%(string)s :"
 
 #, python-format
 msgid "%f to %l"
@@ -537,9 +537,6 @@ msgstr "Chessevent : %(chessevent_user_id)s / %(chessevent_event_id)s"
 msgid "Chessevent: %(chessevent_user_id)s / %(chessevent_event_id)s / %(chessevent_tournament_name)s"
 msgstr "Chessevent : %(chessevent_user_id)s / %(chessevent_event_id)s / %(chessevent_tournament_name)s"
 
-msgid "Chief arbiter"
-msgstr "Arbitre en chef"
-
 msgid "Choose a custom image:"
 msgstr "Choisissez une image personnalisée :"
 
@@ -1021,9 +1018,6 @@ msgstr "Exemple : Pointage commencé depuis %%s"
 msgid "E.g.: DOE"
 msgstr "Exemple : DUPONT"
 
-msgid "E.g.: DOE John"
-msgstr "Exemple: DUPONT Pierre"
-
 msgid "E.g.: John"
 msgstr "Exemple : Pierre"
 
@@ -1041,6 +1035,9 @@ msgstr "Exemple : Mon écran"
 
 msgid "E.g.: My screen family"
 msgstr "Exemple : Ma famille d'écrans"
+
+msgid "E.g.: Paris"
+msgstr "Exemple : Paris"
 
 #, python-format
 msgid "E.g.: Players %%f to %%l"
@@ -1205,6 +1202,9 @@ msgstr "Activer/désactiver l'affichage des détails des tournois sur les cartes
 
 msgid "End of upload (Ctrl-C)"
 msgstr "Fin de mise en ligne (Ctrl-C)"
+
+msgid "End time needs to be after start time."
+msgstr "L'horaire de fin doit être après l'horaire de début."
 
 msgid "End:"
 msgstr "Fin :"
@@ -2348,9 +2348,6 @@ msgstr "Nombre de parties gagnées"
 msgid "Number of players : %(num)d"
 msgstr "Nombre de joueur·euses : %(num)d"
 
-msgid "Number of rounds in the tournament."
-msgstr "Nombre de rondes dans le tournoi."
-
 msgid "Number of wins"
 msgstr "Nombre de victoires"
 
@@ -3326,6 +3323,10 @@ msgstr "Le répertoire du fichier Papi ([%(dir)s] par défaut)."
 msgid "The end date and time of the event."
 msgstr "La date et l'heure de fin de l'évènement."
 
+#, python-format
+msgid "The end time of the tournament (defaults to %(datetime)s)."
+msgstr "L'horaire de fin du tournoi (par défaut %(datetime)s)."
+
 msgid "The federation that organizes the event."
 msgstr "La fédération qui organise l'évènement."
 
@@ -3355,6 +3356,13 @@ msgstr "Le dernier écran ne peut être supprimé."
 
 msgid "The location of the event."
 msgstr "Le lieu de l'évènement."
+
+#, python-format
+msgid "The location of the tournament (defaults to [%(location)s])."
+msgstr "Le lieu du tournoi (par défaut [%(location)s])."
+
+msgid "The location of the tournament."
+msgstr "Le lieu du tournoi."
 
 msgid "The log level allows you to trace the behaviour of the application."
 msgstr "Le niveau de log permet de trancer le comportement de l'application."
@@ -3396,9 +3404,6 @@ msgstr "Le nom du fichier papi n'est pas défini, par défaut [{filename}]"
 msgid "The name of the Papi file without [.papi] extension (defaults to the unique ID)."
 msgstr "Le nom du fichier Papi sans l'extension [.papi] (par défaut l'identifiant unique)."
 
-msgid "The name of the chief arbiter of the event."
-msgstr "Le nom de l'arbitre en chef de l'évènement."
-
 msgid "The name of the event on the ChessEvent platform (by default, can be overridden by the tournaments)."
 msgstr "Le nom de l'évènement sur la plateforme ChessEvent (par défaut, peut être modifié pour chaque tournoi)."
 
@@ -3436,6 +3441,9 @@ msgstr "Le nombre de joueur·euses par écran, facultatif (le nombre d'écrans s
 
 msgid "The number of points difference between the ranking of the players used to calculate the number of penalties applied to the highest ranked player."
 msgstr "Le nombre de points de différence entre le classement des joueur·euses utilisé pour calculer le nombre de pénalités appliqué au·à la joueur·euse le·la mieux classé·e."
+
+msgid "The number of rounds of the tournament."
+msgstr "Le nombre de rondes du tournoi."
 
 msgid "The number of screens on which the boards will be distributed, optional (the number of screens is always the same and the number of boards per screen adapts to the number of boards)."
 msgstr "Le nombre d'écrans sur lesquels les échiquiers seront répartis, facultatif (le nombre d'écrans reste toujours le même et le nombre d'échiquiers par écran s'adapte)."
@@ -3580,6 +3588,10 @@ msgstr "Les écrans à afficher en rotation (les écrans de saisie apparaissent 
 msgid "The start date and time of the event."
 msgstr "La date et l'heure de début de l'évènement."
 
+#, python-format
+msgid "The start time of the tournament (defaults to %(datetime)s)."
+msgstr "L'horaire de début du tournoi (par défaut %(datetime)s)."
+
 msgid "The text colour of the alert messages."
 msgstr "La couleur du texte des messages d'alerte."
 
@@ -3670,6 +3682,9 @@ msgstr "Cadence"
 
 msgid "Time is not defined."
 msgstr "L'heure n'est pas définie"
+
+msgid "Time outside of event time range ({start} - {stop})."
+msgstr "Horaire en dehors des horaires de l'évènement ({start} - {stop})."
 
 msgid "Timer [{timer_id}] not found."
 msgstr "Le chronomètre [{timer_id}] n'existe pas."

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -38,6 +38,10 @@ msgid "%(set_name)s (round %(round)d)"
 msgstr "%(set_name)s (ronde %(round)d)"
 
 #, python-format
+msgid "%(title)s:"
+msgstr "%(title)s :"
+
+#, python-format
 msgid "%f to %l"
 msgstr "%f to %l"
 
@@ -533,6 +537,9 @@ msgstr "Chessevent : %(chessevent_user_id)s / %(chessevent_event_id)s"
 msgid "Chessevent: %(chessevent_user_id)s / %(chessevent_event_id)s / %(chessevent_tournament_name)s"
 msgstr "Chessevent : %(chessevent_user_id)s / %(chessevent_event_id)s / %(chessevent_tournament_name)s"
 
+msgid "Chief arbiter"
+msgstr "Arbitre en chef"
+
 msgid "Choose a custom image:"
 msgstr "Choisissez une image personnalisée :"
 
@@ -1013,6 +1020,9 @@ msgstr "Exemple : Pointage commencé depuis %%s"
 
 msgid "E.g.: DOE"
 msgstr "Exemple : DUPONT"
+
+msgid "E.g.: DOE John"
+msgstr "Exemple: DUPONT Pierre"
 
 msgid "E.g.: John"
 msgstr "Exemple : Pierre"
@@ -1700,6 +1710,9 @@ msgstr "Image :"
 msgid "Image: %(image)s"
 msgstr "Image : %(image)s"
 
+msgid "Impossible to set a round number lower than current round #{round}."
+msgstr "Impossible d'attribuer un nombre de rondes inférieur à la ronde actuelle (ronde n°{round})."
+
 msgid "Incorrect password."
 msgstr "Mot de passe incorrect."
 
@@ -1910,6 +1923,9 @@ msgstr "URL locale : {local_url}"
 
 msgid "Local source databases settings have been updated."
 msgstr "les paramètres des bases de données locales ont été mis à jour."
+
+msgid "Location"
+msgstr "Lieu"
 
 msgid "Log level"
 msgstr "Niveau de log"
@@ -2331,6 +2347,9 @@ msgstr "Nombre de parties gagnées"
 #, python-format
 msgid "Number of players : %(num)d"
 msgstr "Nombre de joueur·euses : %(num)d"
+
+msgid "Number of rounds in the tournament."
+msgstr "Nombre de rondes dans le tournoi."
 
 msgid "Number of wins"
 msgstr "Nombre de victoires"
@@ -2833,6 +2852,9 @@ msgstr "Elo"
 msgid "Rating *** RATING FOR PLAYERS COLUMNS"
 msgstr "Classement"
 
+msgid "Rating:"
+msgstr "Classement :"
+
 msgid "Ratings"
 msgstr "Classements"
 
@@ -2986,6 +3008,9 @@ msgstr "Ronde : %(round)d"
 
 msgid "Round: the last finished round"
 msgstr "Ronde : la dernière ronde terminée"
+
+msgid "Rounds"
+msgstr "Rondes"
 
 msgid "Rounds one Elected to Play"
 msgstr "Rondes jouées"
@@ -3328,6 +3353,9 @@ msgstr "L'installation de la version [{version}] a échoué."
 msgid "The last set of a screen can not be deleted."
 msgstr "Le dernier écran ne peut être supprimé."
 
+msgid "The location of the event."
+msgstr "Le lieu de l'évènement."
+
 msgid "The log level allows you to trace the behaviour of the application."
 msgstr "Le niveau de log permet de trancer le comportement de l'application."
 
@@ -3367,6 +3395,9 @@ msgstr "Le nom du fichier papi n'est pas défini, par défaut [{filename}]"
 
 msgid "The name of the Papi file without [.papi] extension (defaults to the unique ID)."
 msgstr "Le nom du fichier Papi sans l'extension [.papi] (par défaut l'identifiant unique)."
+
+msgid "The name of the chief arbiter of the event."
+msgstr "Le nom de l'arbitre en chef de l'évènement."
 
 msgid "The name of the event on the ChessEvent platform (by default, can be overridden by the tournaments)."
 msgstr "Le nom de l'évènement sur la plateforme ChessEvent (par défaut, peut être modifié pour chaque tournoi)."
@@ -3578,6 +3609,9 @@ msgstr "Le tournoi à imprimer."
 
 msgid "The type of document to print."
 msgstr "Le type de document à imprimer."
+
+msgid "The type of rating to use for the tournament."
+msgstr "Le type de classement utilsé."
 
 msgid "This action can not be applied to the tournaments of this event."
 msgstr "Cette action ne peut être réalisée sur les tournois de cet évènement."
@@ -3860,6 +3894,9 @@ msgstr "UTILISEZ À VOS PROPRES RISQUES"
 
 msgid "Unable to create Papi files."
 msgstr "Impossible de créer les fichiers Papi."
+
+msgid "Undefined"
+msgstr "Non défini"
 
 msgid "Under 10"
 msgstr "Moins de 10"

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -130,25 +130,26 @@ def rgb_to_hexa(rgb: RGB) -> str:
     return '#' + ''.join(f'{max(0, min(255, i)):02X}' for i in rgb)
 
 
+def format_timestamp(ts: float | None = None, format_: str = '%Y-%m-%d %H:%M') -> str:
+    """Formats a timestamp (now if None) to the given format."""
+    return datetime.strftime(
+        datetime.fromtimestamp(ts if ts is not None else time.time()), format_
+    )
+
+
 def format_timestamp_date_time(ts: float | None = None) -> str:
     """Formats the given timestamp (now if None) to YYYY-mm-dd HH:MM format."""
-    return datetime.strftime(
-        datetime.fromtimestamp(ts if ts is not None else time.time()), '%Y-%m-%d %H:%M'
-    )
+    return format_timestamp(ts)
 
 
 def format_timestamp_date(ts: float | None = None) -> str:
     """Formats the given timestamp (now if None) to YYYY-mm-dd format."""
-    return datetime.strftime(
-        datetime.fromtimestamp(ts if ts is not None else time.time()), '%Y-%m-%d'
-    )
+    return format_timestamp(ts, '%Y-%m-%d')
 
 
 def format_timestamp_time(ts: float | None = None) -> str:
     """Formats the given timestamp (now if None) to HH:MM format."""
-    return datetime.strftime(
-        datetime.fromtimestamp(ts if ts is not None else time.time()), '%H:%M'
-    )
+    return format_timestamp(ts, '%H:%M')
 
 
 def show_duration(func):

--- a/src/data/event.py
+++ b/src/data/event.py
@@ -285,6 +285,14 @@ class Event:
             self.add_error(_('[{path}] is not a directory.').format(path=path))
         return path
 
+    @property
+    def location(self) -> str | None:
+        return self.stored_event.location
+
+    @property
+    def arbiter(self) -> str | None:
+        return self.stored_event.arbiter
+
     @cached_property
     def background_image(self) -> str:
         if self.stored_event.hide_background_image:

--- a/src/data/event.py
+++ b/src/data/event.py
@@ -289,10 +289,6 @@ class Event:
     def location(self) -> str | None:
         return self.stored_event.location
 
-    @property
-    def arbiter(self) -> str | None:
-        return self.stored_event.arbiter
-
     @cached_property
     def background_image(self) -> str:
         if self.stored_event.hide_background_image:

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -36,7 +36,7 @@ from utils.enum import (
     TournamentRating,
     TrfType, PlayerRatingType,
 )
-from database.access.papi.papi_database import PapiDatabase
+from database.access.papi.papi_database import PapiDatabase, PapiVariable
 from database.sqlite.event.event_database import EventDatabase
 from database.sqlite.event.event_store import StoredTournament
 from plugins.manager import plugin_manager
@@ -90,10 +90,6 @@ class Tournament:
         self._playing: bool = False
         self._rating_limit1: int = 0
         self._rating_limit2: int = 0
-        self._location: str = ''
-        self._start_date: str = ''
-        self._end_date: str = ''
-        self._arbiter: str = ''
         self._boards: list[Board] = []
         self._unpaired_players: list[Player] = []
         self._players_by_rank: dict[int, Player] = {}
@@ -295,6 +291,14 @@ class Tournament:
         return tie_breaks
 
     @property
+    def stored_rounds(self) -> int:
+        return self.stored_tournament.rounds
+
+    @property
+    def stored_rating(self) -> TournamentRating:
+        return TournamentRating(self.stored_tournament.rating)
+
+    @property
     def download_allowed(self) -> bool:
         return self.file_exists
 
@@ -330,26 +334,6 @@ class Tournament:
     def rating_limit2(self) -> int:
         self.read_papi()
         return self._rating_limit2
-
-    @property
-    def location(self) -> str:
-        self.read_papi()
-        return self._location
-
-    @property
-    def start_date(self) -> str:
-        self.read_papi()
-        return self._start_date
-
-    @property
-    def end_date(self) -> str:
-        self.read_papi()
-        return self._end_date
-
-    @property
-    def arbiter(self) -> str:
-        self.read_papi()
-        return self._arbiter
 
     @property
     def tie_breaks(self) -> list[TieBreak]:
@@ -505,11 +489,11 @@ class Tournament:
         self.compute_player_ranks(after_round=self.max_ranking_round)
         return TrfTournament(
             name=self.full_name,
-            city=self.location,
-            startdate=self.start_date,
-            enddate=self.end_date,
+            city=self.event.location,
+            startdate=self.event.formatted_start_date.replace('-', '/'),
+            enddate=self.event.formatted_stop_date.replace('-', '/'),
             numplayers=len(self.players_by_id),
-            chiefarbiter=self.arbiter,
+            chiefarbiter=self.event.arbiter,
             players=[
                 player.to_trf(
                     self._player_id_to_trf_id,
@@ -598,10 +582,6 @@ class Tournament:
                     self._rating_limit2,
                     self._tie_breaks,
                     self._point_value_type,
-                    self._location,
-                    self._start_date,
-                    self._end_date,
-                    self._arbiter,
                 ) = papi_database.read_info()
                 self._players_by_id = papi_database.read_players(self.id, self._rounds)
             for player in self._players_by_id.values():
@@ -1153,7 +1133,19 @@ class Tournament:
         with PapiDatabase(self.file, write=True) as papi_database:
             if (tie_breaks := self._update_tie_breaks()) is not None:
                 papi_database.update_tie_breaks(tie_breaks)
-            papi_database.update_point_values(self._point_value_type)
+            if self.rounds > self.stored_rounds:
+                for round_ in range(self.stored_rounds + 1, self.rounds + 1):
+                    papi_database.set_round_unused(round_)
+            elif self.rounds < self.stored_rounds:
+                for round_ in range(self.rounds + 1, self.stored_rounds + 1):
+                    papi_database.set_round_used(round_)
+            papi_database.write_info(
+                {
+                    PapiVariable.ROUNDS: self.stored_rounds,
+                    PapiVariable.RATING: self.stored_rating.to_papi_value,
+                    PapiVariable.POINT_VALUE_TYPE: self._point_value_type.to_papi_value,
+                }
+            )
             papi_database.commit()
 
     def _update_tie_breaks(self) -> list[TieBreak] | None:

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -10,7 +10,7 @@ from _weakref import ReferenceType
 
 from trf import Tournament as TrfTournament
 
-from common import format_timestamp_date_time
+from common import format_timestamp_date_time, format_timestamp
 from common.i18n import _
 from common.papi_web_config import PapiWebConfig
 from common.logger import get_logger
@@ -18,7 +18,7 @@ from common.logger import get_logger
 from data.board import Board
 from data.pairing import Pairing
 from data.family import Family
-from data.player import Player, Federation, Club, PlayerRating
+from data.player import Player, Federation, Club
 from data.screen import Screen
 from data.tie_breaks import (
     TieBreak,
@@ -34,7 +34,7 @@ from utils.enum import (
     TournamentPairing,
     Result,
     TournamentRating,
-    TrfType, PlayerRatingType,
+    TrfType,
 )
 from database.access.papi.papi_database import PapiDatabase, PapiVariable
 from database.sqlite.event.event_database import EventDatabase
@@ -90,6 +90,7 @@ class Tournament:
         self._playing: bool = False
         self._rating_limit1: int = 0
         self._rating_limit2: int = 0
+        self._arbiter: str = ''
         self._boards: list[Board] = []
         self._unpaired_players: list[Player] = []
         self._players_by_rank: dict[int, Player] = {}
@@ -151,6 +152,18 @@ class Tournament:
     @property
     def file_exists(self) -> bool:
         return self.file.exists()
+
+    @property
+    def start_timestamp(self) -> float:
+        return self.stored_tournament.start or self.event.start
+
+    @property
+    def stop_timestamp(self) -> float:
+        return self.stored_tournament.stop or self.event.stop
+
+    @property
+    def location(self) -> str | None:
+        return self.stored_tournament.location or self.event.location
 
     @property
     def time_control_initial_time(self) -> int | None:
@@ -336,6 +349,11 @@ class Tournament:
         return self._rating_limit2
 
     @property
+    def arbiter(self) -> str:
+        self.read_papi()
+        return self._arbiter
+
+    @property
     def tie_breaks(self) -> list[TieBreak]:
         self.read_papi()
         return self._tie_breaks
@@ -489,11 +507,11 @@ class Tournament:
         self.compute_player_ranks(after_round=self.max_ranking_round)
         return TrfTournament(
             name=self.full_name,
-            city=self.event.location,
-            startdate=self.event.formatted_start_date.replace('-', '/'),
-            enddate=self.event.formatted_stop_date.replace('-', '/'),
+            city=self.location,
+            startdate=format_timestamp(self.start_timestamp, '%Y/%m/%d'),
+            enddate=format_timestamp(self.stop_timestamp, '%Y/%m/%d'),
             numplayers=len(self.players_by_id),
-            chiefarbiter=self.event.arbiter,
+            chiefarbiter=self.arbiter,
             players=[
                 player.to_trf(
                     self._player_id_to_trf_id,
@@ -582,6 +600,7 @@ class Tournament:
                     self._rating_limit2,
                     self._tie_breaks,
                     self._point_value_type,
+                    self._arbiter,
                 ) = papi_database.read_info()
                 self._players_by_id = papi_database.read_players(self.id, self._rounds)
             for player in self._players_by_id.values():
@@ -1075,8 +1094,12 @@ class Tournament:
                 'ClubRef': 0,
                 'Club': player.club.name if player.club else None,
                 'Fide': player.get_rating(TournamentRating.STANDARD).type.to_papi_value,
-                'RapideFide': player.get_rating(TournamentRating.RAPID).type.to_papi_value,
-                'BlitzFide': player.get_rating(TournamentRating.BLITZ).type.to_papi_value,
+                'RapideFide': player.get_rating(
+                    TournamentRating.RAPID
+                ).type.to_papi_value,
+                'BlitzFide': player.get_rating(
+                    TournamentRating.BLITZ
+                ).type.to_papi_value,
                 'FideCode': player.fide_id if player.fide_id else None,
                 'FideTitre': player.title.to_papi_value,
                 'Pointe': player.check_in,
@@ -1133,12 +1156,6 @@ class Tournament:
         with PapiDatabase(self.file, write=True) as papi_database:
             if (tie_breaks := self._update_tie_breaks()) is not None:
                 papi_database.update_tie_breaks(tie_breaks)
-            if self.rounds > self.stored_rounds:
-                for round_ in range(self.stored_rounds + 1, self.rounds + 1):
-                    papi_database.set_round_unused(round_)
-            elif self.rounds < self.stored_rounds:
-                for round_ in range(self.rounds + 1, self.stored_rounds + 1):
-                    papi_database.set_round_used(round_)
             papi_database.write_info(
                 {
                     PapiVariable.ROUNDS: self.stored_rounds,

--- a/src/database/access/papi/papi_database.py
+++ b/src/database/access/papi/papi_database.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime, timedelta, date
+from enum import StrEnum
 from itertools import product
 from logging import Logger
 from pathlib import Path
@@ -36,10 +37,26 @@ class TournamentInfo(NamedTuple):
     rating_limit2: int
     tie_breaks: list[TieBreak]
     point_value_type: PointValueType
-    location: str
-    start_date: str
-    end_date: str
-    arbiter: str
+
+
+class PapiVariable(StrEnum):
+    NAME = 'Nom'
+    TYPE = 'Genre'
+    ROUNDS = 'NbrRondes'
+    PAIRING = 'Pairing'
+    TIME_CONTROL = 'Cadence'
+    RATING = 'ClassElo'
+    RATING_LIMIT1 = 'EloBase1'
+    RATING_LIMIT2 = 'EloBase2'
+    TIE_BREAK1 = 'Dep1'
+    TIE_BREAK2 = 'Dep2'
+    TIE_BREAK3 = 'Dep3'
+    POINT_VALUE_TYPE = 'DecomptePoints'
+    LOCATION = 'Lieu'
+    START_DATE = 'DateDebut'
+    END_DATE = 'DateFin'
+    ARBITER = 'Arbitre'
+    FFE_ID = 'Homologation'
 
 
 class PapiDatabase(AccessDatabase):
@@ -57,40 +74,40 @@ class PapiDatabase(AccessDatabase):
     def commit(self):
         self._commit()
 
-    def _read_var(self, name: str) -> str:
+    def read_variable(self, variable: PapiVariable) -> str:
         query: str = 'SELECT `Value` FROM `info` WHERE `Variable` = ?'
-        self._execute(query, (name,))
+        self._execute(query, (variable.value,))
         return self._fetchval()
 
-    def _update_var(self, name: str, value: str | int):
+    def update_variable(self, variable: PapiVariable, value: str | int):
         query: str = 'UPDATE `info` SET `Value` = ? WHERE `Variable` = ?'
-        self._execute(query, (value, name))
+        self._execute(query, (value, variable.value))
 
     def read_info(self) -> TournamentInfo:
         """Reads the database and returns basic information about the
         tournament."""
-        rounds: int = int(self._read_var('NbrRondes'))
+        rounds: int = int(self.read_variable(PapiVariable.ROUNDS))
         pairing: TournamentPairing = TournamentPairing.from_papi_value(
-            self._read_var('Pairing')
+            self.read_variable(PapiVariable.PAIRING)
         )
         rating: TournamentRating = TournamentRating.from_papi_value(
-            self._read_var('ClassElo')
+            self.read_variable(PapiVariable.RATING)
         )
-        rating_limit1: int = int(self._read_var('EloBase1'))
-        rating_limit2: int = int(self._read_var('EloBase2'))
+        rating_limit1: int = int(self.read_variable(PapiVariable.RATING_LIMIT1))
+        rating_limit2: int = int(self.read_variable(PapiVariable.RATING_LIMIT2))
         tie_break_type_by_id = PapiTieBreakManager.type_by_papi_id()
         tie_breaks: list[TieBreak] = []
-        for index in range(1, 4):
-            papi_id = self._read_var(f'Dep{index}')
+        for variable in (
+            PapiVariable.TIE_BREAK1,
+            PapiVariable.TIE_BREAK2,
+            PapiVariable.TIE_BREAK3,
+        ):
+            papi_id = self.read_variable(variable)
             if tie_break_type := tie_break_type_by_id.get(papi_id, None):
                 tie_breaks.append(tie_break_type())
         point_value_type: PointValueType = PointValueType.from_papi_value(
-            self._read_var('DecomptePoints')
+            self.read_variable(PapiVariable.POINT_VALUE_TYPE)
         )
-        location: str = self._read_var('Lieu')
-        start_date: str = self._read_var('DateDebut')
-        end_date: str = self._read_var('DateFin')
-        arbiter: str = self._read_var('Arbitre')
         return TournamentInfo(
             rounds,
             pairing,
@@ -99,15 +116,11 @@ class PapiDatabase(AccessDatabase):
             rating_limit2,
             tie_breaks,
             point_value_type,
-            location,
-            start_date,
-            end_date,
-            arbiter,
         )
 
-    def write_info(self, info: dict[str, str | int]):
+    def write_info(self, info: dict[PapiVariable, str | int]):
         for name, value in info.items():
-            self._update_var(name, value)
+            self.update_variable(name, value)
 
     def read_player_dict(
         self, player_papi_id: int
@@ -219,15 +232,16 @@ class PapiDatabase(AccessDatabase):
         )
 
     def update_tie_breaks(self, tie_breaks: list[TieBreak]):
-        for key in ('Dep1', 'Dep2', 'Dep3'):
+        for variable in (
+            PapiVariable.TIE_BREAK1,
+            PapiVariable.TIE_BREAK2,
+            PapiVariable.TIE_BREAK3,
+        ):
             while tie_breaks and tie_breaks[0].papi_id is None:
                 tie_breaks.pop(0)
-            self._update_var(
-                key, (tie_breaks.pop(0).papi_id or '') if tie_breaks else ''
+            self.update_variable(
+                variable, (tie_breaks.pop(0).papi_id or '') if tie_breaks else ''
             )
-
-    def update_point_values(self, point_value_type: PointValueType):
-        self._update_var('DecomptePoints', point_value_type.to_papi_value)
 
     def read_players(self, tournament_id: int, rounds: int) -> dict[int, Player]:
         """Reads the database and fetches the Player identification, pairings and results.
@@ -352,6 +366,26 @@ class PapiDatabase(AccessDatabase):
     def reset_player_result(self, player_papi_id: int, round_: int):
         """Writes the empty result for the given player in the database."""
         self.set_player_result(player_papi_id, round_, Result.NO_RESULT)
+
+    def set_round_used(self, round_: int):
+        prefix = f'Rd{round_:0>2}'
+        self._execute(
+            f'UPDATE `joueur` SET `{prefix}Res` = ?, `{prefix}Cl` = ? WHERE `Ref` > 1',
+            (
+                Result.NO_RESULT.to_papi_value,
+                'R',
+            ),
+        )
+
+    def set_round_unused(self, round_: int):
+        prefix = f'Rd{round_:0>2}'
+        self._execute(
+            f'UPDATE `joueur` SET `{prefix}Res` = ?, `{prefix}Cl` = ? WHERE `Ref` > 1',
+            (
+                None,
+                None,
+            ),
+        )
 
     @staticmethod
     def timestamp_to_papi_date(ts: float) -> str:

--- a/src/database/access/papi/papi_database.py
+++ b/src/database/access/papi/papi_database.py
@@ -19,6 +19,7 @@ from utils.enum import (
     PlayerRatingType,
     BoardColor,
     PointValueType,
+    PapiResult,
 )
 from database.access.access_database import AccessDatabase
 from database.access.papi.papi_template import create_empty_papi_database
@@ -37,6 +38,7 @@ class TournamentInfo(NamedTuple):
     rating_limit2: int
     tie_breaks: list[TieBreak]
     point_value_type: PointValueType
+    arbiter: str
 
 
 class PapiVariable(StrEnum):
@@ -108,6 +110,7 @@ class PapiDatabase(AccessDatabase):
         point_value_type: PointValueType = PointValueType.from_papi_value(
             self.read_variable(PapiVariable.POINT_VALUE_TYPE)
         )
+        arbiter: str = self.read_variable(PapiVariable.ARBITER)
         return TournamentInfo(
             rounds,
             pairing,
@@ -116,6 +119,7 @@ class PapiDatabase(AccessDatabase):
             rating_limit2,
             tie_breaks,
             point_value_type,
+            arbiter,
         )
 
     def write_info(self, info: dict[PapiVariable, str | int]):
@@ -301,7 +305,7 @@ class PapiDatabase(AccessDatabase):
                     if opponent_papi_id and opponent_papi_id != 1
                     else None,
                     Result.from_papi_value(
-                        row[f'{round_str}Res'],
+                        row[f'{round_str}Res'] or PapiResult.NOT_PAIRED.value,
                         opponent_papi_id is None,
                         opponent_papi_id == 1,
                         color_str == 'F',
@@ -328,8 +332,9 @@ class PapiDatabase(AccessDatabase):
                 ratings={
                     tr: PlayerRating(
                         row[tr.papi_value_field] or 0,
-                        PlayerRatingType.from_papi_value(row[tr.papi_type_field])
-                    ) for tr in TournamentRating
+                        PlayerRatingType.from_papi_value(row[tr.papi_type_field]),
+                    )
+                    for tr in TournamentRating
                 },
                 fide_id=fide_id,
                 federation=Federation(row['Federation'] or ''),
@@ -366,26 +371,6 @@ class PapiDatabase(AccessDatabase):
     def reset_player_result(self, player_papi_id: int, round_: int):
         """Writes the empty result for the given player in the database."""
         self.set_player_result(player_papi_id, round_, Result.NO_RESULT)
-
-    def set_round_used(self, round_: int):
-        prefix = f'Rd{round_:0>2}'
-        self._execute(
-            f'UPDATE `joueur` SET `{prefix}Res` = ?, `{prefix}Cl` = ? WHERE `Ref` > 1',
-            (
-                Result.NO_RESULT.to_papi_value,
-                'R',
-            ),
-        )
-
-    def set_round_unused(self, round_: int):
-        prefix = f'Rd{round_:0>2}'
-        self._execute(
-            f'UPDATE `joueur` SET `{prefix}Res` = ?, `{prefix}Cl` = ? WHERE `Ref` > 1',
-            (
-                None,
-                None,
-            ),
-        )
 
     @staticmethod
     def timestamp_to_papi_date(ts: float) -> str:

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -901,6 +901,8 @@ class EventDatabase(MigrationDatabase):
             stop=row['stop'],
             public=self.load_bool_from_database_field(row['public']),
             path=row['path'],
+            location=row['location'],
+            arbiter=row['arbiter'],
             hide_background_image=self.load_bool_from_database_field(
                 row.get(
                     'hide_background_image', PapiWebConfig.default_hide_background_image
@@ -963,6 +965,8 @@ class EventDatabase(MigrationDatabase):
             'public',
             'federation',
             'path',
+            'location',
+            'arbiter',
             'hide_background_image',
             'background_image',
             'background_color',
@@ -984,6 +988,8 @@ class EventDatabase(MigrationDatabase):
             stored_event.public,
             stored_event.federation,
             stored_event.path,
+            stored_event.location,
+            stored_event.arbiter,
             stored_event.hide_background_image,
             stored_event.background_image,
             stored_event.background_color,
@@ -1327,6 +1333,8 @@ class EventDatabase(MigrationDatabase):
             check_in_open=cls.load_bool_from_database_field(
                 row.get('check_in_open', None)
             ),
+            rounds=row['rounds'],
+            rating=row['rating'],
             last_update=row['last_update'],
             last_result_update=row['last_result_update'],
             last_illegal_move_update=row['last_illegal_move_update'],
@@ -1385,6 +1393,8 @@ class EventDatabase(MigrationDatabase):
             'paired_bye_result',
             'max_byes',
             'tie_breaks',
+            'rounds',
+            'rating',
             'last_rounds_no_byes',
             'last_update',
             'last_result_update',
@@ -1408,6 +1418,8 @@ class EventDatabase(MigrationDatabase):
             stored_tournament.paired_bye_result,
             stored_tournament.max_byes,
             self.dump_to_json_database_field(stored_tournament.tie_breaks),
+            stored_tournament.rounds,
+            stored_tournament.rating,
             stored_tournament.last_rounds_no_byes,
             time.time(),
             stored_tournament.last_result_update,

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -904,16 +904,16 @@ class EventDatabase(MigrationDatabase):
             background_color=row['background_color'],
             update_password=row['update_password'],
             record_illegal_moves=row['record_illegal_moves'],
-            rules=row.get('rules', None),
+            rules=row['rules'],
             timer_colors=self.set_dict_int_keys(
                 self.load_json_from_database_field(row['timer_colors'])
             ),
             timer_delays=self.set_dict_int_keys(
                 self.load_json_from_database_field(row['timer_delays'])
             ),
-            message_text=row.get('message_text', None),
-            message_color=row.get('message_color', None),
-            message_background_color=row.get('message_background_color', None),
+            message_text=row['message_text'],
+            message_color=row['message_color'],
+            message_background_color=row['message_background_color'],
             last_update=row['last_update'],
         )
         plugin_manager.hook.augment_event_after_db_fetch(
@@ -1315,21 +1315,19 @@ class EventDatabase(MigrationDatabase):
             ],
             time_control_handicap_min_time=row['time_control_handicap_min_time'],
             record_illegal_moves=row['record_illegal_moves'],
-            rules=row.get('rules', None),
-            first_board_number=row.get('first_board_number', None),
-            paired_bye_result=row.get('paired_bye_result', None),
-            max_byes=row.get('max_byes', None),
-            last_rounds_no_byes=row.get('last_rounds_no_byes', None),
-            check_in_open=cls.load_bool_from_database_field(
-                row.get('check_in_open', None)
-            ),
+            rules=row['rules'],
+            first_board_number=row['first_board_number'],
+            paired_bye_result=row['paired_bye_result'],
+            max_byes=row['max_byes'],
+            last_rounds_no_byes=row['last_rounds_no_byes'],
+            check_in_open=cls.load_bool_from_database_field(row['check_in_open']),
             rounds=row['rounds'],
             rating=row['rating'],
             last_update=row['last_update'],
             last_result_update=row['last_result_update'],
             last_illegal_move_update=row['last_illegal_move_update'],
             last_check_in_update=row['last_check_in_update'],
-            tie_breaks=cls.load_json_from_database_field(row.get('tie_breaks', None)),
+            tie_breaks=cls.load_json_from_database_field(row['tie_breaks']),
             start=row['start'],
             stop=row['stop'],
             location=row['location'],
@@ -1745,11 +1743,11 @@ class EventDatabase(MigrationDatabase):
                 row['players_show_unpaired']
             ),
             ranking_crosstable=cls.load_bool_from_database_field(
-                row.get('ranking_crosstable')
+                row['ranking_crosstable']
             ),
-            ranking_round=row.get('ranking_round', None),
-            ranking_min_points=row.get('ranking_min_points', None),
-            ranking_max_points=row.get('ranking_max_points', None),
+            ranking_round=row['ranking_round'],
+            ranking_min_points=row['ranking_min_points'],
+            ranking_max_points=row['ranking_max_points'],
             columns=row['columns'],
             font_size=row['font_size'],
             menu_link=cls.load_bool_from_database_field(row['menu_link']),
@@ -1760,10 +1758,8 @@ class EventDatabase(MigrationDatabase):
             last=row['last'],
             parts=row['parts'],
             number=row['number'],
-            message_default=cls.load_bool_from_database_field(
-                row.get('message_default', None)
-            ),
-            message_text=row.get('message_text', None),
+            message_default=cls.load_bool_from_database_field(row['message_default']),
+            message_text=row['message_text'],
             last_update=row['last_update'],
         )
 
@@ -1916,17 +1912,15 @@ class EventDatabase(MigrationDatabase):
                 row['results_tournament_ids']
             ),
             ranking_crosstable=cls.load_bool_from_database_field(
-                row.get('ranking_crosstable')
+                row['ranking_crosstable']
             ),
-            ranking_round=row.get('ranking_round', None),
-            ranking_min_points=row.get('ranking_min_points', None),
-            ranking_max_points=row.get('ranking_max_points', None),
+            ranking_round=row['ranking_round'],
+            ranking_min_points=row['ranking_min_points'],
+            ranking_max_points=row['ranking_max_points'],
             background_image=row['background_image'],
             background_color=row['background_color'],
-            message_default=cls.load_bool_from_database_field(
-                row.get('message_default', None)
-            ),
-            message_text=row.get('message_text', None),
+            message_default=cls.load_bool_from_database_field(row['message_default']),
+            message_text=row['message_text'],
             last_update=row['last_update'],
         )
 
@@ -2266,10 +2260,8 @@ class EventDatabase(MigrationDatabase):
             uniq_id=row['uniq_id'],
             public=cls.load_bool_from_database_field(row['public']),
             delay=row['delay'],
-            message_default=cls.load_bool_from_database_field(
-                row.get('message_default', None)
-            ),
-            message_text=row.get('message_text', None),
+            message_default=cls.load_bool_from_database_field(row['message_default']),
+            message_text=row['message_text'],
             screen_ids=cls.load_json_from_database_field(row['screen_ids']),
             family_ids=cls.load_json_from_database_field(row['family_ids']),
         )

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -429,13 +429,6 @@ class EventDatabase(MigrationDatabase):
                                 time_control_handicap_min_time=tournament_dict.get(
                                     'time_control_handicap_min_time', None
                                 ),
-                                record_illegal_moves=None,
-                                rules=None,
-                                first_board_number=None,
-                                paired_bye_result=None,
-                                max_byes=None,
-                                last_rounds_no_byes=None,
-                                tie_breaks=None,
                             )
                         )
                         assert stored_tournament.id is not None
@@ -902,7 +895,6 @@ class EventDatabase(MigrationDatabase):
             public=self.load_bool_from_database_field(row['public']),
             path=row['path'],
             location=row['location'],
-            arbiter=row['arbiter'],
             hide_background_image=self.load_bool_from_database_field(
                 row.get(
                     'hide_background_image', PapiWebConfig.default_hide_background_image
@@ -966,7 +958,6 @@ class EventDatabase(MigrationDatabase):
             'federation',
             'path',
             'location',
-            'arbiter',
             'hide_background_image',
             'background_image',
             'background_color',
@@ -989,7 +980,6 @@ class EventDatabase(MigrationDatabase):
             stored_event.federation,
             stored_event.path,
             stored_event.location,
-            stored_event.arbiter,
             stored_event.hide_background_image,
             stored_event.background_image,
             stored_event.background_color,
@@ -1340,6 +1330,9 @@ class EventDatabase(MigrationDatabase):
             last_illegal_move_update=row['last_illegal_move_update'],
             last_check_in_update=row['last_check_in_update'],
             tie_breaks=cls.load_json_from_database_field(row.get('tie_breaks', None)),
+            start=row['start'],
+            stop=row['stop'],
+            location=row['location'],
         )
         plugin_manager.hook.augment_tournament_after_db_fetch(
             stored_tournament=stored_tournament, row=row
@@ -1395,6 +1388,9 @@ class EventDatabase(MigrationDatabase):
             'tie_breaks',
             'rounds',
             'rating',
+            'location',
+            'start',
+            'stop',
             'last_rounds_no_byes',
             'last_update',
             'last_result_update',
@@ -1420,6 +1416,9 @@ class EventDatabase(MigrationDatabase):
             self.dump_to_json_database_field(stored_tournament.tie_breaks),
             stored_tournament.rounds,
             stored_tournament.rating,
+            stored_tournament.location,
+            stored_tournament.start,
+            stored_tournament.stop,
             stored_tournament.last_rounds_no_byes,
             time.time(),
             stored_tournament.last_result_update,

--- a/src/database/sqlite/event/event_store.py
+++ b/src/database/sqlite/event/event_store.py
@@ -40,18 +40,21 @@ class StoredTournament:
     name: str
     path: str | None
     filename: str | None
-    time_control_initial_time: int | None
-    time_control_increment: int | None
-    time_control_handicap_penalty_step: int | None
-    time_control_handicap_penalty_value: int | None
-    time_control_handicap_min_time: int | None
-    record_illegal_moves: int | None
-    rules: str | None
-    first_board_number: int | None
-    paired_bye_result: int | None
-    max_byes: int | None
-    last_rounds_no_byes: int | None
-    tie_breaks: list[dict[str, str | dict[str, Any]]] | None
+    time_control_initial_time: int | None = None
+    time_control_increment: int | None = None
+    time_control_handicap_penalty_step: int | None = None
+    time_control_handicap_penalty_value: int | None = None
+    time_control_handicap_min_time: int | None = None
+    record_illegal_moves: int | None = None
+    rules: str | None = None
+    first_board_number: int | None = None
+    paired_bye_result: int | None = None
+    max_byes: int | None = None
+    last_rounds_no_byes: int | None = None
+    tie_breaks: list[dict[str, str | dict[str, Any]]] | None = None
+    location: str | None = None
+    start: float | None = None
+    stop: float | None = None
     check_in_open: bool = field(default=False)
     rounds: int = field(default=1)
     rating: int = field(default=1)
@@ -166,7 +169,6 @@ class StoredEvent:
     public: bool = False
     path: str | None = None
     location: str | None = None
-    arbiter: str | None = None
     hide_background_image: bool = PapiWebConfig.default_hide_background_image
     background_image: str | None = None
     background_color: str | None = None

--- a/src/database/sqlite/event/event_store.py
+++ b/src/database/sqlite/event/event_store.py
@@ -53,6 +53,8 @@ class StoredTournament:
     last_rounds_no_byes: int | None
     tie_breaks: list[dict[str, str | dict[str, Any]]] | None
     check_in_open: bool = field(default=False)
+    rounds: int = field(default=1)
+    rating: int = field(default=1)
     last_update: float = field(default=0.0)
     last_result_update: float = field(default=0.0)
     last_illegal_move_update: float = field(default=0.0)
@@ -163,6 +165,8 @@ class StoredEvent:
     stop: float
     public: bool = False
     path: str | None = None
+    location: str | None = None
+    arbiter: str | None = None
     hide_background_image: bool = PapiWebConfig.default_hide_background_image
     background_image: str | None = None
     background_color: str | None = None

--- a/src/database/sqlite/event/migrations/m018_add_papi_info_fields.py
+++ b/src/database/sqlite/event/migrations/m018_add_papi_info_fields.py
@@ -1,0 +1,19 @@
+from database.sqlite.migration import BaseMigration
+
+
+class Migration(BaseMigration):
+    def forward(self):
+        self.database.execute('ALTER TABLE `info` ADD `location` TEXT')
+        self.database.execute('ALTER TABLE `info` ADD `arbiter` TEXT')
+        self.database.execute(
+            'ALTER TABLE `tournament` ADD `rounds` INTEGER NOT NULL DEFAULT 1'
+        )
+        self.database.execute(
+            'ALTER TABLE `tournament` ADD `rating` INTEGER NOT NULL DEFAULT 1'
+        )
+
+    def backward(self):
+        self.database.execute('ALTER TABLE `info` DROP COLUMN `location`')
+        self.database.execute('ALTER TABLE `info` DROP COLUMN `arbiter`')
+        self.database.execute('ALTER TABLE `tournament` DROP COLUMN `rating`')
+        self.database.execute('ALTER TABLE `tournament` DROP COLUMN `rounds`')

--- a/src/database/sqlite/event/migrations/m018_add_papi_info_fields.py
+++ b/src/database/sqlite/event/migrations/m018_add_papi_info_fields.py
@@ -4,7 +4,9 @@ from database.sqlite.migration import BaseMigration
 class Migration(BaseMigration):
     def forward(self):
         self.database.execute('ALTER TABLE `info` ADD `location` TEXT')
-        self.database.execute('ALTER TABLE `info` ADD `arbiter` TEXT')
+        self.database.execute('ALTER TABLE `tournament` ADD `location` TEXT')
+        self.database.execute('ALTER TABLE `tournament` ADD `start` FLOAT')
+        self.database.execute('ALTER TABLE `tournament` ADD `stop` FLOAT')
         self.database.execute(
             'ALTER TABLE `tournament` ADD `rounds` INTEGER NOT NULL DEFAULT 1'
         )
@@ -14,6 +16,8 @@ class Migration(BaseMigration):
 
     def backward(self):
         self.database.execute('ALTER TABLE `info` DROP COLUMN `location`')
-        self.database.execute('ALTER TABLE `info` DROP COLUMN `arbiter`')
+        self.database.execute('ALTER TABLE `tournament` DROP COLUMN `location`')
+        self.database.execute('ALTER TABLE `tournament` DROP COLUMN `start`')
+        self.database.execute('ALTER TABLE `tournament` DROP COLUMN `stop`')
         self.database.execute('ALTER TABLE `tournament` DROP COLUMN `rating`')
         self.database.execute('ALTER TABLE `tournament` DROP COLUMN `rounds`')

--- a/src/plugins/chessevent/engine/action_selector.py
+++ b/src/plugins/chessevent/engine/action_selector.py
@@ -25,7 +25,7 @@ from data.event import Event
 from data.loader import EventLoader
 from data.tournament import Tournament
 from utils.enum import Result
-from database.access.papi.papi_database import PapiDatabase
+from database.access.papi.papi_database import PapiDatabase, PapiVariable
 from database.access.papi.papi_template import create_empty_papi_database
 from database.sqlite.event.event_database import EventDatabase
 from plugins.chessevent import PLUGIN_NAME
@@ -117,20 +117,25 @@ class ActionSelector(metaclass=Singleton):
                 default_rounds,
             )
             chessevent_tournament.rounds = default_rounds
-        data: dict[str, str | int] = {
-            'Nom': chessevent_tournament.name,
-            'Genre': chessevent_tournament.type.to_papi_value,
-            'NbrRondes': chessevent_tournament.rounds,
-            'Pairing': chessevent_tournament.pairing.to_papi_value,
-            'Cadence': chessevent_tournament.time_control,
-            'Lieu': chessevent_tournament.location,
-            'Arbitre': chessevent_tournament.arbiter,
-            'DateDebut': database.timestamp_to_papi_date(chessevent_tournament.start),
-            'DateFin': database.timestamp_to_papi_date(chessevent_tournament.end),
-            'ClassElo': chessevent_tournament.rating.to_papi_value,
-            'Homologation': str(chessevent_tournament.ffe_id),
-        }
-        database.write_info(data)
+        database.write_info(
+            {
+                PapiVariable.NAME: chessevent_tournament.name,
+                PapiVariable.TYPE: chessevent_tournament.type.to_papi_value,
+                PapiVariable.ROUNDS: chessevent_tournament.rounds,
+                PapiVariable.PAIRING: chessevent_tournament.pairing.to_papi_value,
+                PapiVariable.TIME_CONTROL: chessevent_tournament.time_control,
+                PapiVariable.LOCATION: chessevent_tournament.location,
+                PapiVariable.ARBITER: chessevent_tournament.arbiter,
+                PapiVariable.START_DATE: database.timestamp_to_papi_date(
+                    chessevent_tournament.start
+                ),
+                PapiVariable.END_DATE: database.timestamp_to_papi_date(
+                    chessevent_tournament.end
+                ),
+                PapiVariable.RATING: chessevent_tournament.rating.to_papi_value,
+                PapiVariable.FFE_ID: str(chessevent_tournament.ffe_id),
+            }
+        )
         database.update_tie_breaks(chessevent_tournament.tie_breaks)
 
     @classmethod

--- a/src/web/controllers/admin/base_admin_controller.py
+++ b/src/web/controllers/admin/base_admin_controller.py
@@ -340,7 +340,6 @@ class BaseAdminController(BaseController):
         public: bool | None = None
         path: str | None = None
         location: str | None = None
-        arbiter: str | None = None
         hide_background_image: bool | None = None
         background_image: str | None = None
         background_color: str | None = None
@@ -391,7 +390,6 @@ class BaseAdminController(BaseController):
                 public = WebContext.form_data_to_bool(data, 'public')
                 path = WebContext.form_data_to_str(data, 'path')
                 location = WebContext.form_data_to_str(data, 'location')
-                arbiter = WebContext.form_data_to_str(data, 'arbiter')
                 update_password = WebContext.form_data_to_str(data, 'update_password')
                 field = 'background_image'
                 hide_background_image = WebContext.form_data_to_bool(
@@ -504,7 +502,6 @@ class BaseAdminController(BaseController):
             public=bool(public),
             path=path,
             location=location,
-            arbiter=arbiter,
             hide_background_image=bool(hide_background_image),
             background_image=background_image,
             background_color=background_color,
@@ -654,7 +651,6 @@ class BaseAdminController(BaseController):
         background_color: str | None = None
         path: str | None = None
         location: str | None = None
-        arbiter: str | None = None
         update_password: str | None = None
         record_illegal_moves: int | None = None
         rules: str | None = None
@@ -673,7 +669,6 @@ class BaseAdminController(BaseController):
                 background_color = stored_event.background_color
                 path = stored_event.path
                 location = stored_event.location
-                arbiter = stored_event.arbiter
                 update_password = stored_event.update_password
                 record_illegal_moves = stored_event.record_illegal_moves
                 rules = stored_event.rules
@@ -713,7 +708,6 @@ class BaseAdminController(BaseController):
             ),
             'path': WebContext.value_to_form_data(path),
             'location': WebContext.value_to_form_data(location),
-            'arbiter': WebContext.value_to_form_data(arbiter),
             'update_password': WebContext.value_to_form_data(update_password),
             'record_illegal_moves': WebContext.value_to_form_data(record_illegal_moves),
             'rules': WebContext.value_to_form_data(rules),

--- a/src/web/controllers/admin/base_admin_controller.py
+++ b/src/web/controllers/admin/base_admin_controller.py
@@ -14,7 +14,7 @@ from common.i18n import _, ngettext
 from common.papi_web_config import PapiWebConfig
 from data.event import Event
 from data.loader import EventLoader
-from utils.enum import Result
+from utils.enum import Result, TournamentRating
 from database.sqlite.event.event_store import StoredEvent
 from plugins.manager import plugin_manager
 from web.controllers.base_controller import BaseController, WebContext
@@ -141,6 +141,13 @@ class BaseAdminController(BaseController):
         )
         options[''] = _('By default - {option}').format(option=options[default_option])
         return options
+
+    @staticmethod
+    def _get_rating_options() -> dict[str, str]:
+        return {
+            WebContext.value_to_form_data(rating.value): rating.short_name
+            for rating in TournamentRating
+        }
 
     @staticmethod
     def _get_timer_color_texts(delays: dict[int, int]) -> dict[int, str]:
@@ -332,6 +339,8 @@ class BaseAdminController(BaseController):
         stop: float | None = None
         public: bool | None = None
         path: str | None = None
+        location: str | None = None
+        arbiter: str | None = None
         hide_background_image: bool | None = None
         background_image: str | None = None
         background_color: str | None = None
@@ -381,6 +390,8 @@ class BaseAdminController(BaseController):
                     errors[field] = _('Please enter a date after the start date.')
                 public = WebContext.form_data_to_bool(data, 'public')
                 path = WebContext.form_data_to_str(data, 'path')
+                location = WebContext.form_data_to_str(data, 'location')
+                arbiter = WebContext.form_data_to_str(data, 'arbiter')
                 update_password = WebContext.form_data_to_str(data, 'update_password')
                 field = 'background_image'
                 hide_background_image = WebContext.form_data_to_bool(
@@ -492,6 +503,8 @@ class BaseAdminController(BaseController):
             stop=stop,
             public=bool(public),
             path=path,
+            location=location,
+            arbiter=arbiter,
             hide_background_image=bool(hide_background_image),
             background_image=background_image,
             background_color=background_color,
@@ -640,6 +653,8 @@ class BaseAdminController(BaseController):
         background_image: str | None = None
         background_color: str | None = None
         path: str | None = None
+        location: str | None = None
+        arbiter: str | None = None
         update_password: str | None = None
         record_illegal_moves: int | None = None
         rules: str | None = None
@@ -650,16 +665,19 @@ class BaseAdminController(BaseController):
             case 'update' | 'clone':
                 if admin_event is None:
                     raise RuntimeError(f'{admin_event=} for [{action=}]')
-                public = admin_event.stored_event.public
-                federation = admin_event.stored_event.federation
-                hide_background_image = admin_event.stored_event.hide_background_image
-                background_image = admin_event.stored_event.background_image
-                background_color = admin_event.stored_event.background_color
-                path = admin_event.stored_event.path
-                update_password = admin_event.stored_event.update_password
-                record_illegal_moves = admin_event.stored_event.record_illegal_moves
-                rules = admin_event.stored_event.rules
-                message_text = admin_event.stored_event.message_text
+                stored_event = admin_event.stored_event
+                public = stored_event.public
+                federation = stored_event.federation
+                hide_background_image = stored_event.hide_background_image
+                background_image = stored_event.background_image
+                background_color = stored_event.background_color
+                path = stored_event.path
+                location = stored_event.location
+                arbiter = stored_event.arbiter
+                update_password = stored_event.update_password
+                record_illegal_moves = stored_event.record_illegal_moves
+                rules = stored_event.rules
+                message_text = stored_event.message_text
                 message_color = admin_event.message_color
                 message_background_color = admin_event.message_background_color
             case 'create':
@@ -694,6 +712,8 @@ class BaseAdminController(BaseController):
                 background_color is None
             ),
             'path': WebContext.value_to_form_data(path),
+            'location': WebContext.value_to_form_data(location),
+            'arbiter': WebContext.value_to_form_data(arbiter),
             'update_password': WebContext.value_to_form_data(update_password),
             'record_illegal_moves': WebContext.value_to_form_data(record_illegal_moves),
             'rules': WebContext.value_to_form_data(rules),

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -1,3 +1,5 @@
+import time
+from datetime import datetime
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Annotated, Any
@@ -94,6 +96,8 @@ class TournamentAdminController(BaseEventAdminController):
         tie_breaks: list[dict] | None = None
         rounds: int | None = None
         rating: int | None = None
+        start: float | None = None
+        stop: float | None = None
         if action == 'delete':
             if web_context.admin_tournament is None:
                 raise RuntimeError('admin_tournament not defined')
@@ -109,10 +113,6 @@ class TournamentAdminController(BaseEventAdminController):
                     char='/'
                 )
             else:
-                field = 'rounds'
-                rounds = WebContext.form_data_to_int(data, field) or 1
-                if rounds < 1:
-                    errors[field] = _('A positive integer is expected.')
                 match action:
                     case 'create' | 'clone':
                         if uniq_id in web_context.admin_event.tournaments_by_uniq_id:
@@ -120,8 +120,8 @@ class TournamentAdminController(BaseEventAdminController):
                                 'Tournament [{uniq_id}] already exists.'
                             ).format(uniq_id=uniq_id)
                     case 'update':
-                        assert web_context.admin_tournament is not None
                         tournament = web_context.admin_tournament
+                        assert tournament is not None
                         if (
                             uniq_id != tournament.uniq_id
                             and uniq_id
@@ -131,23 +131,56 @@ class TournamentAdminController(BaseEventAdminController):
                                 'Tournament [{uniq_id}] already exists.'
                             ).format(uniq_id=uniq_id)
                         check_in_open = tournament.check_in_open
-                        if rounds and rounds < tournament.current_round:
-                            errors['rounds'] = _(
-                                'Impossible to set a round number '
-                                'lower than current round #{round}.'
-                            ).format(round=tournament.current_round)
+
                     case _:
                         raise ValueError(f'action=[{action}]')
-
-                field = 'rating'
+                rounds = WebContext.form_data_to_int(data, field := 'rounds') or 1
+                if rounds < 1:
+                    errors[field] = _('A positive integer is expected.')
+                elif action == 'update':
+                    tournament = web_context.admin_tournament
+                    assert tournament is not None
+                    if rounds and rounds < tournament.current_round:
+                        errors['rounds'] = _(
+                            'Impossible to set a round number '
+                            'lower than current round #{round}.'
+                        ).format(round=tournament.current_round)
                 rating = (
-                    WebContext.form_data_to_int(data, field)
+                    WebContext.form_data_to_int(data, field := 'rating')
                     or TournamentRating.STANDARD.value
                 )
                 try:
                     TournamentRating(rating)
                 except ValueError:
                     errors[field] = f'Unknown rating [{rating}]'
+                event = web_context.admin_event
+                start_str = WebContext.form_data_to_str(data, field := 'start')
+                if start_str:
+                    start = time.mktime(
+                        datetime.strptime(start_str, '%Y-%m-%dT%H:%M').timetuple()
+                    )
+                    if not event.start <= start <= event.stop:
+                        errors[field] = _(
+                            'Time outside of event time range ({start} - {stop}).'
+                        ).format(
+                            start=event.formatted_start_date_time,
+                            stop=event.formatted_stop_date_time,
+                        )
+                stop_str = WebContext.form_data_to_str(data, field := 'stop')
+                if stop_str:
+                    stop = time.mktime(
+                        datetime.strptime(stop_str, '%Y-%m-%dT%H:%M').timetuple()
+                    )
+                    if not event.start <= stop <= event.stop:
+                        errors[field] = _(
+                            'Time outside of event time range ({start} - {stop}).'
+                        ).format(
+                            start=event.formatted_start_date_time,
+                            stop=event.formatted_stop_date_time,
+                        )
+                    elif start and stop < start:
+                        errors[field] = _('End time needs to be after start time.')
+
                 tie_breaks = []
                 tie_break_type_by_id: dict[str, type[TieBreak]] = (
                     TieBreakManager.type_by_id()
@@ -183,6 +216,7 @@ class TournamentAdminController(BaseEventAdminController):
         paired_bye_result: int | None = None
         max_byes: int | None = None
         last_rounds_no_byes: int | None = None
+        location: str | None = None
         match action:
             case 'create' | 'update' | 'clone':
                 name = WebContext.form_data_to_str(data, 'name') or ''
@@ -219,6 +253,7 @@ class TournamentAdminController(BaseEventAdminController):
                 last_rounds_no_byes = WebContext.form_data_to_int(
                     data, 'last_rounds_no_byes'
                 )
+                location = WebContext.form_data_to_str(data, 'location')
             case 'delete':
                 if web_context.admin_tournament is None:
                     raise RuntimeError(
@@ -272,6 +307,9 @@ class TournamentAdminController(BaseEventAdminController):
             last_rounds_no_byes=last_rounds_no_byes,
             check_in_open=check_in_open,
             tie_breaks=tie_breaks,
+            location=location,
+            start=start,
+            stop=stop,
             rounds=rounds or 1,
             rating=rating or TournamentRating.STANDARD.value,
             errors=errors,
@@ -375,6 +413,9 @@ class TournamentAdminController(BaseEventAdminController):
                     tie_break_1: str | None = None
                     tie_break_2: str | None = None
                     tie_break_3: str | None = None
+                    location: str | None = None
+                    start: float | None = None
+                    stop: float | None = None
                     rounds: int | None = None
                     rating: TournamentRating | None = None
                     match action:
@@ -406,6 +447,9 @@ class TournamentAdminController(BaseEventAdminController):
                             paired_bye_result = stored_tournament.paired_bye_result
                             max_byes = stored_tournament.max_byes
                             last_rounds_no_byes = stored_tournament.last_rounds_no_byes
+                            location = stored_tournament.location
+                            start = stored_tournament.start
+                            stop = stored_tournament.stop
                             rating = admin_tournament.rating
                             rounds = admin_tournament.rounds or 1
                         case 'create':
@@ -476,6 +520,9 @@ class TournamentAdminController(BaseEventAdminController):
                         'tie_break_1': WebContext.value_to_form_data(tie_break_1),
                         'tie_break_2': WebContext.value_to_form_data(tie_break_2),
                         'tie_break_3': WebContext.value_to_form_data(tie_break_3),
+                        'location': WebContext.value_to_form_data(location),
+                        'start': WebContext.value_to_datetime_form_data(start),
+                        'stop': WebContext.value_to_datetime_form_data(stop),
                         'rounds': WebContext.value_to_form_data(rounds),
                         'rating': WebContext.value_to_form_data(
                             rating.value if rating else None

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -23,6 +23,7 @@ from data.loader import EventLoader
 from data.print_documents import PrintDocumentManager
 from data.tie_breaks import TieBreak, TieBreakManager, PapiTieBreakManager
 from data.tournament import Tournament
+from utils.enum import TournamentRating
 from database.access.papi.papi_database import PapiDatabase
 from database.sqlite.event.event_database import EventDatabase
 from database.sqlite.event.event_store import StoredTournament, StoredScreen
@@ -91,6 +92,8 @@ class TournamentAdminController(BaseEventAdminController):
         uniq_id: str | None = WebContext.form_data_to_str(data, 'uniq_id')
         check_in_open: bool = False
         tie_breaks: list[dict] | None = None
+        rounds: int | None = None
+        rating: int | None = None
         if action == 'delete':
             if web_context.admin_tournament is None:
                 raise RuntimeError('admin_tournament not defined')
@@ -106,6 +109,10 @@ class TournamentAdminController(BaseEventAdminController):
                     char='/'
                 )
             else:
+                field = 'rounds'
+                rounds = WebContext.form_data_to_int(data, field) or 1
+                if rounds < 1:
+                    errors[field] = _('A positive integer is expected.')
                 match action:
                     case 'create' | 'clone':
                         if uniq_id in web_context.admin_event.tournaments_by_uniq_id:
@@ -114,18 +121,33 @@ class TournamentAdminController(BaseEventAdminController):
                             ).format(uniq_id=uniq_id)
                     case 'update':
                         assert web_context.admin_tournament is not None
+                        tournament = web_context.admin_tournament
                         if (
-                            uniq_id != web_context.admin_tournament.uniq_id
+                            uniq_id != tournament.uniq_id
                             and uniq_id
                             in web_context.admin_event.tournaments_by_uniq_id
                         ):
                             errors['uniq_id'] = _(
                                 'Tournament [{uniq_id}] already exists.'
                             ).format(uniq_id=uniq_id)
-                        check_in_open = web_context.admin_tournament.check_in_open
+                        check_in_open = tournament.check_in_open
+                        if rounds and rounds < tournament.current_round:
+                            errors['rounds'] = _(
+                                'Impossible to set a round number '
+                                'lower than current round #{round}.'
+                            ).format(round=tournament.current_round)
                     case _:
                         raise ValueError(f'action=[{action}]')
 
+                field = 'rating'
+                rating = (
+                    WebContext.form_data_to_int(data, field)
+                    or TournamentRating.STANDARD.value
+                )
+                try:
+                    TournamentRating(rating)
+                except ValueError:
+                    errors[field] = f'Unknown rating [{rating}]'
                 tie_breaks = []
                 tie_break_type_by_id: dict[str, type[TieBreak]] = (
                     TieBreakManager.type_by_id()
@@ -250,6 +272,8 @@ class TournamentAdminController(BaseEventAdminController):
             last_rounds_no_byes=last_rounds_no_byes,
             check_in_open=check_in_open,
             tie_breaks=tie_breaks,
+            rounds=rounds or 1,
+            rating=rating or TournamentRating.STANDARD.value,
             errors=errors,
             plugin_data=plugin_data,
         )
@@ -351,31 +375,43 @@ class TournamentAdminController(BaseEventAdminController):
                     tie_break_1: str | None = None
                     tie_break_2: str | None = None
                     tie_break_3: str | None = None
+                    rounds: int | None = None
+                    rating: TournamentRating | None = None
                     match action:
                         case 'update' | 'clone':
                             assert admin_tournament is not None
                             assert admin_tournament.stored_tournament is not None
-                            path = admin_tournament.stored_tournament.path
-                            time_control_initial_time = admin_tournament.stored_tournament.time_control_initial_time
-                            time_control_increment = admin_tournament.stored_tournament.time_control_increment
-                            time_control_handicap_penalty_value = admin_tournament.stored_tournament.time_control_handicap_penalty_value
-                            time_control_handicap_penalty_step = admin_tournament.stored_tournament.time_control_handicap_penalty_step
-                            time_control_handicap_min_time = admin_tournament.stored_tournament.time_control_handicap_min_time
+                            stored_tournament = admin_tournament.stored_tournament
+                            path = stored_tournament.path
+                            time_control_initial_time = (
+                                stored_tournament.time_control_initial_time
+                            )
+                            time_control_increment = (
+                                stored_tournament.time_control_increment
+                            )
+                            time_control_handicap_penalty_value = (
+                                stored_tournament.time_control_handicap_penalty_value
+                            )
+                            time_control_handicap_penalty_step = (
+                                stored_tournament.time_control_handicap_penalty_step
+                            )
+                            time_control_handicap_min_time = (
+                                stored_tournament.time_control_handicap_min_time
+                            )
                             record_illegal_moves = (
-                                admin_tournament.stored_tournament.record_illegal_moves
+                                stored_tournament.record_illegal_moves
                             )
-                            rules = admin_tournament.stored_tournament.rules
-                            first_board_number = (
-                                admin_tournament.stored_tournament.first_board_number
-                            )
-                            paired_bye_result = (
-                                admin_tournament.stored_tournament.paired_bye_result
-                            )
-                            max_byes = admin_tournament.stored_tournament.max_byes
-                            last_rounds_no_byes = (
-                                admin_tournament.stored_tournament.last_rounds_no_byes
-                            )
-                        case 'create' | 'delete':
+                            rules = stored_tournament.rules
+                            first_board_number = stored_tournament.first_board_number
+                            paired_bye_result = stored_tournament.paired_bye_result
+                            max_byes = stored_tournament.max_byes
+                            last_rounds_no_byes = stored_tournament.last_rounds_no_byes
+                            rating = admin_tournament.rating
+                            rounds = admin_tournament.rounds or 1
+                        case 'create':
+                            rounds = 1
+                            rating = TournamentRating.STANDARD
+                        case 'delete':
                             pass
                         case _:
                             raise ValueError(f'action=[{action}]')
@@ -440,6 +476,10 @@ class TournamentAdminController(BaseEventAdminController):
                         'tie_break_1': WebContext.value_to_form_data(tie_break_1),
                         'tie_break_2': WebContext.value_to_form_data(tie_break_2),
                         'tie_break_3': WebContext.value_to_form_data(tie_break_3),
+                        'rounds': WebContext.value_to_form_data(rounds),
+                        'rating': WebContext.value_to_form_data(
+                            rating.value if rating else None
+                        ),
                     } | plugin_form_data
                     stored_tournament: StoredTournament = (
                         cls._admin_validate_tournament_update_data(
@@ -460,6 +500,7 @@ class TournamentAdminController(BaseEventAdminController):
                     'paired_bye_result_options': cls._get_paired_bye_result_options(),
                     'tie_break_options': {'': _('None')}
                     | PapiTieBreakManager.options(),
+                    'rating_options': cls._get_rating_options(),
                     'plugin_form_fields_templates': plugin_form_fields_templates,
                     'file_exists': cls._extract_papi_file_path(
                         data, admin_event

--- a/src/web/templates/admin/event/event_modal.html
+++ b/src/web/templates/admin/event/event_modal.html
@@ -82,6 +82,26 @@
                         </div>
                     </div>
                     <div class="row">
+                        <div class="col-12 col-md-6 mb-3">
+                            {{ admin_macros.text_input(
+                                name='location',
+                                label=_('%(title)s:', title=_('Location')),
+                                placeholder=_('E.g.: %(string)s', string='Paris'),
+                                help_text=_('The location of the event.'),
+                                data=data, errors=errors
+                            ) }}
+                        </div>
+                        <div class="col-12 col-md-6 mb-3">
+                            {{ admin_macros.text_input(
+                                name='arbiter',
+                                label=_('%(title)s:', title=_('Chief arbiter')),
+                                placeholder=_('E.g.: DOE John'),
+                                help_text=_('The name of the chief arbiter of the event.'),
+                                data=data, errors=errors
+                            ) }}
+                        </div>
+                    </div>
+                    <div class="row">
                         <div class="col-12 col-md-6 col-lg-3 mb-3">
                             {{ admin_macros.datetime_input(
                                 name='start',

--- a/src/web/templates/admin/event/event_modal.html
+++ b/src/web/templates/admin/event/event_modal.html
@@ -82,26 +82,6 @@
                         </div>
                     </div>
                     <div class="row">
-                        <div class="col-12 col-md-6 mb-3">
-                            {{ admin_macros.text_input(
-                                name='location',
-                                label=_('%(title)s:', title=_('Location')),
-                                placeholder=_('E.g.: %(string)s', string='Paris'),
-                                help_text=_('The location of the event.'),
-                                data=data, errors=errors
-                            ) }}
-                        </div>
-                        <div class="col-12 col-md-6 mb-3">
-                            {{ admin_macros.text_input(
-                                name='arbiter',
-                                label=_('%(title)s:', title=_('Chief arbiter')),
-                                placeholder=_('E.g.: DOE John'),
-                                help_text=_('The name of the chief arbiter of the event.'),
-                                data=data, errors=errors
-                            ) }}
-                        </div>
-                    </div>
-                    <div class="row">
                         <div class="col-12 col-md-6 col-lg-3 mb-3">
                             {{ admin_macros.datetime_input(
                                 name='start',
@@ -118,7 +98,18 @@
                                 data=data, errors=errors
                             ) }}
                         </div>
-                        <div class="col-12 col-lg-6 mb-3">
+                        <div class="col-12 col-md-6 mb-3">
+                            {{ admin_macros.text_input(
+                                name='location',
+                                label=_('%(string)s:', string=_('Location')),
+                                placeholder=_('E.g.: Paris'),
+                                help_text=_('The location of the event.'),
+                                data=data, errors=errors
+                            ) }}
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-12 col-md-12 mb-3">
                             {{ admin_macros.text_input(
                                 name='path',
                                 label=_('Default directory of the Papi files:'),
@@ -128,7 +119,6 @@
                             ) }}
                         </div>
                     </div>
-
                     {% for form_fields_template in plugin_form_fields_templates %}
                         {% include form_fields_template %}
                     {% endfor %}

--- a/src/web/templates/admin/event/tab.html
+++ b/src/web/templates/admin/event/tab.html
@@ -106,18 +106,6 @@
             </td>
         </tr>
         <tr>
-            <th scope="row" class="text-nowrap">{{ _('Chief arbiter') }}</th>
-            <td>
-                {% if admin_event.arbiter %}
-                    {{ admin_event.arbiter }}
-                {% else %}
-                    <span class="fst-italic">
-                        {{ _('Undefined') }}
-                    </span>
-                {% endif %}
-            </td>
-        </tr>
-        <tr>
             <th scope="row" class="text-nowrap">{{ _('Background image and colour') }}</th>
             <td class="text-nowrap">
                 <div style="width: 160px; height: 90px; background-image: url('{{ admin_event.background_url }}'); background-color: {{ admin_event.background_color }}; background-repeat: no-repeat; background-size: contain; background-position: center center;">

--- a/src/web/templates/admin/event/tab.html
+++ b/src/web/templates/admin/event/tab.html
@@ -94,6 +94,30 @@
             </td>
         </tr>
         <tr>
+            <th scope="row" class="text-nowrap">{{ _('Location') }}</th>
+            <td>
+                {% if admin_event.location %}
+                    {{ admin_event.location }}
+                {% else %}
+                    <span class="fst-italic">
+                        {{ _('Undefined') }}
+                    </span>
+                {% endif %}
+            </td>
+        </tr>
+        <tr>
+            <th scope="row" class="text-nowrap">{{ _('Chief arbiter') }}</th>
+            <td>
+                {% if admin_event.arbiter %}
+                    {{ admin_event.arbiter }}
+                {% else %}
+                    <span class="fst-italic">
+                        {{ _('Undefined') }}
+                    </span>
+                {% endif %}
+            </td>
+        </tr>
+        <tr>
             <th scope="row" class="text-nowrap">{{ _('Background image and colour') }}</th>
             <td class="text-nowrap">
                 <div style="width: 160px; height: 90px; background-image: url('{{ admin_event.background_url }}'); background-color: {{ admin_event.background_color }}; background-repeat: no-repeat; background-size: contain; background-position: center center;">

--- a/src/web/templates/admin/tournaments/tournament_modal.html
+++ b/src/web/templates/admin/tournaments/tournament_modal.html
@@ -79,6 +79,45 @@
                             ) }}
                         </div>
                     </div>
+                    <div class="row">
+                        <div
+                            class="file-exists col-12 col-md-6 mb-3"
+                            data-bs-toggle="{%if not file_exists %}tooltip{%endif%}"
+                            {{
+                                macros.tooltip_attributes(
+                                    'info',
+                                    _('Fields relying on the Papi database can\'t be updated if the file does not exist.'),
+                                    'bottom'
+                                )
+                            }}
+                        >
+                            {{ admin_macros.number_input(
+                                name='rounds',
+                                label=_('%(title)s:', title=_('Rounds')),
+                                help_text=_('Number of rounds in the tournament.'),
+                                data=data, errors=errors
+                            ) }}
+                        </div>
+                        <div
+                            class="file-exists col-12 col-md-6 mb-3"
+                            data-bs-toggle="{%if not file_exists %}tooltip{%endif%}"
+                            {{
+                                macros.tooltip_attributes(
+                                    'info',
+                                    _('Fields relying on the Papi database can\'t be updated if the file does not exist.'),
+                                    'bottom'
+                                )
+                            }}
+                        >
+                            {{ admin_macros.select_input(
+                                name='rating',
+                                label=_('Rating:'),
+                                help_text=_('The type of rating to use for the tournament.'),
+                                select_options=rating_options,
+                                data=data, errors=errors
+                            ) }}
+                        </div>
+                    </div>
                     <h4>
                         {{ _('Papi file') }}
                     </h4>

--- a/src/web/templates/admin/tournaments/tournament_modal.html
+++ b/src/web/templates/admin/tournaments/tournament_modal.html
@@ -93,8 +93,8 @@
                         >
                             {{ admin_macros.number_input(
                                 name='rounds',
-                                label=_('%(title)s:', title=_('Rounds')),
-                                help_text=_('Number of rounds in the tournament.'),
+                                label=_('%(string)s:', string=_('Rounds')),
+                                help_text=_('The number of rounds of the tournament.'),
                                 data=data, errors=errors
                             ) }}
                         </div>
@@ -114,6 +114,38 @@
                                 label=_('Rating:'),
                                 help_text=_('The type of rating to use for the tournament.'),
                                 select_options=rating_options,
+                                data=data, errors=errors
+                            ) }}
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-12 col-md-6 col-lg-3 mb-3">
+                            {{ admin_macros.datetime_input(
+                                name='start',
+                                label=_('Start:'),
+                                help_text=_('The start time of the tournament (defaults to %(datetime)s).', datetime=admin_event.formatted_start_date_time),
+                                data=data, errors=errors
+                            ) }}
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3 mb-3">
+                            {{ admin_macros.datetime_input(
+                                name='stop',
+                                label=_('End:'),
+                                help_text=_('The end time of the tournament (defaults to %(datetime)s).', datetime=admin_event.formatted_stop_date_time),
+                                data=data, errors=errors
+                            ) }}
+                        </div>
+                        <div class="col-12 col-md-6 mb-3">
+                            {{ admin_macros.text_input(
+                                name='location',
+                                label=_('%(string)s:', string=_('Location')),
+                                placeholder=_('E.g.: Paris'),
+                                help_text=(
+                                    _(
+                                        'The location of the tournament (defaults to [%(location)s]).',
+                                        location=admin_event.location
+                                    ) if admin_event.location else _('The location of the tournament.')
+                                ),
                                 data=data, errors=errors
                             ) }}
                         </div>


### PR DESCRIPTION
Add fields from the papi Info table  to the database and forms. Same as tie-breaks, papi stays the value of reference.  
Location / arbiter --> Event level  
![image](https://github.com/user-attachments/assets/6c0689a9-f3f7-4c1a-b343-c64ba731bec4)  

Rounds / Rating --> Tournament level  
![image](https://github.com/user-attachments/assets/7c970b54-8bfd-4cbe-a2b4-48e5ea79ed4e)
