### PR TITLE
Fix players screen issue

### DIFF
--- a/src/web/templates/admin/screens/screen_modal.html
+++ b/src/web/templates/admin/screens/screen_modal.html
@@ -146,11 +146,8 @@
                         </h4>
                         <div class="row">
                             {% if screen_type == 'players' %}
-                                <div class="col-12 col-md-6 mb-3">
+                                <div class="col-12 mb-3">
                                     {% include '../common/modal/show_unpaired.html' %}
-                                </div>
-                                <div class="col-12 col-md-6 mb-3">
-                                    {% include '../common/modal/alert_message.html' %}
                                 </div>
                             {% endif %}
                             {% if screen_type == 'ranking' %}


### PR DESCRIPTION
There are two "alert message" fields and checkboxes, which made Litestar fail to validate the query.

I removed the additional alert message, and made the "unpaired players" selection full-width.