### PR TITLE
Fixed ChessEvent players initialization

### DIFF
--- a/docs/03-change-log.md
+++ b/docs/03-change-log.md
@@ -2,9 +2,10 @@
 
 # Papi-web - ChangeLog
 
-## Version 2.5.3 - 10 avril 2025
+## Version 2.5.3 - 11 avril 2025
 - Récupération de la configuration de l'application à partir d'une version antérieure
 - Modification de l'encodage des fichiers de log
+- Correction d'un bug d'initialisation des joueur·euses depuis ChessEvent
 
 ## Version 2.5.2 - 8 avril 2025
 - Correction d'un bug à la récupération des versions antérieures

--- a/src/plugins/chessevent/data/chessevent_tournament.py
+++ b/src/plugins/chessevent/data/chessevent_tournament.py
@@ -51,7 +51,8 @@ class ChessEventTournament:
                 chessevent_player: ChessEventPlayer = ChessEventPlayer(
                     chessevent_player_info
                 )
-                self.check_in_started = True
+                if chessevent_player.check_in:
+                    self.check_in_started = True
                 if chessevent_player.error:
                     return
                 self.players.append(chessevent_player)


### PR DESCRIPTION
Initializes players as forfeit for all rounds only if check-in has started on ChessEvent.
Closes #388.
This PR should also be merged to the dev branch.