### PR TITLE
Fix a hole in contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,9 @@ Whenever possible, please add tests to ensure your changes do not cause regressi
 
 Make sure to run `pytest` and solve problems before sending your code to review.
 
+If you're changing translation files, make sure you have the `translate` dependency group installed, run `python scripts/i18n/i18n_update.py`, and update all locales.
+A PR with a partial `docs/86-i18n.md` will get changes requested immediately.
+
 Once all the changes are made, create a Pull Request with a descriptive name, and why you made the changes.
 If you're solving an issue, link to it in when opening your PR.
 


### PR DESCRIPTION
Currently, we get inconsistent PRs in the i18n.

Some don't update the experimental locales and thus remove lines from `docs/86-i18n.md`, some update them and add them back.

This fixes this hole, and makes us update all locales before proposing a change