### PR TITLE
Make the app 1000 times faster

### DIFF
--- a/src/data/event.py
+++ b/src/data/event.py
@@ -28,12 +28,11 @@ from data.screen import Screen
 from data.screen_set import ScreenSet
 from data.timer import Timer, TimerHour
 from data.tournament import Tournament
-from database.sqlite.event.event_database import EventDatabase
 from utils.enum import (
     ScreenType,
     PlayerGender,
 )
-from database.sqlite.event.event_store import StoredEvent, StoredTournament
+from database.sqlite.event.event_store import StoredEvent
 
 logger: Logger = get_logger()
 
@@ -507,10 +506,6 @@ class Event:
             base_uniq_id or _('timer'), self.timers_by_uniq_id
         )
 
-    @property
-    def tournaments(self) -> Iterable[Tournament]:
-        return self.tournaments_by_id.values()
-
     @cached_property
     def tournaments_by_id(self) -> dict[int, Tournament]:
         if self.errors:
@@ -554,31 +549,6 @@ class Event:
             for tournament in self.tournaments_sorted_by_uniq_id
             if not tournament.finished and tournament.file_exists
         ]
-
-    def check_update(self):
-        """Verify that all the tournaments of the event are up to date.
-        If they are not, update them."""
-        stored_tournaments: list[StoredTournament] = []
-        modified = False
-        with EventDatabase(self.uniq_id) as database:
-            last_updates = database.get_stored_tournament_last_updates()
-            for stored_tournament in self.stored_event.stored_tournaments:
-                id_ = stored_tournament.id
-                assert id_ is not None
-                if stored_tournament.last_update == last_updates[id_]:
-                    stored_tournaments.append(stored_tournament)
-                else:
-                    modified = True
-                    new_stored_tournament = database.get_stored_tournament(id_)
-                    assert new_stored_tournament is not None
-                    stored_tournaments.append(new_stored_tournament)
-                    if tournament := self.tournaments_by_id[id_]:
-                        tournament.stored_tournament = new_stored_tournament
-                        tournament.clear_cache()
-        if modified:
-            self.stored_event.stored_tournaments = stored_tournaments
-        for tournament in self.tournaments:
-            tournament.check_papi_update()
 
     def get_unused_tournament_uniq_id(
         self,

--- a/src/data/event.py
+++ b/src/data/event.py
@@ -28,11 +28,12 @@ from data.screen import Screen
 from data.screen_set import ScreenSet
 from data.timer import Timer, TimerHour
 from data.tournament import Tournament
+from database.sqlite.event.event_database import EventDatabase
 from utils.enum import (
     ScreenType,
     PlayerGender,
 )
-from database.sqlite.event.event_store import StoredEvent
+from database.sqlite.event.event_store import StoredEvent, StoredTournament
 
 logger: Logger = get_logger()
 
@@ -506,6 +507,10 @@ class Event:
             base_uniq_id or _('timer'), self.timers_by_uniq_id
         )
 
+    @property
+    def tournaments(self) -> Iterable[Tournament]:
+        return self.tournaments_by_id.values()
+
     @cached_property
     def tournaments_by_id(self) -> dict[int, Tournament]:
         if self.errors:
@@ -549,6 +554,31 @@ class Event:
             for tournament in self.tournaments_sorted_by_uniq_id
             if not tournament.finished and tournament.file_exists
         ]
+
+    def check_update(self):
+        """Verify that all the tournaments of the event are up to date.
+        If they are not, update them."""
+        stored_tournaments: list[StoredTournament] = []
+        modified = False
+        with EventDatabase(self.uniq_id) as database:
+            last_updates = database.get_stored_tournament_last_updates()
+            for stored_tournament in self.stored_event.stored_tournaments:
+                id_ = stored_tournament.id
+                assert id_ is not None
+                if stored_tournament.last_update == last_updates[id_]:
+                    stored_tournaments.append(stored_tournament)
+                else:
+                    modified = True
+                    new_stored_tournament = database.get_stored_tournament(id_)
+                    assert new_stored_tournament is not None
+                    stored_tournaments.append(new_stored_tournament)
+                    if tournament := self.tournaments_by_id[id_]:
+                        tournament.stored_tournament = new_stored_tournament
+                        tournament.clear_cache()
+        if modified:
+            self.stored_event.stored_tournaments = stored_tournaments
+        for tournament in self.tournaments:
+            tournament.check_papi_update()
 
     def get_unused_tournament_uniq_id(
         self,

--- a/src/data/event.py
+++ b/src/data/event.py
@@ -28,11 +28,12 @@ from data.screen import Screen
 from data.screen_set import ScreenSet
 from data.timer import Timer, TimerHour
 from data.tournament import Tournament
+from database.sqlite.event.event_database import EventDatabase
 from utils.enum import (
     ScreenType,
     PlayerGender,
 )
-from database.sqlite.event.event_store import StoredEvent
+from database.sqlite.event.event_store import StoredEvent, StoredTournament
 
 logger: Logger = get_logger()
 
@@ -506,6 +507,10 @@ class Event:
             base_uniq_id or _('timer'), self.timers_by_uniq_id
         )
 
+    @property
+    def tournaments(self) -> Iterable[Tournament]:
+        return self.tournaments_by_id.values()
+
     @cached_property
     def tournaments_by_id(self) -> dict[int, Tournament]:
         if self.errors:
@@ -549,6 +554,31 @@ class Event:
             for tournament in self.tournaments_sorted_by_uniq_id
             if not tournament.finished and tournament.file_exists
         ]
+
+    def check_update(self):
+        """Verify that all the tournaments of the event are up to date.
+        If they are not, update them."""
+        stored_tournaments: list[StoredTournament] = []
+        modified = False
+        with EventDatabase(self.uniq_id) as database:
+            last_updates = database.get_stored_tournament_last_updates()
+            for stored_tournament in self.stored_event.stored_tournaments:
+                id_ = stored_tournament.id
+                assert id_ is not None
+                if stored_tournament.last_update == last_updates[id_]:
+                    stored_tournaments.append(stored_tournament)
+                else:
+                    modified = True
+                    new_stored_tournament = database.get_stored_tournament(id_)
+                    assert new_stored_tournament is not None
+                    stored_tournaments.append(new_stored_tournament)
+                    if tournament := self.tournaments_by_id.get(id_, None):
+                        tournament.stored_tournament = new_stored_tournament
+                        tournament.clear_cache()
+        if modified:
+            self.stored_event.stored_tournaments = stored_tournaments
+        for tournament in self.tournaments:
+            tournament.check_papi_update()
 
     def get_unused_tournament_uniq_id(
         self,

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -167,14 +167,13 @@ class EventLoader:
     def _load_event(self, uniq_id: str, reload: bool) -> Event:
         if reload:
             self.clear_cache(uniq_id)
-        if uniq_id in self._loaded_events_by_id:
-            event = self._loaded_events_by_id[uniq_id]
-            event.check_update()
-            return event
-        self.load_event_ids(uniq_id)
-        stored_event: StoredEvent = self.load_stored_event(uniq_id)
-        self.__class__._loaded_events_by_id[uniq_id] = Event(stored_event)
-        return self._loaded_events_by_id[uniq_id]
+        try:
+            return self._loaded_events_by_id[uniq_id]
+        except KeyError:
+            self.load_event_ids(uniq_id)
+            stored_event: StoredEvent = self.load_stored_event(uniq_id)
+            self.__class__._loaded_events_by_id[uniq_id] = Event(stored_event)
+            return self._loaded_events_by_id[uniq_id]
 
     def load_event(self, uniq_id: str) -> Event:
         return self._load_event(uniq_id, reload=False)

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -3,6 +3,7 @@ import shutil
 import time
 from contextlib import suppress
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from functools import cached_property
 from logging import Logger
 from operator import attrgetter
@@ -33,6 +34,12 @@ class EventLoader:
     _invalid_uniq_ids: list[str] = []
     _loaded_stored_events_by_id: dict[str, StoredEvent] = {}
     _loaded_events_by_id: dict[str, Event] = {}
+    _loaded_events_expire_at: dict[str, datetime] = {}
+
+    def __init__(self):
+        for uniq_id, expires_at in self._loaded_events_expire_at.items():
+            if expires_at < datetime.now():
+                self.unload_event(uniq_id)
 
     @classmethod
     def get(cls, request: HTMXRequest | None):
@@ -43,17 +50,22 @@ class EventLoader:
             request.state['event_loader'] = cls()
         return request.state['event_loader']
 
+    @classmethod
+    def unload_event(cls, event_uniq_id: str):
+        with suppress(KeyError):
+            del cls._loaded_stored_events_by_id[event_uniq_id]
+        with suppress(KeyError):
+            del cls._loaded_events_by_id[event_uniq_id]
+        with suppress(KeyError):
+            del cls._loaded_events_expire_at[event_uniq_id]
+        with suppress(ValueError):
+            cls._valid_event_ids.remove(event_uniq_id)
+
     def clear_cache(self, event_uniq_id: str | None = None):
         """If `event_uniq_id` is provided, clears the load cache regarding the
         given event."""
         if event_uniq_id:
-            cls = self.__class__
-            with suppress(KeyError):
-                del cls._loaded_stored_events_by_id[event_uniq_id]
-            with suppress(KeyError):
-                del cls._loaded_events_by_id[event_uniq_id]
-            with suppress(ValueError):
-                cls._valid_event_ids.remove(event_uniq_id)
+            self.unload_event(event_uniq_id)
         cached_property_names = [
             'event_uniq_ids',
             'stored_events_by_id',
@@ -165,15 +177,18 @@ class EventLoader:
         return sorted(self.stored_events_by_id.values(), key=lambda event: event.name)
 
     def _load_event(self, uniq_id: str, reload: bool) -> Event:
+        cls = self.__class__
+        cls._loaded_events_expire_at[uniq_id] = datetime.now() + timedelta(minutes=30)
         if reload:
             self.clear_cache(uniq_id)
-        try:
-            return self._loaded_events_by_id[uniq_id]
-        except KeyError:
-            self.load_event_ids(uniq_id)
-            stored_event: StoredEvent = self.load_stored_event(uniq_id)
-            self.__class__._loaded_events_by_id[uniq_id] = Event(stored_event)
-            return self._loaded_events_by_id[uniq_id]
+        if uniq_id in self._loaded_events_by_id:
+            event = self._loaded_events_by_id[uniq_id]
+            event.check_update()
+            return event
+        self.load_event_ids(uniq_id)
+        stored_event: StoredEvent = self.load_stored_event(uniq_id)
+        cls._loaded_events_by_id[uniq_id] = Event(stored_event)
+        return self._loaded_events_by_id[uniq_id]
 
     def load_event(self, uniq_id: str) -> Event:
         return self._load_event(uniq_id, reload=False)

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -31,10 +31,8 @@ logger: Logger = get_logger()
 class EventLoader:
     _valid_event_ids: list[str] = []
     _invalid_uniq_ids: list[str] = []
-
-    def __init__(self):
-        self._loaded_stored_events_by_id: dict[str, StoredEvent] = {}
-        self._loaded_events_by_id: dict[str, Event] = {}
+    _loaded_stored_events_by_id: dict[str, StoredEvent] = {}
+    _loaded_events_by_id: dict[str, Event] = {}
 
     @classmethod
     def get(cls, request: HTMXRequest | None):
@@ -49,12 +47,13 @@ class EventLoader:
         """If `event_uniq_id` is provided, clears the load cache regarding the
         given event."""
         if event_uniq_id:
+            cls = self.__class__
             with suppress(KeyError):
-                del self._loaded_stored_events_by_id[event_uniq_id]
+                del cls._loaded_stored_events_by_id[event_uniq_id]
             with suppress(KeyError):
-                del self._loaded_events_by_id[event_uniq_id]
+                del cls._loaded_events_by_id[event_uniq_id]
             with suppress(ValueError):
-                self.__class__._valid_event_ids.remove(event_uniq_id)
+                cls._valid_event_ids.remove(event_uniq_id)
         cached_property_names = [
             'event_uniq_ids',
             'stored_events_by_id',
@@ -84,7 +83,7 @@ class EventLoader:
             return self._loaded_stored_events_by_id[uniq_id]
         except KeyError:
             with EventDatabase(uniq_id) as event_database:
-                self._loaded_stored_events_by_id[uniq_id] = (
+                self.__class__._loaded_stored_events_by_id[uniq_id] = (
                     event_database.load_stored_event()
                 )
             return self._loaded_stored_events_by_id[uniq_id]
@@ -173,7 +172,7 @@ class EventLoader:
         except KeyError:
             self.load_event_ids(uniq_id)
             stored_event: StoredEvent = self.load_stored_event(uniq_id)
-            self._loaded_events_by_id[uniq_id] = Event(stored_event)
+            self.__class__._loaded_events_by_id[uniq_id] = Event(stored_event)
             return self._loaded_events_by_id[uniq_id]
 
     def load_event(self, uniq_id: str) -> Event:

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -167,13 +167,14 @@ class EventLoader:
     def _load_event(self, uniq_id: str, reload: bool) -> Event:
         if reload:
             self.clear_cache(uniq_id)
-        try:
-            return self._loaded_events_by_id[uniq_id]
-        except KeyError:
-            self.load_event_ids(uniq_id)
-            stored_event: StoredEvent = self.load_stored_event(uniq_id)
-            self.__class__._loaded_events_by_id[uniq_id] = Event(stored_event)
-            return self._loaded_events_by_id[uniq_id]
+        if uniq_id in self._loaded_events_by_id:
+            event = self._loaded_events_by_id[uniq_id]
+            event.check_update()
+            return event
+        self.load_event_ids(uniq_id)
+        stored_event: StoredEvent = self.load_stored_event(uniq_id)
+        self.__class__._loaded_events_by_id[uniq_id] = Event(stored_event)
+        return self._loaded_events_by_id[uniq_id]
 
     def load_event(self, uniq_id: str) -> Event:
         return self._load_event(uniq_id, reload=False)

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -88,6 +88,9 @@ class Tournament:
                 ).format(filename=self.filename),
                 tournament=self,
             )
+        self.stored_file_modified_timestamp: float | None = None
+        if self.file_exists:
+            self.stored_file_modified_timestamp = self.file_modified_timestamp
         self._players_by_id: dict[int, Player] | None = None
         self._papi_tournament_info: PapiTournamentInfo | None = None
         self._players_by_rank: dict[int, Player] | None = None
@@ -145,6 +148,20 @@ class Tournament:
     @property
     def file_exists(self) -> bool:
         return self.file.exists()
+
+    @property
+    def file_modified_timestamp(self) -> float:
+        return self.file.lstat().st_mtime
+
+    @property
+    def papi_write_database(self) -> PapiDatabase:
+        """This database should be used instead of creating a new instance
+        in write mode to ensure not reloading it unnecessarily."""
+        return PapiDatabase(
+            self.file,
+            write=True,
+            on_exit=self.update_stored_file_modified_timestamp,
+        )
 
     @property
     def start_timestamp(self) -> float:
@@ -517,11 +534,17 @@ class Tournament:
                 self._players_by_id = {}
         return self._papi_tournament_info, self._players_by_id
 
-    def clear_cache(
-        self,
-        clear_papi_tournament_info: bool = False,
-        clear_players_by_id: bool = False,
-    ):
+    def check_papi_update(self):
+        if not self.file_exists:
+            self.clear_cache(clear_papi_cache=True)
+        elif self.stored_file_modified_timestamp != self.file_modified_timestamp:
+            self.clear_cache(clear_papi_cache=True)
+            self.update_stored_file_modified_timestamp()
+
+    def update_stored_file_modified_timestamp(self):
+        self.stored_file_modified_timestamp = self.file_modified_timestamp
+
+    def clear_cache(self, clear_papi_cache: bool = False):
         """Clears the cache of the tournament.
         If *clear_papi_tournament_info* or *clear_players_by_id*,
         the values will need to be fetched again from the Papi Database."""
@@ -530,13 +553,11 @@ class Tournament:
             for name in dir(self)
             if isinstance(getattr(type(self), name, None), cached_property)
         ]
-        if clear_players_by_id:
+        if clear_papi_cache:
             self._players_by_id = None
-        else:
-            cached_property_names.remove('players_by_id')
-        if clear_papi_tournament_info:
             self._papi_tournament_info = None
         else:
+            cached_property_names.remove('players_by_id')
             cached_property_names.remove('papi_tournament_info')
         for property_name in cached_property_names:
             if property_name in self.__dict__:
@@ -981,7 +1002,7 @@ class Tournament:
         if round_ is None:
             round_ = self.current_round
 
-        with PapiDatabase(self.file, write=True) as papi_database:
+        with self.papi_write_database as papi_database:
             papi_database.set_player_result(
                 board.white_player.ref_id, round_, white_result, True
             )
@@ -1015,7 +1036,7 @@ class Tournament:
         assert board.white_player is not None
         assert board.black_player is not None
         assert board.id is not None
-        with PapiDatabase(self.file, write=True) as papi_database:
+        with self.papi_write_database as papi_database:
             for player in (board.white_player, board.black_player):
                 papi_database.set_player_result(
                     player.ref_id, self.current_round, Result.NO_RESULT, True
@@ -1034,7 +1055,7 @@ class Tournament:
 
     def check_in_player(self, player: Player, check_in: bool):
         """Stores the `check_in` status for the given `player`."""
-        with PapiDatabase(self.file, write=True) as papi_database:
+        with self.papi_write_database as papi_database:
             with EventDatabase(self.event.uniq_id, write=True) as event_database:
                 papi_database.check_in_player(player.id, check_in)
                 event_database.set_tournament_last_check_in_update(self.id)
@@ -1042,12 +1063,9 @@ class Tournament:
                 papi_database.commit()
         player.check_in = check_in
 
-    def add_player(
-        self,
-        player: Player,
-    ):
+    def add_player(self, player: Player):
         """Adds a new player to the tournament, returns the player's ID."""
-        with PapiDatabase(self.file, write=True) as papi_database:
+        with self.papi_write_database as papi_database:
             per_plugin_player_data = plugin_manager.hook.player_data_for_db_write(
                 player=player
             )
@@ -1106,7 +1124,7 @@ class Tournament:
     ):
         """Removes a player from the tournament, returns the deleted data as a dict if needed
         (used to move players from one tournament to another one)."""
-        with PapiDatabase(self.file, write=True) as papi_database:
+        with self.papi_write_database as papi_database:
             papi_database.delete_player(player.ref_id)
             papi_database.commit()
 
@@ -1115,7 +1133,7 @@ class Tournament:
         player: Player,
     ):
         """Updates a player."""
-        with PapiDatabase(self.file, write=True) as papi_database:
+        with self.papi_write_database as papi_database:
             papi_database.update_player(player)
             papi_database.commit()
 
@@ -1141,7 +1159,7 @@ class Tournament:
                 f'Black player {black_player.last_name} {black_player.first_name} already has an opponent for round {round_nb}.'
             )
 
-        with PapiDatabase(self.file, write=True) as papi_database:
+        with self.papi_write_database as papi_database:
             white_player.pairings[round_nb] = Pairing(
                 BoardColor.WHITE,
                 black_player.id if black_player else 1,
@@ -1161,7 +1179,7 @@ class Tournament:
             papi_database.commit()
 
     def unpair_boards(self, boards: list[Board], round_: int):
-        with PapiDatabase(self.file, True) as database:
+        with self.papi_write_database as database:
             for board in boards:
                 for player in (board.white_player, board.black_player):
                     if not player:
@@ -1176,7 +1194,7 @@ class Tournament:
     def permute_board_colors(self, board: Board, round_: int):
         assert board.white_player is not None
         assert board.black_player is not None
-        with PapiDatabase(self.file, True) as database:
+        with self.papi_write_database as database:
             pairing = Pairing(BoardColor.BLACK, board.black_player.id, board.result)
             database.update_player_pairing(board.white_player, round_, pairing)
             self.players_by_id[board.white_player.id].pairings[round_] = pairing
@@ -1187,7 +1205,7 @@ class Tournament:
 
     def update_round_pairings(self, round_nb: int):
         """Updates the pairings of all players for a round."""
-        with PapiDatabase(self.file, write=True) as papi_database:
+        with self.papi_write_database as papi_database:
             for player in self.players:
                 if round_nb in player.pairings:
                     papi_database.update_player_pairing(
@@ -1200,7 +1218,7 @@ class Tournament:
         values in common with the stored tournament."""
         if not self.file_exists:
             return
-        with PapiDatabase(self.file, write=True) as papi_database:
+        with self.papi_write_database as papi_database:
             if (tie_breaks := self._update_tie_breaks()) is not None:
                 papi_database.update_tie_breaks(tie_breaks)
             papi_database.write_info(
@@ -1231,7 +1249,7 @@ class Tournament:
         )
         assert self.stored_tournament.id is not None
         with EventDatabase(self.event.uniq_id, write=True) as event_database:
-            with PapiDatabase(self.file, write=True) as papi_database:
+            with self.papi_write_database as papi_database:
                 event_database.set_tournament_last_check_in_update(
                     self.stored_tournament.id
                 )
@@ -1253,7 +1271,7 @@ class Tournament:
             )
             event_database.set_tournament_check_in(self.id, False)
             event_database.commit()
-        with PapiDatabase(self.file, write=True) as papi_database:
+        with self.papi_write_database as papi_database:
             papi_database.close_check_in(
                 self.current_round + 1,
                 (self.rounds + 1) if forfeit_last_rounds else None,
@@ -1265,7 +1283,7 @@ class Tournament:
         with EventDatabase(self.event.uniq_id, write=True) as event_database:
             event_database.set_tournament_last_result_update(player.tournament_id)
             event_database.commit()
-        with PapiDatabase(self.file, write=True) as papi_database:
+        with self.papi_write_database as papi_database:
             for round_, result in byes.items():
                 papi_database.set_player_result(
                     player.ref_id,

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -88,6 +88,9 @@ class Tournament:
                 ).format(filename=self.filename),
                 tournament=self,
             )
+        self.stored_file_modified_timestamp: float | None = None
+        if self.file_exists:
+            self.stored_file_modified_timestamp = self.file_modified_timestamp
         self._players_by_id: dict[int, Player] | None = None
         self._papi_tournament_info: PapiTournamentInfo | None = None
         self._players_by_rank: dict[int, Player] | None = None
@@ -145,6 +148,14 @@ class Tournament:
     @property
     def file_exists(self) -> bool:
         return self.file.exists()
+
+    @property
+    def file_modified_timestamp(self) -> float:
+        return self.file.lstat().st_mtime
+
+    @property
+    def papi_write_database(self) -> PapiDatabase:
+        return PapiDatabase(self.file, write=True, on_exit=self.on_papi_write_exit)
 
     @property
     def start_timestamp(self) -> float:
@@ -517,11 +528,12 @@ class Tournament:
                 self._players_by_id = {}
         return self._papi_tournament_info, self._players_by_id
 
-    def clear_cache(
-        self,
-        clear_papi_tournament_info: bool = False,
-        clear_players_by_id: bool = False,
-    ):
+    def on_papi_write_exit(self):
+        """This function has to be executed after the Papi DB was opened
+        in write mode to ensure not reloading it unnecessarily."""
+        self.stored_file_modified_timestamp = self.file_modified_timestamp
+
+    def clear_cache(self, clear_papi_cache: bool = False):
         """Clears the cache of the tournament.
         If *clear_papi_tournament_info* or *clear_players_by_id*,
         the values will need to be fetched again from the Papi Database."""
@@ -530,13 +542,11 @@ class Tournament:
             for name in dir(self)
             if isinstance(getattr(type(self), name, None), cached_property)
         ]
-        if clear_players_by_id:
+        if clear_papi_cache:
             self._players_by_id = None
-        else:
-            cached_property_names.remove('players_by_id')
-        if clear_papi_tournament_info:
             self._papi_tournament_info = None
         else:
+            cached_property_names.remove('players_by_id')
             cached_property_names.remove('papi_tournament_info')
         for property_name in cached_property_names:
             if property_name in self.__dict__:
@@ -981,7 +991,8 @@ class Tournament:
         if round_ is None:
             round_ = self.current_round
 
-        with PapiDatabase(self.file, write=True) as papi_database:
+        print(self.stored_file_modified_timestamp)
+        with self.papi_write_database as papi_database:
             papi_database.set_player_result(
                 board.white_player.ref_id, round_, white_result, True
             )
@@ -989,6 +1000,8 @@ class Tournament:
                 board.black_player.ref_id, round_, black_result, True
             )
             papi_database.commit()
+        print(self.stored_file_modified_timestamp)
+        print(self.file_modified_timestamp)
         with EventDatabase(self.event.uniq_id, write=True) as event_database:
             event_database.add_stored_result(self.id, round_, board, white_result)
             event_database.commit()

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -88,9 +88,6 @@ class Tournament:
                 ).format(filename=self.filename),
                 tournament=self,
             )
-        self.stored_file_modified_timestamp: float | None = None
-        if self.file_exists:
-            self.stored_file_modified_timestamp = self.file_modified_timestamp
         self._players_by_id: dict[int, Player] | None = None
         self._papi_tournament_info: PapiTournamentInfo | None = None
         self._players_by_rank: dict[int, Player] | None = None
@@ -148,14 +145,6 @@ class Tournament:
     @property
     def file_exists(self) -> bool:
         return self.file.exists()
-
-    @property
-    def file_modified_timestamp(self) -> float:
-        return self.file.lstat().st_mtime
-
-    @property
-    def papi_write_database(self) -> PapiDatabase:
-        return PapiDatabase(self.file, write=True, on_exit=self.on_papi_write_exit)
 
     @property
     def start_timestamp(self) -> float:
@@ -528,12 +517,11 @@ class Tournament:
                 self._players_by_id = {}
         return self._papi_tournament_info, self._players_by_id
 
-    def on_papi_write_exit(self):
-        """This function has to be executed after the Papi DB was opened
-        in write mode to ensure not reloading it unnecessarily."""
-        self.stored_file_modified_timestamp = self.file_modified_timestamp
-
-    def clear_cache(self, clear_papi_cache: bool = False):
+    def clear_cache(
+        self,
+        clear_papi_tournament_info: bool = False,
+        clear_players_by_id: bool = False,
+    ):
         """Clears the cache of the tournament.
         If *clear_papi_tournament_info* or *clear_players_by_id*,
         the values will need to be fetched again from the Papi Database."""
@@ -542,11 +530,13 @@ class Tournament:
             for name in dir(self)
             if isinstance(getattr(type(self), name, None), cached_property)
         ]
-        if clear_papi_cache:
+        if clear_players_by_id:
             self._players_by_id = None
-            self._papi_tournament_info = None
         else:
             cached_property_names.remove('players_by_id')
+        if clear_papi_tournament_info:
+            self._papi_tournament_info = None
+        else:
             cached_property_names.remove('papi_tournament_info')
         for property_name in cached_property_names:
             if property_name in self.__dict__:
@@ -991,8 +981,7 @@ class Tournament:
         if round_ is None:
             round_ = self.current_round
 
-        print(self.stored_file_modified_timestamp)
-        with self.papi_write_database as papi_database:
+        with PapiDatabase(self.file, write=True) as papi_database:
             papi_database.set_player_result(
                 board.white_player.ref_id, round_, white_result, True
             )
@@ -1000,8 +989,6 @@ class Tournament:
                 board.black_player.ref_id, round_, black_result, True
             )
             papi_database.commit()
-        print(self.stored_file_modified_timestamp)
-        print(self.file_modified_timestamp)
         with EventDatabase(self.event.uniq_id, write=True) as event_database:
             event_database.add_stored_result(self.id, round_, board, white_result)
             event_database.commit()

--- a/src/database/access/papi/papi_database.py
+++ b/src/database/access/papi/papi_database.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, date
 from enum import StrEnum
@@ -87,9 +88,17 @@ class PapiDatabase(AccessDatabase):
     """The database class, using the Papi format of the French Chess Federation
     Tournament manager."""
 
-    def __init__(self, file: Path, write: bool = False):
+    def __init__(
+        self, file: Path, write: bool = False, on_exit: Callable | None = None
+    ):
         super().__init__(file, write)
         self.date_of_birth_pattern: Pattern = re.compile(r'^\d{1,2}/\d{1,2}/(\d{1,4})$')
+        self.on_exit = on_exit
+
+    def __exit__(self, exc_type, exc_val, tb):
+        super().__exit__(exc_type, exc_val, tb)
+        if self.on_exit:
+            self.on_exit()
 
     def create_empty(self):
         assert not self.file.exists()

--- a/src/database/access/papi/papi_database.py
+++ b/src/database/access/papi/papi_database.py
@@ -1,5 +1,4 @@
 import re
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, date
 from enum import StrEnum
@@ -88,17 +87,9 @@ class PapiDatabase(AccessDatabase):
     """The database class, using the Papi format of the French Chess Federation
     Tournament manager."""
 
-    def __init__(
-        self, file: Path, write: bool = False, on_exit: Callable | None = None
-    ):
+    def __init__(self, file: Path, write: bool = False):
         super().__init__(file, write)
         self.date_of_birth_pattern: Pattern = re.compile(r'^\d{1,2}/\d{1,2}/(\d{1,4})$')
-        self.on_exit = on_exit
-
-    def __exit__(self, exc_type, exc_val, tb):
-        super().__exit__(exc_type, exc_val, tb)
-        if self.on_exit:
-            self.on_exit()
 
     def create_empty(self):
         assert not self.file.exists()

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -1351,11 +1351,14 @@ class EventDatabase(MigrationDatabase):
             return self._row_to_stored_tournament(row)
         return None
 
+    def get_stored_tournament_last_updates(self) -> dict[int, float]:
+        """Fetches the timestamp of the last update of each tournament.
+        Returns a dict of timestamp per tournament ID."""
+        self.execute('SELECT `id`, `last_update` FROM `tournament`')
+        return {row['id']: row['last_update'] for row in self.fetchall()}
+
     def load_stored_tournaments(self) -> Iterator[StoredTournament]:
-        self.execute(
-            'SELECT * FROM `tournament` ORDER BY `uniq_id`',
-            (),
-        )
+        self.execute('SELECT * FROM `tournament` ORDER BY `uniq_id`')
         yield from map(self._row_to_stored_tournament, self.fetchall())
 
     def _write_stored_tournament(

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -1351,14 +1351,11 @@ class EventDatabase(MigrationDatabase):
             return self._row_to_stored_tournament(row)
         return None
 
-    def get_stored_tournament_last_updates(self) -> dict[int, float]:
-        """Fetches the timestamp of the last update of each tournament.
-        Returns a dict of timestamp per tournament ID."""
-        self.execute('SELECT `id`, `last_update` FROM `tournament`')
-        return {row['id']: row['last_update'] for row in self.fetchall()}
-
     def load_stored_tournaments(self) -> Iterator[StoredTournament]:
-        self.execute('SELECT * FROM `tournament` ORDER BY `uniq_id`')
+        self.execute(
+            'SELECT * FROM `tournament` ORDER BY `uniq_id`',
+            (),
+        )
         yield from map(self._row_to_stored_tournament, self.fetchall())
 
     def _write_stored_tournament(

--- a/src/plugins/chessevent/chessevent.py
+++ b/src/plugins/chessevent/chessevent.py
@@ -186,6 +186,9 @@ class ChessEventPlugin(Plugin):
             'chessevent_tournament_name': self.get_data(
                 td, 'chessevent_tournament_name', ''
             ),
+            'chessevent_last_download_md5': self.get_data(
+                td, 'chessevent_last_download_md5', ''
+            ),
         }
 
     @hookimpl

--- a/src/plugins/chessevent/chessevent.py
+++ b/src/plugins/chessevent/chessevent.py
@@ -186,9 +186,6 @@ class ChessEventPlugin(Plugin):
             'chessevent_tournament_name': self.get_data(
                 td, 'chessevent_tournament_name', ''
             ),
-            'chessevent_last_download_md5': self.get_data(
-                td, 'chessevent_last_download_md5', ''
-            ),
         }
 
     @hookimpl

--- a/src/plugins/chessevent/engine/action_selector.py
+++ b/src/plugins/chessevent/engine/action_selector.py
@@ -25,7 +25,12 @@ from data.event import Event
 from data.loader import EventLoader
 from data.tournament import Tournament
 from utils.enum import Result
-from database.access.papi.papi_database import PapiDatabase, PapiVariable, UNPLAYED_COLOR, BYE_COLOR
+from database.access.papi.papi_database import (
+    PapiDatabase,
+    PapiVariable,
+    UNPLAYED_COLOR,
+    BYE_COLOR,
+)
 from database.access.papi.papi_template import create_empty_papi_database
 from database.sqlite.event.event_database import EventDatabase
 from plugins.chessevent import PLUGIN_NAME
@@ -149,7 +154,7 @@ class ActionSelector(metaclass=Singleton):
         For comparison, also stores `chessevent_download_md5`, so that the tournament is not downloaded unnecessarily.
         Returns the number of players added."""
         players_added: int = 0
-        with PapiDatabase(tournament.file, write=True) as papi_database:
+        with tournament.papi_write_database as papi_database:
             with EventDatabase(tournament.event.uniq_id, write=True) as event_database:
                 cls.write_chessevent_info(papi_database, chessevent_tournament)
                 for player_papi_id, chessevent_player in enumerate(
@@ -165,9 +170,11 @@ class ActionSelector(metaclass=Singleton):
                 event_database.set_tournament_check_in(tournament.id, True)
                 papi_database.open_check_in(1)
                 event_database.execute(
-                    'UPDATE `tournament` SET `chessevent_last_download_md5` = ? WHERE `id` = ?',
+                    'UPDATE `tournament` SET `chessevent_last_download_md5` = ?, '
+                    '`last_update` = ? WHERE `id` = ?',
                     (
                         chessevent_download_md5,
+                        time.time(),
                         tournament.id,
                     ),
                 )

--- a/src/plugins/chessevent/engine/action_selector.py
+++ b/src/plugins/chessevent/engine/action_selector.py
@@ -25,7 +25,12 @@ from data.event import Event
 from data.loader import EventLoader
 from data.tournament import Tournament
 from utils.enum import Result
-from database.access.papi.papi_database import PapiDatabase, PapiVariable, UNPLAYED_COLOR, BYE_COLOR
+from database.access.papi.papi_database import (
+    PapiDatabase,
+    PapiVariable,
+    UNPLAYED_COLOR,
+    BYE_COLOR,
+)
 from database.access.papi.papi_template import create_empty_papi_database
 from database.sqlite.event.event_database import EventDatabase
 from plugins.chessevent import PLUGIN_NAME
@@ -165,9 +170,11 @@ class ActionSelector(metaclass=Singleton):
                 event_database.set_tournament_check_in(tournament.id, True)
                 papi_database.open_check_in(1)
                 event_database.execute(
-                    'UPDATE `tournament` SET `chessevent_last_download_md5` = ? WHERE `id` = ?',
+                    'UPDATE `tournament` SET `chessevent_last_download_md5` = ?, '
+                    '`last_update` = ? WHERE `id` = ?',
                     (
                         chessevent_download_md5,
+                        time.time(),
                         tournament.id,
                     ),
                 )

--- a/src/plugins/chessevent/engine/action_selector.py
+++ b/src/plugins/chessevent/engine/action_selector.py
@@ -25,12 +25,7 @@ from data.event import Event
 from data.loader import EventLoader
 from data.tournament import Tournament
 from utils.enum import Result
-from database.access.papi.papi_database import (
-    PapiDatabase,
-    PapiVariable,
-    UNPLAYED_COLOR,
-    BYE_COLOR,
-)
+from database.access.papi.papi_database import PapiDatabase, PapiVariable, UNPLAYED_COLOR, BYE_COLOR
 from database.access.papi.papi_template import create_empty_papi_database
 from database.sqlite.event.event_database import EventDatabase
 from plugins.chessevent import PLUGIN_NAME
@@ -170,11 +165,9 @@ class ActionSelector(metaclass=Singleton):
                 event_database.set_tournament_check_in(tournament.id, True)
                 papi_database.open_check_in(1)
                 event_database.execute(
-                    'UPDATE `tournament` SET `chessevent_last_download_md5` = ?, '
-                    '`last_update` = ? WHERE `id` = ?',
+                    'UPDATE `tournament` SET `chessevent_last_download_md5` = ? WHERE `id` = ?',
                     (
                         chessevent_download_md5,
-                        time.time(),
                         tournament.id,
                     ),
                 )

--- a/src/plugins/ffe/engine/action_selector.py
+++ b/src/plugins/ffe/engine/action_selector.py
@@ -53,7 +53,7 @@ class ActionSelector(metaclass=Singleton):
     def ffe_upload_needed(cls, tournament: Tournament) -> NeedsUpload:
         try:
             ffe_last_upload = cls.ffe_last_upload(tournament)
-            if ffe_last_upload > tournament.file.lstat().st_mtime:
+            if ffe_last_upload > tournament.file_modified_timestamp:
                 # last version already uploaded
                 return NeedsUpload.NO_CHANGE
             if time() < ffe_last_upload + PapiWebConfig().ffe_upload_delay:

--- a/src/plugins/ffe/engine/action_selector.py
+++ b/src/plugins/ffe/engine/action_selector.py
@@ -53,7 +53,7 @@ class ActionSelector(metaclass=Singleton):
     def ffe_upload_needed(cls, tournament: Tournament) -> NeedsUpload:
         try:
             ffe_last_upload = cls.ffe_last_upload(tournament)
-            if ffe_last_upload > tournament.file_modified_timestamp:
+            if ffe_last_upload > tournament.file.lstat().st_mtime:
                 # last version already uploaded
                 return NeedsUpload.NO_CHANGE
             if time() < ffe_last_upload + PapiWebConfig().ffe_upload_delay:

--- a/src/plugins/ffe/engine/ffe_session.py
+++ b/src/plugins/ffe/engine/ffe_session.py
@@ -449,10 +449,13 @@ class FFESession(Session):
         if error:
             return
         with EventDatabase(self.tournament.event.uniq_id, write=True) as event_database:
+            now = time.time()
             event_database.execute(
-                'UPDATE `tournament` SET `ffe_last_upload` = ? WHERE `id` = ?',
+                'UPDATE `tournament` SET `ffe_last_upload` = ?, '
+                '`last_update` = ? WHERE `id` = ?',
                 (
-                    time.time(),
+                    now,
+                    now,
                     self.tournament.id,
                 ),
             )
@@ -558,10 +561,13 @@ class FFESession(Session):
             logger.error(error)
             return
         with EventDatabase(self.tournament.event.uniq_id, write=True) as event_database:
+            now = time.time()
             event_database.execute(
-                'UPDATE `tournament` SET `ffe_last_rules_upload` = ? WHERE `id` = ?',
+                'UPDATE `tournament` SET `ffe_last_rules_upload` = ?, '
+                '`last_update` = ? WHERE `id` = ?',
                 (
-                    time.time(),
+                    now,
+                    now,
                     self.tournament.id,
                 ),
             )

--- a/src/plugins/ffe/engine/ffe_session.py
+++ b/src/plugins/ffe/engine/ffe_session.py
@@ -449,13 +449,10 @@ class FFESession(Session):
         if error:
             return
         with EventDatabase(self.tournament.event.uniq_id, write=True) as event_database:
-            now = time.time()
             event_database.execute(
-                'UPDATE `tournament` SET `ffe_last_upload` = ?, '
-                '`last_update` = ? WHERE `id` = ?',
+                'UPDATE `tournament` SET `ffe_last_upload` = ? WHERE `id` = ?',
                 (
-                    now,
-                    now,
+                    time.time(),
                     self.tournament.id,
                 ),
             )
@@ -561,13 +558,10 @@ class FFESession(Session):
             logger.error(error)
             return
         with EventDatabase(self.tournament.event.uniq_id, write=True) as event_database:
-            now = time.time()
             event_database.execute(
-                'UPDATE `tournament` SET `ffe_last_rules_upload` = ?, '
-                '`last_update` = ? WHERE `id` = ?',
+                'UPDATE `tournament` SET `ffe_last_rules_upload` = ? WHERE `id` = ?',
                 (
-                    now,
-                    now,
+                    time.time(),
                     self.tournament.id,
                 ),
             )

--- a/src/plugins/ffe/ffe.py
+++ b/src/plugins/ffe/ffe.py
@@ -382,12 +382,10 @@ class FfePlugin(Plugin):
     def set_player_default_ratings(self, federation: str, player: 'Player'):
         if federation != 'FRA':
             return
-
         def set_rating(tournament_rating: TournamentRating, rating_value: int):
             player.ratings[tournament_rating] = PlayerRating(
                 rating_value, PlayerRatingType.ESTIMATED
             )
-
         if not player.get_rating(TournamentRating.RAPID).value:
             match player.category:
                 case PlayerCategory.U8 | PlayerCategory.U10:
@@ -588,6 +586,8 @@ class FfePlugin(Plugin):
         return {
             'ffe_id': self.get_data(data, 'ffe_id', None),
             'ffe_password': self.get_data(data, 'ffe_password', None),
+            'ffe_last_upload': self.get_data(data, 'ffe_last_upload', 0.0),
+            'ffe_last_rules_upload': self.get_data(data, 'ffe_last_rules_upload', 0.0),
         }
 
     @hookimpl

--- a/src/plugins/ffe/ffe.py
+++ b/src/plugins/ffe/ffe.py
@@ -382,10 +382,12 @@ class FfePlugin(Plugin):
     def set_player_default_ratings(self, federation: str, player: 'Player'):
         if federation != 'FRA':
             return
+
         def set_rating(tournament_rating: TournamentRating, rating_value: int):
             player.ratings[tournament_rating] = PlayerRating(
                 rating_value, PlayerRatingType.ESTIMATED
             )
+
         if not player.get_rating(TournamentRating.RAPID).value:
             match player.category:
                 case PlayerCategory.U8 | PlayerCategory.U10:
@@ -586,8 +588,6 @@ class FfePlugin(Plugin):
         return {
             'ffe_id': self.get_data(data, 'ffe_id', None),
             'ffe_password': self.get_data(data, 'ffe_password', None),
-            'ffe_last_upload': self.get_data(data, 'ffe_last_upload', 0.0),
-            'ffe_last_rules_upload': self.get_data(data, 'ffe_last_rules_upload', 0.0),
         }
 
     @hookimpl

--- a/src/web/controllers/admin/player_admin_controller.py
+++ b/src/web/controllers/admin/player_admin_controller.py
@@ -31,7 +31,6 @@ from utils.enum import (
     PlayerTitle,
     Result,
 )
-from database.access.papi.papi_database import PapiDatabase
 from database.sqlite.fide.fide_database import FideDatabase
 from plugins.ffe.util import PlayerFFELicence
 from plugins.manager import plugin_manager
@@ -1657,7 +1656,7 @@ class PlayerAdminController(BaseEventAdminController):
                 tournament: Tournament = web_context.admin_event.tournaments_by_id[
                     tournament_id
                 ]
-                with PapiDatabase(tournament.file, True) as database:
+                with tournament.papi_write_database as database:
                     for player in tournament_players:
                         database.update_player(player)
                     database.commit()

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -108,7 +108,7 @@ class ScreenUserController(BaseScreenUserController):
             case _:
                 raise ValueError(f'type={screen_set.type}')
         with suppress(FileNotFoundError):
-            if tournament.file_modified_timestamp > date:
+            if tournament.file.lstat().st_mtime > date:
                 return True
         return False
 

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -108,7 +108,7 @@ class ScreenUserController(BaseScreenUserController):
             case _:
                 raise ValueError(f'type={screen_set.type}')
         with suppress(FileNotFoundError):
-            if tournament.file.lstat().st_mtime > date:
+            if tournament.file_modified_timestamp > date:
                 return True
         return False
 


### PR DESCRIPTION
### TODO  

- [x]  reload a tournament when the `last_update`  field does not match
- [x] store the modified time of each papi file, and clear the tournament cache if it is different (i.e. if the user has modified the tournament in Papi)
- [x] make sure to not reload the papi_file when we the modification is made by SC
- [x] restrict the written fields of the scripts to `uploaded_at`
- [x] remove written fields from the global tournament update
- [x] set `last_update` to now when the tournament is modified from scripts
- [x] add an expire time of 30 minutes for each event

### Outside of PR scope: handle 2 servers running on different ports  
Add server config via a `sharly-chess.ini` file in which the port can be configured