### PR TITLE
Fix pairings / results printing with no round

### DIFF
--- a/src/data/print_documents/documents.py
+++ b/src/data/print_documents/documents.py
@@ -247,7 +247,7 @@ class BoardPrintDocument(PrintDocument, ABC):
         super().validate_options()
         assert self.tournament is not None
         at_round = self._get_option(RoundPrintOption)
-        if at_round is None:
+        if at_round.value is None:
             return
         if at_round.value > self.tournament.rounds:
             raise OptionError(


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/3a7d57d2-3e1b-4760-bcca-cfeb4b9ca4a7)

TypeError: '>' not supported between instances of 'NoneType' and 'int'  

Already fixed on stable