### PR TITLE
Fix TypeError

### DIFF
--- a/docs/03-change-log.md
+++ b/docs/03-change-log.md
@@ -2,6 +2,9 @@
 
 # Papi-web - ChangeLog
 
+## Version 2.5.8 - 30 avril 2025
+- Correction d'un bug sur les droits d'inscription (#481)
+
 ## Version 2.5.7 - 20 avril 2025
 - Correction d'un bug sur les impressions
 

--- a/src/database/access/papi/papi_database.py
+++ b/src/database/access/papi/papi_database.py
@@ -308,8 +308,8 @@ class PapiDatabase(AccessDatabase):
                 mail=row['EMail'] or '',
                 phone=row['Tel'] or '',
                 comment=row['Commentaire'] or '',
-                owed=float(row['InscriptionDu']) or 0.0,
-                paid=float(row['InscriptionRegle']) or 0.0,
+                owed=float(row['InscriptionDu'] or 0.0),
+                paid=float(row['InscriptionRegle'] or 0.0),
                 title=PlayerTitle.from_papi_value(row['FideTitre'] or ''),
                 ratings={tr: row[tr.papi_value_field] or 0 for tr in TournamentRating},
                 rating_types={


### PR DESCRIPTION
Sometimes, players may have an empty "InscriptionRegle" value in the PapiDatabase (if an arbiter deleted the value).

This PR aims to make the type conversion less brittle by preventing a type conversion on None for this column and InscriptionDu