### PR TITLE
Prevent log polluting `Locale set to ...`

### DIFF
--- a/src/common/i18n/__init__.py
+++ b/src/common/i18n/__init__.py
@@ -103,6 +103,8 @@ def get_locale() -> str:
 
 def set_locale(locale: str) -> bool:
     """Sets the locale for the current thread, returns True if the given locale is recognized."""
+    if hasattr(_thread_local_data, 'locale') and _thread_local_data.locale == locale:
+        return True
     if locale in locales:
         _thread_local_data.locale = locale
         logger.debug('Locale set to [%s].', locale)

--- a/src/common/papi_web_config.py
+++ b/src/common/papi_web_config.py
@@ -88,6 +88,7 @@ class PapiWebConfig(metaclass=Singleton):
                 self.stored_config.locale = locales[locale_num - 1]
                 config_database.update_stored_config(self.stored_config)
                 config_database.commit()
+            set_locale(self.locale)
         # TODO (up to here)
 
     def reload(self):

--- a/src/common/papi_web_config.py
+++ b/src/common/papi_web_config.py
@@ -89,7 +89,6 @@ class PapiWebConfig(metaclass=Singleton):
                 config_database.update_stored_config(self.stored_config)
                 config_database.commit()
         # TODO (up to here)
-        set_locale(self.locale)
 
     def reload(self):
         self.stored_config = self.load()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/04e12206-14f3-493b-8dad-7506b58c9947)
currently there is one additional log per request because the locale needs to be set again in the web context to handle multiple sessions with different locales.  
This only logs the locale being set if it is different to the current one