### PR TITLE
Fix TypeError on float conversion

### DIFF
--- a/src/database/access/papi/papi_database.py
+++ b/src/database/access/papi/papi_database.py
@@ -409,8 +409,8 @@ class PapiDatabase(AccessDatabase):
                 mail=row['EMail'] or '',
                 phone=row['Tel'] or '',
                 comment=row['Commentaire'] or '',
-                owed=float(row['InscriptionDu']) or 0.0,
-                paid=float(row['InscriptionRegle']) or 0.0,
+                owed=float(row['InscriptionDu'] or 0.0),
+                paid=float(row['InscriptionRegle'] or 0.0),
                 title=PlayerTitle.from_papi_value(row['FideTitre'] or ''),
                 ratings={
                     tr: PlayerRating(


### PR DESCRIPTION
Some papi databases somehow had `NULL` values in `InscriptionDu` and/or `InscriptionRegle` columns.

This solves that problem by providing a default 0 value for those columns, then converting to `float`.

Was solved for `stable-2.5` in #481.