### PR TITLE
Improve pairings UI for swiss tournaments

### DIFF
--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -2952,9 +2952,6 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
-msgid "Points"
-msgstr ""
-
 msgid "Points for draw (Half-Point Bye)"
 msgstr ""
 
@@ -3039,7 +3036,7 @@ msgstr ""
 msgid "Protected pairings editing"
 msgstr ""
 
-msgid "Pts *** POINTS FOR PRINT VIEW"
+msgid "Pts *** POINTS FOR TABULAR DISPLAY"
 msgstr "Pts"
 
 msgid "Public display controller"

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -2952,9 +2952,6 @@ msgstr "Veuillez patienter..."
 msgid "Plugins"
 msgstr "Plug-ins"
 
-msgid "Points"
-msgstr "Points"
-
 msgid "Points for draw (Half-Point Bye)"
 msgstr "Points de match nul (demi-point joker)"
 
@@ -3039,7 +3036,7 @@ msgstr "Propriétés (saisie des résultats)"
 msgid "Protected pairings editing"
 msgstr "Édition d'appariements protégés"
 
-msgid "Pts *** POINTS FOR PRINT VIEW"
+msgid "Pts *** POINTS FOR TABULAR DISPLAY"
 msgstr "Pts"
 
 msgid "Public display controller"

--- a/src/data/pairings/systems.py
+++ b/src/data/pairings/systems.py
@@ -72,10 +72,10 @@ class PairingSystem(IdentifiableEntity, ABC):
         return True
 
     @property
-    def pair_tournament_from_settings_modal(self) -> bool:
-        """Determines if the `Save` button on the `pairing settings modal`
-        should be replaced by a `pair tournament` button."""
-        return False
+    def round_per_round_pairing_generation(self) -> bool:
+        """Determines if the pairings are generated round per round
+        or all the rounds at the same time."""
+        return True
 
     @property
     def variation_field_id(self) -> str:
@@ -178,8 +178,8 @@ class RoundRobinPairingSystem(PairingSystem):
         return _('Round-Robin')
 
     @property
-    def pair_tournament_from_settings_modal(self) -> bool:
-        return True
+    def round_per_round_pairing_generation(self) -> bool:
+        return False
 
     @property
     def variation_manager(self) -> EntityManager['PairingVariation']:

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -531,7 +531,7 @@ class Tournament:
                     dependent_screens.append(screen)
         return dependent_screens
 
-    @property
+    @cached_property
     def print_real_points(self) -> bool:
         return self.pairing_variation.print_real_points(self.current_round, self.rounds)
 

--- a/src/plugins/pairing_acceleration/pairing_settings.py
+++ b/src/plugins/pairing_acceleration/pairing_settings.py
@@ -188,8 +188,8 @@ class DualRatingLimitsSetting(PairingSetting[tuple[int, int]]):
         player_count = len(ratings)
         if player_count < 3:
             return 0, 0
-        if player_count < 7:
-            # Min ideal repartition: A(4), B(2), C(1)
+        if player_count < 11:
+            # Min ideal repartition: A(4), B(4), C(3)
             first_c = player_count // 3 - 1
             first_b = 2 * player_count // 3 - 1
         else:

--- a/src/plugins/pairing_acceleration/pairing_settings.py
+++ b/src/plugins/pairing_acceleration/pairing_settings.py
@@ -54,8 +54,9 @@ class RatingLimitSetting(PairingSetting[int]):
 
     @classmethod
     def default_value(cls, tournament: 'Tournament') -> int:
-        # TODO replace by recommended value once papi dependency has been removed
-        return tournament.papi_tournament_info.rating_limit1
+        if papi_limit := tournament.papi_tournament_info.rating_limit1:
+            return papi_limit
+        return cls.recommended_value(tournament)
 
     @classmethod
     def recommended_value(cls, tournament: 'Tournament') -> int:
@@ -172,16 +173,30 @@ class DualRatingLimitsSetting(PairingSetting[tuple[int, int]]):
 
     @classmethod
     def default_value(cls, tournament: 'Tournament') -> tuple[int, int]:
-        # TODO replace by recommended value once papi dependency has been removed
-        return cls.papi_limits(tournament)
+        if (papi_limits := cls.papi_limits(tournament)) != (0, 0):
+            return papi_limits
+        return cls.recommended_value(tournament)
 
     @classmethod
     def recommended_value(cls, tournament: 'Tournament') -> tuple[int, int]:
+        """Recommend the values for an ideal repartition of players.
+        Ideal repartition:
+            - Group A: closest multiple of 4 to a third of the players
+            - Group B: closest multiple of 2 of half of the remaining players
+            - Group C: remaining players"""
         ratings = cls.player_ratings(tournament)
-        if len(ratings) < 3:
+        player_count = len(ratings)
+        if player_count < 3:
             return 0, 0
-        first_c = len(ratings) // 3 - 1
-        first_b = 2 * len(ratings) // 3 - 1
+        if player_count < 7:
+            # Min ideal repartition: A(4), B(2), C(1)
+            first_c = player_count // 3 - 1
+            first_b = 2 * player_count // 3 - 1
+        else:
+            a_count = 4 * round((player_count / 3) / 4)
+            b_count = 2 * round((player_count - a_count) / 4)
+            first_b = (player_count - 1) - a_count
+            first_c = (player_count - 1) - (a_count + b_count)
         return (
             math.ceil((ratings[first_c] + ratings[first_c + 1]) / 2),
             math.ceil((ratings[first_b] + ratings[first_b + 1]) / 2),

--- a/src/plugins/pairing_acceleration/templates/pairing_acceleration/dual_rating_limits.html
+++ b/src/plugins/pairing_acceleration/templates/pairing_acceleration/dual_rating_limits.html
@@ -1,4 +1,15 @@
 {% with recommended=setting.recommended_value(admin_tournament) %}
+    <div class="row mt-3 mb-3">
+        {{ admin_macros.number_input(
+            name=setting.upper_limit_field,
+            label=_('%(string)s:', string=_('Upper rating limit')),
+            help_text=_(
+                'Rating splitting groups A and B (recommended: %(recommended)d).',
+                recommended=recommended[1],
+            ) if recommended else _('Rating splitting groups A and B.'),
+            data=data, errors=errors
+        ) }}
+    </div>
     <div class="row mb-3">
         {{ admin_macros.number_input(
             name=setting.lower_limit_field,
@@ -7,17 +18,6 @@
                 'Rating splitting groups B and C (recommended: %(recommended)d).',
                 recommended=recommended[0],
             ) if recommended else _('Rating splitting groups B and C.'),
-            data=data, errors=errors
-        ) }}
-    </div>
-    <div class="row mb-3">
-        {{ admin_macros.number_input(
-            name=setting.upper_limit_field,
-            label=_('%(string)s:', string=_('Upper rating limit')),
-            help_text=_(
-                'Rating splitting groups A and B (recommended: %(recommended)d).',
-                recommended=recommended[1],
-            ) if recommended else _('Rating splitting groups A and B.'),
             data=data, errors=errors
         ) }}
     </div>

--- a/src/plugins/pairing_acceleration/templates/pairing_acceleration/rating_limit.html
+++ b/src/plugins/pairing_acceleration/templates/pairing_acceleration/rating_limit.html
@@ -1,4 +1,4 @@
-<div class="row mb-3">
+<div class="row mt-3 mb-3">
     {% with recommended=setting.recommended_value(admin_tournament) %}
         {{ admin_macros.number_input(
             name=setting.id,

--- a/src/web/controllers/admin/pairings_admin_controller.py
+++ b/src/web/controllers/admin/pairings_admin_controller.py
@@ -1198,11 +1198,11 @@ class PairingsAdminController(BaseEventAdminController):
             data=data,
         )
 
-    @patch(
-        path='/admin/pairings/settings-update/{event_uniq_id:str}/{tournament_id:int}/{round:int}',
-        name='admin-pairings-settings-update',
+    @post(
+        path='/admin/pairings/generate-with-settings/{event_uniq_id:str}/{tournament_id:int}/{round:int}',
+        name='admin-generate-round-pairings-with-settings',
     )
-    async def htmx_admin_pairings_settings_update(
+    async def htmx_admin_generate_round_pairings_with_settings(
         self,
         request: HTMXRequest,
         data: Annotated[
@@ -1217,7 +1217,7 @@ class PairingsAdminController(BaseEventAdminController):
             request,
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
-            round_=None,
+            round_=round,
             board_id=None,
             player_id=None,
             data=data,
@@ -1235,6 +1235,17 @@ class PairingsAdminController(BaseEventAdminController):
                 modal='pairing-settings',
             )
         self._save_pairing_settings_data(tournament, data)
+        tournament.pairing_variation.engine.generate_pairings(
+            tournament, web_context.admin_round
+        )
+        Message.success(
+            request,
+            _(
+                'Pairings of round {round} generated for tournament [{tournament_uniq_id}].'
+            ).format(
+                round=web_context.admin_round, tournament_uniq_id=tournament.uniq_id
+            ),
+        )
         return self._admin_event_pairings_render(
             request,
             event_uniq_id=event_uniq_id,

--- a/src/web/templates/admin/pairings/pairing_row.html
+++ b/src/web/templates/admin/pairings/pairing_row.html
@@ -9,6 +9,9 @@
 >
     <td class="text-center">{{ board.number }}</td>
     <td class="text-center">{{ wp.vpoints_str }}</td>
+    {% if admin_tournament.print_real_points %}
+        <td class="text-start">[{{ wp.points_str }}]</td>
+    {% endif %}
     <td>{{ wp.last_name }} {{ wp.first_name }} ({{ wp.get_rating(admin_tournament.rating) }})</td>
     <td class="text-center" style="width: 3rem;">
         <button
@@ -27,9 +30,14 @@
     </td>
     {% if bp %}
         <td>{{ bp.last_name }} {{ bp.first_name }} ({{ bp.get_rating(admin_tournament.rating) }})</td>
+        {% if admin_tournament.print_real_points %}
+            <td class="text-end">[{{ bp.points_str }}]</td>
+        {% endif %}
         <td class="text-center">{{ bp.vpoints_str }}</td>
+
     {% else %}
         <td>{{ _('EXEMPT') }}</td>
-        <td class="text-center"></td>
+        <td></td>
+        {% if admin_tournament.print_real_points %}<td></td>{% endif %}
     {% endif %}
 </tr>

--- a/src/web/templates/admin/pairings/settings/modal.html
+++ b/src/web/templates/admin/pairings/settings/modal.html
@@ -10,10 +10,10 @@
         <div class="modal-body">
             <form
                 id="modal-form"
-                {% if admin_tournament.pairing_system.pair_tournament_from_settings_modal %}
-                    hx-post="{{ url_for('admin-generate-tournament-pairings', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id) }}"
+                {% if admin_tournament.pairing_system.round_per_round_pairing_generation %}
+                    hx-post="{{ url_for('admin-generate-round-pairings-with-settings', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round) }}"
                 {% else %}
-                    hx-patch="{{ url_for('admin-pairings-settings-update', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round) }}"
+                    hx-post="{{ url_for('admin-generate-tournament-pairings', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id) }}"
                 {% endif %}
                 hx-target="body"
                 hx-indicator="#please-wait"
@@ -40,13 +40,8 @@
                 form="modal-form"
                 class="text-nowrap white btn btn-primary"
             >
-                {% if admin_tournament.pairing_system.pair_tournament_from_settings_modal %}
-                    <i class="bi-shuffle pe-1"></i>
-                    {{ _('Pair tournament') }}
-                {% else %}
-                    <i class="bi-floppy-fill pe-1"></i>
-                    {{ _('Save') }}
-                {% endif %}
+                <i class="bi-shuffle pe-1"></i>
+                {{ _('Pair') }}
             </button>
         </div>
     </div>

--- a/src/web/templates/admin/pairings/swiss_pairing_buttons.html
+++ b/src/web/templates/admin/pairings/swiss_pairing_buttons.html
@@ -18,7 +18,7 @@
                 >
                     <button
                         class="btn btn-outline-primary text-nowrap"
-                        {% if admin_tournament.are_pairing_settings_valid %}
+                        {% if admin_tournament.are_pairing_settings_valid and admin_round != 1 %}
                             hx-post="{{ url_for('admin-generate-round-pairings', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round) }}"
                         {% else %}
                             hx-get="{{ url_for('admin-pairings-settings-modal', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round) }}"

--- a/src/web/templates/admin/pairings/tab.html
+++ b/src/web/templates/admin/pairings/tab.html
@@ -180,11 +180,17 @@
                 >
                     <tr>
                         <th>{{ _('Board') }}</th>
-                        <th>{{ _('Points') }}</th>
+                        <th>{{ _('Pts *** POINTS FOR TABULAR DISPLAY') }}</th>
+                        {% if admin_tournament.print_real_points %}
+                            <th>&nbsp;</th>
+                        {% endif %}
                         <th>{{ _('White') }}</th>
                         <th class="text-center">{{ _('Result') }}</th>
                         <th>{{ _('Black') }}</th>
-                        <th>{{ _('Points') }}</th>
+                        {% if admin_tournament.print_real_points %}
+                            <th>&nbsp;</th>
+                        {% endif %}
+                        <th>{{ _('Pts *** POINTS FOR TABULAR DISPLAY') }}</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/web/templates/admin/print/boards.html
+++ b/src/web/templates/admin/print/boards.html
@@ -9,7 +9,10 @@
         <thead>
             <tr class="board-header">
                 <th class="board-number">{{ _('Bd. *** BOARD NUMBER FOR PRINT VIEW') }}</th>
-                <th class="points">{{ _('Pts *** POINTS FOR PRINT VIEW') }}</th>
+                <th class="points">{{ _('Pts *** POINTS FOR TABULAR DISPLAY') }}</th>
+                {% if document.tournament.print_real_points %}
+                    <th class="points">&nbsp;</th>
+                {% endif %}
                 <th class="player">{{ _('White') }}</th>
                 <th class="rating"></th>
                 <th class="result">
@@ -19,7 +22,10 @@
                 </th>
                 <th class="player">{{ _('Black') }}</th>
                 <th class="rating"></th>
-                <th class="points">{{ _('Pts *** POINTS FOR PRINT VIEW') }}</th>
+                {% if document.tournament.print_real_points %}
+                    <th class="points">&nbsp;</th>
+                {% endif %}
+                <th class="points">{{ _('Pts *** POINTS FOR TABULAR DISPLAY') }}</th>
             </tr>
         </thead>
         <tbody>
@@ -29,7 +35,10 @@
                     class="board-row {% if loop.index is even %}even{% else %}odd{% endif %}"
                 >
                     <td class="board-number">{{ board.number }}</td>
-                    <td class="points">{{ board.white_player.points_str }}</td>
+                    <td class="points">{{ board.white_player.vpoints_str }}</td>
+                    {% if document.tournament.print_real_points %}
+                        <td class="points">[{{ board.white_player.points_str }}]</td>
+                    {% endif %}
                     <td class="player">
                         {{ board.white_player.last_name }}&nbsp;{{ board.white_player.first_name }}
                     </td>
@@ -48,10 +57,15 @@
                         <td class="rating">
                             {{ board.black_player.rating }}&nbsp;{{ board.black_player.rating_type }}
                         </td>
-                        <td class="points">{{ board.black_player.points_str }}</td>
+                        {% if document.tournament.print_real_points %}
+                            <td class="points">[{{ board.black_player.points_str }}]</td>
+                        {% endif %}
+                        <td class="points">{{ board.black_player.vpoints_str }}</td>
                     {% else %}
                         <td class="player">{{ board.white_player.exempt_str }}</td>
-                        <td></td><td></td>
+                        <td></td>
+                        <td></td>
+                        {% if document.tournament.print_real_points %}<td></td>{% endif %}
                     {% endif %}
 
                 </tr>

--- a/src/web/templates/common/print/player_header.html
+++ b/src/web/templates/common/print/player_header.html
@@ -36,7 +36,7 @@
     {% endif %}
     {% if ranking or crosstable %}
         <th class="points text-center">
-            <strong>{{ _('Pts *** POINTS FOR PRINT VIEW') }}</strong>
+            <strong>{{ _('Pts *** POINTS FOR TABULAR DISPLAY') }}</strong>
         </th>
         {% for tie_break in tournament.tie_breaks %}
             {% if tie_break.is_displayable %}


### PR DESCRIPTION
closes #547 closes #552 
- reverse upper / lower limit input fields
- for rating limits, fill recommanded values instead of 0
- pair round 1 from the settings modal
- improve recommanded rating limits for SAD
- display settings modal when pairing round 1
- show real points / vpoints in print view / pairing tab