### PR TITLE
Add CSRF protection

### DIFF
--- a/src/database/access/papi/papi_database.py
+++ b/src/database/access/papi/papi_database.py
@@ -234,6 +234,7 @@ class PapiDatabase(AccessDatabase):
                 'Commentaire',
                 'InscriptionDu',
                 'InscriptionRegle',
+                'Fixe',
             ]
             + [tr.papi_value_field for tr in TournamentRating]
             + [tr.papi_type_field for tr in TournamentRating]
@@ -254,6 +255,7 @@ class PapiDatabase(AccessDatabase):
                 player.comment,
                 player.owed,
                 player.paid,
+                player.fixed or 0,
             ]
             + [player.get_rating(tr).value for tr in TournamentRating]
             + [player.get_rating(tr).type.to_papi_value for tr in TournamentRating]

--- a/src/web/server_engine.py
+++ b/src/web/server_engine.py
@@ -32,6 +32,7 @@ from web.settings import (
     middlewares,
     stores,
     exception_handlers,
+    csrf_config,
 )
 
 logger = get_logger()
@@ -130,6 +131,7 @@ class ServerEngine(Engine):
             template_config=template_config,
             logging_config=LoggingConfig(**logging_config),  # type: ignore
             middleware=middlewares,
+            csrf_config=csrf_config,
             stores=stores,
             pdb_on_exception=self.debug,
         )

--- a/src/web/settings.py
+++ b/src/web/settings.py
@@ -3,9 +3,11 @@ import posixpath
 import typing as t
 from pathlib import Path
 from typing import Sequence
+from secrets import token_hex
 
 from jinja2 import Environment, FileSystemLoader, TemplateNotFound
 from litestar import Router
+from litestar.config.csrf import CSRFConfig
 from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.datastructures import CacheControlHeader
 from litestar.middleware.session.client_side import CookieBackendConfig
@@ -187,3 +189,10 @@ stores: dict[str, Store] = {'sessions': FileStore(path=sessions_dir)}
 middlewares: Sequence[Middleware] = [
     CookieBackendConfig(secret=os.urandom(16)).middleware,
 ]
+
+if 'SC_CSRF_SECRET' not in os.environ:
+    csrf_secret = token_hex(64)
+else:
+    csrf_secret = os.environ['SC_CSRF_SECRET']
+
+csrf_config: CSRFConfig = CSRFConfig(secret=csrf_secret, header_name='X-CSRF-TOKEN')

--- a/src/web/templates/common/base.html
+++ b/src/web/templates/common/base.html
@@ -232,6 +232,7 @@
     <body
         hx-ext="multi-swap,preload,morphdom-swap"
         hx-swap="transition:true"
+        hx-headers='{"X-CSRF-TOKEN": "{{ csrf_token() }}" }'
     >
         {% set redirect_url = '' %}
         {% if sharly_chess_config.force_edit %}


### PR DESCRIPTION
Also fixed the fixed table not updating

NOTE: while this works flawlessly for short-lived sessions, once the server is restarted, the CSRF token changes.
Changing it requires both removing the session cookie (simply by closing the browser), and refreshing.
I don't know how to signal that the token changed to the client(s) to avoid problems on crashes.