### PR TITLE
Fixed the ChessEvent players' Estimated/National rating type

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,6 +41,7 @@ English version below
 
 - Prise en compte correcte des dates de naissance antérieures au 01/01/1970 (2.7.0)
 - Normalisation des noms des joueur·euses (2.7.1)
+- Correction du type de classement Estimé/National des joueur·euses (2.7.4)
 
 ---
 
@@ -86,3 +87,4 @@ English version below
 
 - Fixed birth dates prior to 1970-01-01 (2.7.0)
 - Normalized players' names (2.7.1)
+- Fixed the players' Estimated/National rating type (2.7.4)

--- a/TAG_MESSAGE.txt
+++ b/TAG_MESSAGE.txt
@@ -1,1 +1,3 @@
 Fourth bugfix update of Sharly Chess version 2.7
+
+- Fixed the ChessEvent players' Estimated/National rating type

--- a/src/plugins/chessevent/data/chessevent_player.py
+++ b/src/plugins/chessevent/data/chessevent_player.py
@@ -31,8 +31,8 @@ class ChessEventRatingType(PluginCoreMapper[int, PlayerRatingType]):
     @staticmethod
     def _core_object_by_plugin_value() -> dict[int, PlayerRatingType]:
         return {
-            1: PlayerRatingType.NATIONAL,
-            2: PlayerRatingType.ESTIMATED,
+            1: PlayerRatingType.ESTIMATED,
+            2: PlayerRatingType.NATIONAL,
             3: PlayerRatingType.FIDE,
         }
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/aa7dfc83-91e7-41ea-80c9-9fa267669e63)
After:
![image](https://github.com/user-attachments/assets/a65110ec-d2fa-4013-9d10-8f6b5cd78362)
