### PR TITLE
Fix the colors of the players update modal

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,7 @@ English version below
 - Correction et ajout de champs dans l'export des joueur·euses au format ODS (2.7.1)
 - Correction de l'affichage des joueur·euses non-FIDE lors de la mise à jour depuis les bases de données FIDE et FFE (2.7.3)
 - Correction de la mise à jour des classements des joueur·euses (2.7.5)
+- Correction des couleurs du modal de mise à jour des joueur·euses (2.7.5)
 
 ### Gestion des appariements
 
@@ -72,6 +73,7 @@ English version below
 - Fixed and added columns to the players ODS export (2.7.1)
 - Fixed the display of non-FIDE players when updating the players from FFE or FIDE databases (2.7.3)
 - Update players when rating types differ in data sources (2.7.5)
+- Fixed the colors of the players update modal (2.7.5)
 
 # Pairings management
 

--- a/src/plugins/ffe/templates/ffe_players_update/league_cell.html
+++ b/src/plugins/ffe/templates/ffe_players_update/league_cell.html
@@ -2,18 +2,12 @@
 
 {% set field_id='league' %}
 {% if field_id in field_ids %}
-    {% set field_updated=value.diff_field_ids and field_id in value.diff_field_ids %}
-    {% set field_updated_class='text-warning fw-bold' %}
-    {% set field_unchanged_class='' %}
-    {% set field_class=field_updated_class if field_updated else field_unchanged_class %}
+    {% set field_updated=value.player_updated and field_id in value.diff_field_ids %}
+    {% set field_class=value.field_updated_class if field_updated else value.field_unchanged_class %}
     <td
-        scope="col" class="text-nowrap text-center {{ player_class }} {{ field_class }}"
+        scope="col" class="text-nowrap text-center {{ value.player_class }} {{ field_class }}"
         {% if field_updated %}{{ macros.tooltip_attributes('info', _('Replace [%(old)s] by [%(new)s]', old=value.player.plugin_data.ffe.league, new=value.match_player.plugin_data.ffe.league), 'top') }}{% endif %}
     >
-        {% if field_updated %}
-            {{ value.match_player.plugin_data.ffe.league }}
-        {% else %}
-            {{ value.player.plugin_data.ffe.league }}
-        {% endif %}
+        {{ value.match_player.plugin_data.ffe.league }}
     </td>
 {% endif %}

--- a/src/plugins/ffe/templates/ffe_players_update/licence_cell.html
+++ b/src/plugins/ffe/templates/ffe_players_update/licence_cell.html
@@ -3,18 +3,12 @@
 
 {% set field_id='ffe_licence' %}
 {% if field_id in field_ids %}
-    {% set field_updated=value.diff_field_ids and field_id in value.diff_field_ids %}
-    {% set field_updated_class='text-warning fw-bold' %}
-    {% set field_unchanged_class='' %}
-    {% set field_class=field_updated_class if field_updated else field_unchanged_class %}
+    {% set field_updated=value.player_updated and field_id in value.diff_field_ids %}
+    {% set field_class=value.field_updated_class if field_updated else value.field_unchanged_class %}
     <td
-        scope="col" class="text-nowrap text-center {{ player_class }} {{ field_class }}"
+        scope="col" class="text-nowrap text-center {{ value.player_class }} {{ field_class }}"
         {% if field_updated %}{{ macros.tooltip_attributes('info', _('Replace [%(old)s] by [%(new)s]', old=value.player.plugin_data.ffe.ffe_licence.name, new=value.match_player.plugin_data.ffe.ffe_licence.name), 'top') }}{% endif %}
     >
-        {% if field_updated %}
-            {{ ffe_macros.ffe_licence(value.match_player.plugin_data.ffe.ffe_licence) }}
-        {% else %}
-            {{ ffe_macros.ffe_licence(value.player.plugin_data.ffe.ffe_licence) }}
-        {% endif %}
+        {{ ffe_macros.ffe_licence(value.match_player.plugin_data.ffe.ffe_licence) }}
     </td>
 {% endif %}

--- a/src/plugins/ffe/templates/ffe_players_update/licence_number_cell.html
+++ b/src/plugins/ffe/templates/ffe_players_update/licence_number_cell.html
@@ -2,7 +2,9 @@
 
 {% set field_id='ffe_licence_number' %}
 {% if field_id in field_ids %}
-    <td scope="col" class="text-nowrap text-start {{ player_class }}">
-        {{ value.player.plugin_data.ffe.ffe_licence_number }}
+    {% set field_updated=value.player_updated and field_id in value.diff_field_ids %}
+    {% set field_class=value.field_updated_class if field_updated else value.field_unchanged_class %}
+    <td scope="col" class="text-nowrap text-start {{ value.player_class }} {{ field_class }}">
+        {{ value.match_player.plugin_data.ffe.ffe_licence_number }}
     </td>
 {% endif %}

--- a/src/web/static/css/base.css
+++ b/src/web/static/css/base.css
@@ -186,6 +186,10 @@ body[data-bs-theme="dark"] .htmx-indicator {
     display: inline-block;
     width: 1.2em;
 }
+.player-unchanged .player-ffe-lic,
+.player-updated .player-ffe-lic {
+    color: unset;
+}
 .player-ffe-lic.ffe-lic-A {
     background-color: #001da3;
 }

--- a/src/web/templates/admin/players/players_diff_modal.html
+++ b/src/web/templates/admin/players/players_diff_modal.html
@@ -219,6 +219,15 @@
                                 {% set match_player=player %}
                                 {% set player_class=player_unchanged_class %}
                             {% endif %}
+                            {% set player_context={
+                                'player': player,
+                                'diff_field_ids': diff_field_ids,
+                                'player_updated': player_updated,
+                                'match_player': match_player,
+                                'player_class': player_class,
+                                'field_updated_class': 'text-warning fw-bold',
+                                'field_unchanged_class': '',
+                            } %}
                             <tr
                                     class="{% if player_updated %}player-updated{% else %}player-unchanged{% endif %}"
                                     style="{% if update_enabled and not player_updated %}display: none{% endif %}"
@@ -239,15 +248,15 @@
                                         {% endif %}
                                     </td>
                                 {% endif %}
-                                {{ admin_macros.extra_admin_column_cell("fide_id", player_match, admin_players_update_extra_columns)}}
-                                {% set field_id='fide_id' %}
+                                {% set field_id = 'fide_id' %}
+                                {{ admin_macros.extra_admin_column_cell(field_id, player_context, admin_players_update_extra_columns)}}
                                 {% set field_updated=player_updated and field_id in diff_field_ids %}
                                 {% set field_class=field_updated_class if field_updated else field_unchanged_class %}
                                 <td scope="col" class="text-nowrap text-start {{ player_class }} {{ field_class }}">
                                     {{ player.fide_id or '-' }}
                                 </td>
-                                {{ admin_macros.extra_admin_column_cell("title", player_match, admin_players_update_extra_columns)}}
                                 {% set field_id='title' %}
+                                {{ admin_macros.extra_admin_column_cell(field_id, player_context, admin_players_update_extra_columns)}}
                                 {% set field_updated=player_updated and field_id in diff_field_ids %}
                                 {% set field_class=field_updated_class if field_updated else field_unchanged_class %}
                                 <td
@@ -256,8 +265,8 @@
                                 >
                                     {{ match_player.title.short_name }}
                                 </th>
-                                {{ admin_macros.extra_admin_column_cell("name", player_match, admin_players_update_extra_columns)}}
                                 {% set field_id='name' %}
+                                {{ admin_macros.extra_admin_column_cell(field_id, player_context, admin_players_update_extra_columns)}}
                                 {% set field_updated=player_updated and field_id in diff_field_ids %}
                                 {% set field_class=field_updated_class if field_updated else field_unchanged_class %}
                                 <td
@@ -266,8 +275,8 @@
                                 >
                                     {{ match_player.full_name }}
                                 </td>
-                                {{ admin_macros.extra_admin_column_cell("date_of_birth", player_match, admin_players_update_extra_columns)}}
                                 {% set field_id='date_of_birth' %}
+                                {{ admin_macros.extra_admin_column_cell(field_id, player_context, admin_players_update_extra_columns)}}
                                 {% set field_updated=player_updated and field_id in diff_field_ids %}
                                 {% set field_class=field_updated_class if field_updated else field_unchanged_class %}
                                 {% set tooltip_text=_(
@@ -289,8 +298,8 @@
                                 >
                                     {{ match_player.category }}
                                 </td>
-                                {{ admin_macros.extra_admin_column_cell("gender", player_match, admin_players_update_extra_columns)}}
                                 {% set field_id='gender' %}
+                                {{ admin_macros.extra_admin_column_cell(field_id, player_context, admin_players_update_extra_columns)}}
                                 {% set field_updated=player_updated and field_id in diff_field_ids %}
                                 {% set field_class=field_updated_class if field_updated else field_unchanged_class %}
                                 <td
@@ -300,7 +309,7 @@
                                     {{ admin_macros.gender_icon(match_player.gender) }}
                                     {{ match_player.gender.short_name }}
                                 </td>
-                                {{ admin_macros.extra_admin_column_cell("rating_1", player_match, admin_players_update_extra_columns)}}
+                                {{ admin_macros.extra_admin_column_cell("rating_1", player_context, admin_players_update_extra_columns)}}
                                 {% for rt in range(1, 4) %}
                                     {% set field_id='rating_' ~ rt %}
                                     {% set field_updated=player_updated and field_id in diff_field_ids %}
@@ -316,7 +325,6 @@
                                         {% endif %}
                                     </td>
                                 {% endfor %}
-                                {{ admin_macros.extra_admin_column_cell("federation", player_match, admin_players_update_extra_columns)}}
                                 {% set field_id='federation' %}
                                 {% set field_updated=player_updated and field_id in diff_field_ids %}
                                 {% set field_class=field_updated_class if field_updated else field_unchanged_class %}
@@ -326,8 +334,8 @@
                                 >
                                     {{ match_player.federation }}
                                 </td>
-                                {{ admin_macros.extra_admin_column_cell("club", player_match, admin_players_update_extra_columns)}}
                                 {% set field_id='club' %}
+                                {{ admin_macros.extra_admin_column_cell(field_id, player_context, admin_players_update_extra_columns)}}
                                 {% set field_updated=player_updated and field_id in diff_field_ids %}
                                 {% set field_class=field_updated_class if field_updated else field_unchanged_class %}
                                 <td
@@ -336,7 +344,7 @@
                                 >
                                     {{ match_player.club.name if match_player.club.name else player.club.name }}
                                 </td>
-                                {{ admin_macros.extra_admin_column_cell("end", player_match, admin_players_update_extra_columns)}}
+                                {{ admin_macros.extra_admin_column_cell("end", player_context, admin_players_update_extra_columns)}}
                                 {% if show_tournament %}
                                     <td scope="col" class="text-nowrap text-start {{ player_class }} {{ field_class }}">
                                         {{ player.tournament.uniq_id }}


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/f86e0f24-dcd4-4989-b862-06695b06e872)
After (FFE fields grey when players are not updated and tooltip added to ffe_licence changes):
![image](https://github.com/user-attachments/assets/21a70f08-19bf-4b69-a879-280b8bea4d25)
