### PR TITLE
Only create indexes when they don't exist already

### DIFF
--- a/src/database/sqlite/fide/fide_database.py
+++ b/src/database/sqlite/fide/fide_database.py
@@ -180,12 +180,14 @@ class FideDatabase(LocalSourceDatabase):
         self.write = True
         with self:
             self.execute(
-                'CREATE INDEX `player_first_name` ON `player` (`first_name` COLLATE NOCASE)'
+                'CREATE INDEX IF NOT EXISTS `player_first_name` ON `player` (`first_name` COLLATE NOCASE)'
             )
             self.execute(
-                'CREATE INDEX `player_last_name` ON `player` (`last_name` COLLATE NOCASE)'
+                'CREATE INDEX IF NOT EXISTS `player_last_name` ON `player` (`last_name` COLLATE NOCASE)'
             )
-            self.execute('CREATE INDEX `player_fide_id` ON `player` (`fide_id`)')
+            self.execute(
+                'CREATE INDEX IF NOT EXISTS `player_fide_id` ON `player` (`fide_id`)'
+            )
             self.commit()
 
     def read_federation_ids(self) -> Iterator[str]:

--- a/src/plugins/ffe/ffe_database.py
+++ b/src/plugins/ffe/ffe_database.py
@@ -181,14 +181,16 @@ class FfeDatabase(LocalSourceDatabase):
         self.write = True
         with self:
             self.execute(
-                'CREATE INDEX `player_last_name` ON `player`(`last_name` COLLATE NOCASE)'
+                'CREATE INDEX IF NOT EXISTS `player_last_name` ON `player`(`last_name` COLLATE NOCASE)'
             )
             self.execute(
-                'CREATE INDEX `player_first_name` ON `player`(`first_name` COLLATE NOCASE)'
+                'CREATE INDEX IF NOT EXISTS `player_first_name` ON `player`(`first_name` COLLATE NOCASE)'
             )
-            self.execute('CREATE INDEX `player_fide_id` ON `player`(`fide_id`)')
             self.execute(
-                'CREATE INDEX `player_ffe_licence` ON `player`(`ffe_licence_number` COLLATE NOCASE)'
+                'CREATE INDEX IF NOT EXISTS `player_fide_id` ON `player`(`fide_id`)'
+            )
+            self.execute(
+                'CREATE INDEX IF NOT EXISTS `player_ffe_licence` ON `player`(`ffe_licence_number` COLLATE NOCASE)'
             )
             self.commit()
 


### PR DESCRIPTION
Following discussion #709, I've fixed the index creation on local player databases.

From the SQLite documentation : "If the optional IF NOT EXISTS clause is present and another index with the same name already exists, then [the CREATE INDEX command] becomes a no-op."