### PR TITLE
Convert all databases to JOURNAL mode

### DIFF
--- a/src/database/sqlite/sqlite_database.py
+++ b/src/database/sqlite/sqlite_database.py
@@ -59,7 +59,7 @@ class SQLiteDatabase:
         self.database = connect(db_url, detect_types=1, uri=True)
         self.cursor = self.database.cursor()
         if self.write:
-            self.cursor.execute('PRAGMA journal_mode=JOURNAL')
+            self.cursor.execute('PRAGMA journal_mode=DELETE')
             self.commit()
         return self
 

--- a/src/database/sqlite/sqlite_database.py
+++ b/src/database/sqlite/sqlite_database.py
@@ -59,7 +59,7 @@ class SQLiteDatabase:
         self.database = connect(db_url, detect_types=1, uri=True)
         self.cursor = self.database.cursor()
         if self.write:
-            self.cursor.execute('PRAGMA journal_mode=WAL')
+            self.cursor.execute('PRAGMA journal_mode=JOURNAL')
             self.commit()
         return self
 


### PR DESCRIPTION
Currently, all databases in write mode are opened in the Write-Ahead Logging mode for transactions.

While this is a good trade-off to get more performance out of SQLite in our case, performance considerations are not relevant to our use.

This PR opens all databases in JOURNAL transaction mode (the default).
This will convert all WAL databases to JOURNAL, and be a no-op to all future databases.

This will also shrink back the number of files to 1 per event (and configuration).