### PR TITLE
Fixed Pycharm exception on Ctrl-C

### DIFF
--- a/src/sharly_chess.py
+++ b/src/sharly_chess.py
@@ -69,4 +69,7 @@ except Exception:
     except Exception:
         print(message)
     print('An error occurred.')
-input('Press Enter to end.')
+from contextlib import suppress
+
+with suppress(UnicodeDecodeError):
+    input('Press Enter to end.')


### PR DESCRIPTION
Before, in Pycharm:
![image](https://github.com/user-attachments/assets/7d9e3569-d73f-4d7a-b89b-4d54a8badf95)
After:
![image](https://github.com/user-attachments/assets/9170d34e-4097-4045-a192-ce21a4db3ac7)
No impact on the EXE (tested).
