### PR TITLE
Execute pairings protected actions from safety modal

### DIFF
--- a/docs/technical-appendices/i18n.md
+++ b/docs/technical-appendices/i18n.md
@@ -2,12 +2,12 @@
 
 ## Locales implemented and translation status
 
-<!-- DO NOT EDIT! (START en|1793|1692|0|fr|1793|1|0) -->
+<!-- DO NOT EDIT! (START en|1787|1686|0|fr|1787|2|0) -->
 | Locale | Messages | Empty | Empty mandatory | PO file | Translators |
 |--|:--:|:--:|:--:|:--:|:--:|
-|<img src="../../src/web/static/images/locales/en.svg" style="height: 1em;"/>&nbsp;``en``&nbsp;English | 1793 | 1692 | 0 | [messages.po](../locale/en/LC_MESSAGES/messages.po) | [Timothy ARMES](https://github.com/timothyarmes) |
-|<img src="../../src/web/static/images/locales/fr.svg" style="height: 1em;"/>&nbsp;``fr``&nbsp;Français | 1793 | 1 | 0 | [messages.po](../locale/fr/LC_MESSAGES/messages.po) | [Pascal AUBRY](https://github.com/pascalaubry)<br/>[Sammy PLAT](https://github.com/Amaras) |
-Last update: 2025-06-26 20:40
+|<img src="../../src/web/static/images/locales/en.svg" style="height: 1em;"/>&nbsp;``en``&nbsp;English | 1787 | 1686 | 0 | [messages.po](../locale/en/LC_MESSAGES/messages.po) | [Timothy ARMES](https://github.com/timothyarmes) |
+|<img src="../../src/web/static/images/locales/fr.svg" style="height: 1em;"/>&nbsp;``fr``&nbsp;Français | 1787 | 2 | 0 | [messages.po](../locale/fr/LC_MESSAGES/messages.po) | [Pascal AUBRY](https://github.com/pascalaubry)<br/>[Sammy PLAT](https://github.com/Amaras) |
+Last update: 2025-06-28 11:19
 <!-- DO NOT EDIT! (END) -->
 
 Flags:

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -343,9 +343,6 @@ msgstr ""
 msgid "Allow"
 msgstr ""
 
-msgid "An error occurred."
-msgstr ""
-
 msgid "An unexpected error occurred."
 msgstr ""
 
@@ -362,9 +359,6 @@ msgid "Archived ({num})"
 msgstr ""
 
 msgid "Archived event"
-msgstr ""
-
-msgid "Are you sure you wish to proceed?"
 msgstr ""
 
 msgid "Argument --server is deprecated, ignored."
@@ -601,6 +595,9 @@ msgstr ""
 
 #, python-format
 msgid "By default: %(minutes)d minutes"
+msgstr ""
+
+msgid "By executing this operation, you are enabling an unsafe mode for this round, allowing other unsafe operations."
 msgstr ""
 
 msgid "By player"
@@ -1298,12 +1295,6 @@ msgid "Displayed round: %(round)d"
 msgstr ""
 
 msgid "Do not assign zero-point byes"
-msgstr ""
-
-msgid "Do you want to allow manual pairings for this round?"
-msgstr ""
-
-msgid "Do you want to allow the pairings to be edited for this round?"
 msgstr ""
 
 msgid "Do you want to install example event databases [{y_uc}/{n_lc}]? "
@@ -2087,9 +2078,6 @@ msgid "Gender:"
 msgstr ""
 
 msgid "General"
-msgstr ""
-
-msgid "Generate complementary pairings"
 msgstr ""
 
 msgid "Generate pairings for all the rounds of the tournament."
@@ -3156,13 +3144,10 @@ msgstr ""
 msgid "Pairings generation not allowed if there are fewer players than rounds."
 msgstr ""
 
-msgid "Pairings of round {round} generated for tournament [{tournament_uniq_id}]."
-msgstr ""
-
 msgid "Pairings should strictly abide by the rules of the tournament, and not be biased by the arbiter. For this reason, pairing manually is strongly discouraged."
 msgstr ""
 
-msgid "Pairings successfully generated!"
+msgid "Pairings successfully generated."
 msgstr ""
 
 #, python-format
@@ -5076,10 +5061,6 @@ msgstr ""
 msgid "Unpair all the rounds the tournament."
 msgstr ""
 
-#, python-format
-msgid "Unpair round #%(round)d"
-msgstr ""
-
 msgid "Unpair tournament"
 msgstr ""
 
@@ -5104,7 +5085,7 @@ msgstr ""
 msgid "Unpaired: hidden"
 msgstr ""
 
-msgid "Unpairing a published round can be very inconvenient for players. Additionally, you will lose all data associated with this round, including results and manual adjustments."
+msgid "Unpairing a published round can be very inconvenient for players. Additionally, you will lose any manual adjustments."
 msgstr ""
 
 msgid "Unpairing all the boards of this round is not allowed because the round has results."

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -343,9 +343,6 @@ msgstr "Tous les tournois"
 msgid "Allow"
 msgstr "Autoriser"
 
-msgid "An error occurred."
-msgstr "Une erreur est survenue."
-
 msgid "An unexpected error occurred."
 msgstr "Une erreur inattendue s'est produite."
 
@@ -363,9 +360,6 @@ msgstr "Archivés ({num})"
 
 msgid "Archived event"
 msgstr "Évènement archivé"
-
-msgid "Are you sure you wish to proceed?"
-msgstr "Êtes vous sûr de vouloir continuer ?"
 
 msgid "Argument --server is deprecated, ignored."
 msgstr "L'option --server est obsolète, ignorée."
@@ -602,6 +596,9 @@ msgstr "Par défaut, les tournois ne sont pas visibles sur le site de la FFE."
 #, python-format
 msgid "By default: %(minutes)d minutes"
 msgstr "Par défaut : %(minutes)d (minutes)"
+
+msgid "By executing this operation, you are enabling an unsafe mode for this round, allowing other unsafe operations."
+msgstr "En effectuant cette opération, vous activez un mode non-sécurisé pour cette ronde, autorisant ainsi d'autres opérations non-sécurisées."
 
 msgid "By player"
 msgstr "Par ordre alpha."
@@ -1299,12 +1296,6 @@ msgstr "Ronde affichée : %(round)d"
 
 msgid "Do not assign zero-point byes"
 msgstr "Ne pas marquer forfait"
-
-msgid "Do you want to allow manual pairings for this round?"
-msgstr "Voulez vous autoriser les appariements manuels pour cette ronde ?"
-
-msgid "Do you want to allow the pairings to be edited for this round?"
-msgstr "Voulez vous autoriser l'édition des appariements pour cette ronde ?"
 
 msgid "Do you want to install example event databases [{y_uc}/{n_lc}]? "
 msgstr "Voulez-vous installer des bases d'évènement d'exemple [{y_uc}/{n_lc}] ? "
@@ -2088,9 +2079,6 @@ msgstr "Genre :"
 
 msgid "General"
 msgstr "Général"
-
-msgid "Generate complementary pairings"
-msgstr "Générer les appariements complémentaires"
 
 msgid "Generate pairings for all the rounds of the tournament."
 msgstr "Générer les appariements pour toutes les rondes du tournoi."
@@ -3156,14 +3144,11 @@ msgstr "La génération d'appariements n'est pas autorisée si une ronde passée
 msgid "Pairings generation not allowed if there are fewer players than rounds."
 msgstr "La génération d'appariements n'est pas autorisée s'il y a moins de joueur·euses que de rondes."
 
-msgid "Pairings of round {round} generated for tournament [{tournament_uniq_id}]."
-msgstr "Les appariements de la ronde {round} ont été générés pour le tournoi [{tournament_uniq_id}]."
-
 msgid "Pairings should strictly abide by the rules of the tournament, and not be biased by the arbiter. For this reason, pairing manually is strongly discouraged."
 msgstr "Les appariements devraient strictement respecter les règles du tournoi, et non pas être dirigés par l'arbitre. Pour cette raison, apparier manuellement est fortement déconseillé."
 
-msgid "Pairings successfully generated!"
-msgstr "Appariements générés avec succès !"
+msgid "Pairings successfully generated."
+msgstr "Appariements générés avec succès."
 
 #, python-format
 msgid "Pairings: %(pairing_variation)s"
@@ -5076,10 +5061,6 @@ msgstr "Désapparier tous les échiquiers de cette ronde."
 msgid "Unpair all the rounds the tournament."
 msgstr "Désapparier toutes les rondes du tournoi."
 
-#, python-format
-msgid "Unpair round #%(round)d"
-msgstr "Désapparier la ronde n°%(round)d"
-
 msgid "Unpair tournament"
 msgstr "Désapparier le tournoi"
 
@@ -5104,8 +5085,8 @@ msgstr "Non apparié·es : affiché·es"
 msgid "Unpaired: hidden"
 msgstr "Non apparié·es : caché·es"
 
-msgid "Unpairing a published round can be very inconvenient for players. Additionally, you will lose all data associated with this round, including results and manual adjustments."
-msgstr "Désapparier une ronde publiée peut être très désagréable pour les joueur·euses. De plus, vous perdrez toutes les données associées à cette ronde, y compris les résultats saisis et les ajustements manuels."
+msgid "Unpairing a published round can be very inconvenient for players. Additionally, you will lose any manual adjustments."
+msgstr "Désapparier une ronde publiée peut être très désagréable pour les joueur·euses. De plus, vous perdrez tout ajustement manuel."
 
 msgid "Unpairing all the boards of this round is not allowed because the round has results."
 msgstr "Désapparier tous les échiquiers est impossible tant que la ronde a des résultats enregistrés."

--- a/src/web/controllers/admin/pairings_admin_controller.py
+++ b/src/web/controllers/admin/pairings_admin_controller.py
@@ -185,10 +185,13 @@ class PairingsAdminWebContext(BaseEventAdminWebContext):
                 if not permission_handler.validate_action(
                     action, self.round_status, self.safety_mode
                 ):
-                    SessionHandler.set_session_admin_pairings_safety_mode(
-                        request,
-                        permission_handler.required_mode(self.round_status, action),
+                    required_mode = permission_handler.required_mode(
+                        self.round_status, action
                     )
+                    SessionHandler.set_session_admin_pairings_safety_mode(
+                        request, required_mode
+                    )
+                    self.safety_mode = required_mode
                     self.requires_refresh = True
             except SharlyChessException:
                 self._redirect_error(
@@ -775,7 +778,7 @@ class PairingsAdminController(BaseEventAdminController):
         if not tournament.are_pairing_settings_valid:
             tournament.set_default_pairing_settings()
         tournament.pairing_variation.engine.generate_pairings(tournament, round_)
-        Message.success(request, _('Pairings successfully generated!'))
+        Message.success(request, _('Pairings successfully generated.'))
         return self._admin_event_pairings_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1161,7 +1164,7 @@ class PairingsAdminController(BaseEventAdminController):
         tournament.pairing_variation.engine.generate_pairings(
             tournament, web_context.admin_round
         )
-        Message.success(request, _('Pairings successfully generated!'))
+        Message.success(request, _('Pairings successfully generated.'))
         return self._admin_event_pairings_render(
             request,
             event_uniq_id=event_uniq_id,

--- a/src/web/controllers/admin/pairings_admin_controller.py
+++ b/src/web/controllers/admin/pairings_admin_controller.py
@@ -11,10 +11,10 @@ from litestar.status_codes import HTTP_200_OK
 from litestar_htmx import HTMXTemplate
 from litestar.channels import ChannelsPlugin
 
+from common.exception import SharlyChessException
 from common.i18n import _, ngettext
 from common.logger import get_logger
 from data.board import Board
-from data.event import Event
 from data.player import Player
 from data.safety_mode import RoundStatus, SafetyMode, PairingAction
 from data.tournament import Tournament
@@ -24,7 +24,7 @@ from web.controllers.admin.base_event_admin_controller import (
     BaseEventAdminWebContext,
     BaseEventAdminController,
 )
-from web.controllers.base_controller import BaseController
+from web.controllers.base_controller import WebContext
 from web.messages import Message
 from web.session import SessionHandler
 
@@ -60,13 +60,14 @@ class PairingsAdminWebContext(BaseEventAdminWebContext):
         event_uniq_id: str,
         tournament_id: int | None,
         round_: int | None,
-        board_id: int | None,
-        player_id: int | None,
+        board_id: int | None = None,
+        player_id: int | None = None,
         data: Annotated[
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ]
-        | None,
+        | None = None,
+        action: PairingAction | None = None,
     ):
         super().__init__(
             request,
@@ -144,7 +145,7 @@ class PairingsAdminWebContext(BaseEventAdminWebContext):
             self.admin_unpaired = sorted(unpaired, key=lambda p: p.last_name)
 
         self.admin_board: Board | None = None
-        if board_id is not None and self.admin_boards is not None:
+        if board_id is not None:
             self.admin_board = next(
                 (b for b in self.admin_boards if b.board_id == board_id), None
             )
@@ -175,6 +176,25 @@ class PairingsAdminWebContext(BaseEventAdminWebContext):
                 self.safety_mode = (
                     SessionHandler.get_session_admin_pairings_safety_mode(request)
                 )
+        self.requires_refresh = False
+        if action:
+            permission_handler = (
+                self.get_admin_tournament().pairing_system.permission_handler
+            )
+            try:
+                if not permission_handler.validate_action(
+                    action, self.round_status, self.safety_mode
+                ):
+                    SessionHandler.set_session_admin_pairings_safety_mode(
+                        request,
+                        permission_handler.required_mode(self.round_status, action),
+                    )
+                    self.requires_refresh = True
+            except SharlyChessException:
+                self._redirect_error(
+                    f'Action [{action}] does not exist for '
+                    f'round with status [{self.round_status}].'
+                )
 
     @property
     def template_context(self) -> dict[str, Any]:
@@ -187,12 +207,27 @@ class PairingsAdminWebContext(BaseEventAdminWebContext):
             )
             existing_actions = permission_handler.existing_actions(self.round_status)
         return super().template_context | {
+            'admin_event_tab': 'admin-event-pairings-tab',
             'admin_tournament': self.admin_tournament,
+            'admin_round': self.admin_round,
+            'admin_boards': self.admin_boards,
             'round_status': self.round_status,
             'safety_mode': self.safety_mode,
             'allowed_actions': allowed_actions,
             'existing_actions': existing_actions,
         }
+
+    def get_admin_tournament(self) -> Tournament:
+        assert self.admin_tournament is not None
+        return self.admin_tournament
+
+    def get_admin_board(self) -> Board:
+        assert self.admin_board is not None
+        return self.admin_board
+
+    def get_admin_player(self) -> Player:
+        assert self.admin_player is not None
+        return self.admin_player
 
 
 class PairingsAdminController(BaseEventAdminController):
@@ -210,14 +245,7 @@ class PairingsAdminController(BaseEventAdminController):
         errors: dict[str, str] | None = None,
         trigger_event: str | None = None,
         params: dict[str, Any] | None = None,
-        admin_pairings_show_without_results: bool | None = None,
-        protected_action: PairingAction | None = None,
     ) -> Template | ClientRedirect:
-        if admin_pairings_show_without_results is not None:
-            SessionHandler.set_session_admin_pairings_show_without_results(
-                request, admin_pairings_show_without_results
-            )
-
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -229,9 +257,6 @@ class PairingsAdminController(BaseEventAdminController):
         )
         if web_context.error:
             return web_context.error
-        if web_context.admin_event is None:
-            raise RuntimeError('admin_event not defined')
-        admin_event: Event = web_context.admin_event
         admin_tournament: Tournament | None = web_context.admin_tournament
         template_context: dict[str, Any] = cls._get_admin_event_render_context(
             web_context
@@ -277,17 +302,6 @@ class PairingsAdminController(BaseEventAdminController):
                     'modal': modal,
                     'board': web_context.admin_board,
                 }
-            case 'safety-mode':
-                assert admin_tournament is not None
-                template_context |= {
-                    'modal': modal,
-                    'action': protected_action,
-                    'required_mode': (
-                        admin_tournament.pairing_system.permission_handler.required_mode(
-                            web_context.round_status, protected_action
-                        )
-                    ),
-                }
             case 'unfinished-round':
                 template_context |= {
                     'modal': modal,
@@ -314,15 +328,10 @@ class PairingsAdminController(BaseEventAdminController):
                 }
         round_ = web_context.admin_round
         template_context |= {
-            'admin_event_tab': 'admin-event-pairings-tab',
-            'admin_event': admin_event,
-            'admin_tournament': admin_tournament,
             'admin_tournament_id': web_context.value_to_form_data(admin_tournament.id)
             if admin_tournament
             else None,
             'tournament_options': web_context.get_tournament_options(),
-            'admin_round': round_,
-            'admin_boards': web_context.admin_boards,
             'admin_filtered_boards': web_context.admin_filtered_boards,
             'admin_unpaired': web_context.admin_unpaired,
             'admin_bye_players': web_context.admin_bye_players,
@@ -368,14 +377,17 @@ class PairingsAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int | None,
         round: int | None,
-        admin_pairings_show_without_results: bool | None,
+        show_without_results: bool | None,
     ) -> Template | ClientRedirect:
+        if show_without_results is not None:
+            SessionHandler.set_session_admin_pairings_show_without_results(
+                request, show_without_results
+            )
         return self._admin_event_pairings_render(
             request,
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=round,
-            admin_pairings_show_without_results=admin_pairings_show_without_results,
         )
 
     @get(
@@ -441,20 +453,12 @@ class PairingsAdminController(BaseEventAdminController):
             tournament_id=tournament_id,
             round_=round_,
             board_id=board_id,
-            player_id=None,
-            data=None,
+            action=None if validate_result else PairingAction.RESULT_UPDATE,
         )
         if web_context.error:
             return web_context.error
-        event = web_context.admin_event
-        tournament = web_context.admin_tournament
-        board = web_context.admin_board
-        if event is None:
-            raise RuntimeError('admin_event not defined')
-        if tournament is None:
-            raise RuntimeError('admin_tournament not defined')
-        if board is None:
-            raise RuntimeError('admin_board not defined')
+        tournament = web_context.get_admin_tournament()
+        board = web_context.get_admin_board()
 
         if board.exempt:
             return self._admin_event_pairings_render(
@@ -467,7 +471,7 @@ class PairingsAdminController(BaseEventAdminController):
 
         target_board_id: int | None
         if result not in (Result.admin_imputable_results()):
-            return BaseController.redirect_error(request, f'Invalid result [{result}].')
+            return self.redirect_error(request, f'Invalid result [{result}].')
 
         if validate_result:
             if board.result != result:
@@ -478,35 +482,11 @@ class PairingsAdminController(BaseEventAdminController):
                     board_id, web_context.admin_filtered_boards
                 )
         else:
-            if not tournament.pairing_system.permission_handler.validate_action(
-                PairingAction.RESULT_UPDATE,
-                web_context.round_status,
-                web_context.safety_mode,
-            ):
-                return self._admin_event_pairings_render(
-                    request,
-                    event_uniq_id=event_uniq_id,
-                    tournament_id=tournament_id,
-                    round_=round_,
-                    modal='safety-mode',
-                    protected_action=PairingAction.RESULT_UPDATE,
-                )
             tournament.add_result(
                 board,
                 Result.from_papi_value(result),
                 web_context.admin_round,
             )
-            web_context = PairingsAdminWebContext(
-                request,
-                data=None,
-                event_uniq_id=event_uniq_id,
-                tournament_id=tournament_id,
-                round_=round_,
-                board_id=board_id,
-                player_id=None,
-            )
-            if web_context.error:
-                return web_context.error
             target_board_id = self._next_board_id(
                 board_id, web_context.admin_filtered_boards
             )
@@ -516,7 +496,7 @@ class PairingsAdminController(BaseEventAdminController):
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=round_,
-            board_id=board_id,
+            board_id=None if web_context.requires_refresh else board_id,
             trigger_event=trigger_event,
             params={'board_id': target_board_id},
         )
@@ -535,7 +515,7 @@ class PairingsAdminController(BaseEventAdminController):
     @put(
         path='/admin/pairing/set-result/'
         '{event_uniq_id:str}/{tournament_id:int}/{round:int}/{board_id:int}/{result:int}',
-        name='admin-set-result',
+        name='admin-pairings-set-result',
     )
     async def htmx_admin_set_result(
         self,
@@ -559,7 +539,7 @@ class PairingsAdminController(BaseEventAdminController):
     @delete(
         path='/admin/pairing/unpair/'
         '{event_uniq_id:str}/{tournament_id:int}/{round:int}/{board_id:int}',
-        name='admin-unpair',
+        name='admin-pairings-unpair-board',
         status_code=HTTP_200_OK,
     )
     async def htmx_admin_unpair(
@@ -576,27 +556,12 @@ class PairingsAdminController(BaseEventAdminController):
             tournament_id=tournament_id,
             round_=round,
             board_id=board_id,
-            player_id=None,
-            data=None,
+            action=PairingAction.MANUAL_UNPAIRING,
         )
-        board = web_context.admin_board
-        tournament = web_context.admin_tournament
-        assert board is not None
-        assert tournament is not None
-
-        if not tournament.pairing_system.permission_handler.validate_action(
-            PairingAction.MANUAL_UNPAIRING,
-            web_context.round_status,
-            web_context.safety_mode,
-        ):
-            return self._admin_event_pairings_render(
-                request,
-                event_uniq_id=event_uniq_id,
-                tournament_id=tournament_id,
-                round_=round,
-                modal='safety-mode',
-                protected_action=PairingAction.MANUAL_UNPAIRING,
-            )
+        if web_context.error:
+            return web_context.error
+        board = web_context.get_admin_board()
+        tournament = web_context.get_admin_tournament()
         tournament.unpair_boards([board], round)
         return self._admin_event_pairings_render(
             request,
@@ -608,7 +573,7 @@ class PairingsAdminController(BaseEventAdminController):
     @patch(
         path='/admin/pairing/permute/'
         '{event_uniq_id:str}/{tournament_id:int}/{round:int}/{board_id:int}',
-        name='admin-permute',
+        name='admin-pairings-permute',
     )
     async def htmx_admin_permute(
         self,
@@ -624,26 +589,12 @@ class PairingsAdminController(BaseEventAdminController):
             tournament_id=tournament_id,
             round_=round,
             board_id=board_id,
-            player_id=None,
-            data=None,
+            action=PairingAction.COLOR_PERMUTE,
         )
-        board = web_context.admin_board
-        tournament = web_context.admin_tournament
-        assert board is not None
-        assert tournament is not None
-        if not tournament.pairing_system.permission_handler.validate_action(
-            PairingAction.COLOR_PERMUTE,
-            web_context.round_status,
-            web_context.safety_mode,
-        ):
-            return self._admin_event_pairings_render(
-                request,
-                event_uniq_id=event_uniq_id,
-                tournament_id=tournament_id,
-                round_=round,
-                modal='safety-mode',
-                protected_action=PairingAction.COLOR_PERMUTE,
-            )
+        if web_context.error:
+            return web_context.error
+        board = web_context.get_admin_board()
+        tournament = web_context.get_admin_tournament()
         tournament.permute_board_colors(board, round)
         return self._admin_event_pairings_render(
             request,
@@ -654,7 +605,7 @@ class PairingsAdminController(BaseEventAdminController):
 
     @put(
         path='/admin/pairing/set-result-hotkey/{event_uniq_id:str}/{tournament_id:int}/{round:int}',
-        name='admin-event-set-result-hotkey',
+        name='admin-pairings-set-result-hotkey',
         data=Body(media_type=RequestEncodingType.URL_ENCODED),
     )
     async def htmx_admin_set_result_hotkey(
@@ -670,8 +621,6 @@ class PairingsAdminController(BaseEventAdminController):
     ) -> Template | ClientRedirect:
         board_id: int = int(data['board_id'])
         key: str = data['key']
-
-        result: int | None = None
         match key:
             case 'Digit0' | 'Numpad0':
                 result = Result.NO_RESULT
@@ -697,34 +646,12 @@ class PairingsAdminController(BaseEventAdminController):
             validate_result=data['validate_result'] == 'true',
         )
 
-    @delete(
-        path='/admin/pairing/delete-result/'
-        '{event_uniq_id:str}/{tournament_id:int}/{round:int}/{board_id:int}',
-        name='admin-delete-result',
-        status_code=HTTP_200_OK,
-    )
-    async def htmx_user_delete_result(
-        self,
-        request: HTMXRequest,
-        event_uniq_id: str,
-        tournament_id: int,
-        round: int,
-        board_id: int,
-    ) -> Template | ClientRedirect:
-        return self._admin_update_result(
-            request,
-            event_uniq_id=event_uniq_id,
-            tournament_id=tournament_id,
-            round_=round,
-            board_id=board_id,
-            trigger_event='close_modal',
-            result=Result.NO_RESULT.value,
-        )
-
     @patch(
-        path='/admin/pairing/set-participation/'
-        '{event_uniq_id:str}/{tournament_id:int}/{player_id:int}/{round:int}/{action:str}',
-        name='admin-set-participation',
+        path=(
+            '/admin/pairing/set-participation/{event_uniq_id:str}/'
+            '{tournament_id:int}/{player_id:int}/{round:int}/{action:str}'
+        ),
+        name='admin-pairings-set-participation',
     )
     async def htmx_admin_set_participation(
         self,
@@ -737,38 +664,20 @@ class PairingsAdminController(BaseEventAdminController):
     ) -> Template | ClientRedirect:
         web_context = PairingsAdminWebContext(
             request,
-            data=None,
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=round,
-            board_id=None,
             player_id=player_id,
+            action=(
+                PairingAction.MANUAL_PAIRING
+                if action == 'PAIR'
+                else PairingAction.BYE_UPDATE
+            ),
         )
-        tournament = web_context.admin_tournament
-        player = web_context.admin_player
-        assert tournament is not None
-        assert player is not None
-        protected_action = (
-            PairingAction.MANUAL_PAIRING
-            if action == 'PAIR'
-            else PairingAction.BYE_UPDATE
-        )
-        if not tournament.pairing_system.permission_handler.validate_action(
-            protected_action,
-            web_context.round_status,
-            web_context.safety_mode,
-        ):
-            return self._admin_event_pairings_render(
-                request,
-                event_uniq_id=event_uniq_id,
-                tournament_id=tournament_id,
-                round_=round,
-                modal='safety-mode',
-                protected_action=protected_action,
-            )
-
         if web_context.error:
             return web_context.error
+        tournament = web_context.get_admin_tournament()
+        player = web_context.get_admin_player()
 
         # If there aren't any pairings, then the round for the bye is the first round
         round_for_participation = web_context.admin_round or 1
@@ -857,27 +766,12 @@ class PairingsAdminController(BaseEventAdminController):
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=round,
-            board_id=None,
-            player_id=None,
-            data=None,
+            action=PairingAction.FULL_PAIRING,
         )
         if web_context.error:
             return web_context.error
-        tournament = web_context.admin_tournament
-        assert tournament is not None
+        tournament = web_context.get_admin_tournament()
         round_ = web_context.admin_round
-        action = PairingAction.FULL_PAIRING
-        if not tournament.pairing_system.permission_handler.validate_action(
-            action, web_context.round_status, web_context.safety_mode
-        ):
-            return self._admin_event_pairings_render(
-                request,
-                event_uniq_id=event_uniq_id,
-                tournament_id=tournament_id,
-                round_=round_,
-                modal='safety-mode',
-                protected_action=action,
-            )
         if not tournament.are_pairing_settings_valid:
             tournament.set_default_pairing_settings()
         tournament.pairing_variation.engine.generate_pairings(tournament, round_)
@@ -905,24 +799,12 @@ class PairingsAdminController(BaseEventAdminController):
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=round,
-            board_id=None,
-            player_id=None,
-            data=None,
+            action=PairingAction.PARTIAL_PAIRING,
         )
         if web_context.error:
             return web_context.error
-        tournament = web_context.admin_tournament
-        assert tournament is not None
+        tournament = web_context.get_admin_tournament()
         round_ = web_context.admin_round
-        action = PairingAction.PARTIAL_PAIRING
-        round_status = web_context.round_status
-        permission_handler = tournament.pairing_system.permission_handler
-        if not permission_handler.validate_action(
-            action, round_status, web_context.safety_mode
-        ):
-            SessionHandler.set_session_admin_pairings_safety_mode(
-                request, permission_handler.required_mode(round_status, action)
-            )
         if not tournament.are_pairing_settings_valid:
             tournament.set_default_pairing_settings()
         tournament.pairing_variation.engine.generate_pairings(tournament, round_, True)
@@ -987,8 +869,7 @@ class PairingsAdminController(BaseEventAdminController):
             player_id=None,
             data=data,
         )
-        tournament = web_context.admin_tournament
-        assert tournament is not None
+        tournament = web_context.get_admin_tournament()
         if errors := self._validate_pairing_settings(tournament, data):
             return self._admin_event_pairings_render(
                 request,
@@ -1021,7 +902,7 @@ class PairingsAdminController(BaseEventAdminController):
 
     @post(
         path='/admin/pairings/unpair/{event_uniq_id:str}/{tournament_id:int}/{round:int}',
-        name='admin-pairings-unpair',
+        name='admin-pairings-unpair-round',
     )
     async def admin_pairings_unpair(
         self,
@@ -1035,23 +916,12 @@ class PairingsAdminController(BaseEventAdminController):
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=round,
-            board_id=None,
-            player_id=None,
-            data=None,
+            action=PairingAction.FULL_UNPAIRING,
         )
         if web_context.error:
             return web_context.error
-        tournament = web_context.admin_tournament
-        boards = web_context.admin_boards
-        assert tournament is not None
-        assert boards is not None
-
-        tournament.pairing_system.permission_handler.validate_action(
-            PairingAction.FULL_UNPAIRING,
-            web_context.round_status,
-            web_context.safety_mode,
-        )
-        tournament.unpair_boards(boards, round)
+        tournament = web_context.get_admin_tournament()
+        tournament.unpair_boards(web_context.admin_boards, round)
         return self._admin_event_pairings_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1074,14 +944,10 @@ class PairingsAdminController(BaseEventAdminController):
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=None,
-            board_id=None,
-            player_id=None,
-            data=None,
         )
         if web_context.error:
             return web_context.error
-        tournament = web_context.admin_tournament
-        assert tournament is not None
+        tournament = web_context.get_admin_tournament()
         for round_ in reversed(range(1, tournament.rounds + 1)):
             boards = tournament.build_boards(round_)
             tournament.unpair_boards(boards, round_)
@@ -1093,35 +959,11 @@ class PairingsAdminController(BaseEventAdminController):
             round_=1,
         )
 
-    @post(
-        path='/admin/pairings/update-safety-mode/'
-        '{event_uniq_id:str}/{tournament_id:int}/{round:int}/{mode:str}',
-        name='admin-pairings-update-safety-mode',
-    )
-    async def admin_pairings_update_safety_mode(
-        self,
-        request: HTMXRequest,
-        event_uniq_id: str,
-        tournament_id: int,
-        round: int,
-        mode: str,
-    ) -> Template | ClientRedirect:
-        try:
-            SessionHandler.set_session_admin_pairings_safety_mode(
-                request, SafetyMode(mode)
-            )
-        except ValueError:
-            logger.error(f'Unknown safety mode [{mode}]')
-            Message.error(request, _('An error occurred.'))
-        return self._admin_event_pairings_render(
-            request,
-            event_uniq_id=event_uniq_id,
-            tournament_id=tournament_id,
-            round_=round,
-        )
-
     @get(
-        path='/admin/pairings/safety-mode-modal/{event_uniq_id:str}/{tournament_id:int}/{round:int}/{action:str}',
+        path=(
+            '/admin/pairings/safety-mode-modal/{event_uniq_id:str}/{tournament_id:int}'
+            '/{round:int}/{action:str}/{redirect_method:str}/{redirect_route:path}'
+        ),
         name='admin-pairings-safety-mode-modal',
     )
     async def admin_pairings_safety_mode_modal(
@@ -1131,22 +973,66 @@ class PairingsAdminController(BaseEventAdminController):
         tournament_id: int,
         round: int,
         action: str,
+        redirect_method: str,
+        redirect_route: str,
     ) -> Template | ClientRedirect:
-        modal: str | None = 'safety-mode'
-        protected_action: PairingAction | None = None
         try:
             protected_action = PairingAction(action)
         except ValueError:
-            logger.error(f'Unknown pairing action [{action}]')
-            Message.error(request, _('An error occurred.'))
-            modal = None
+            return self.redirect_error(request, f'Unknown pairing action [{action}]')
+        web_context = PairingsAdminWebContext(
+            request, event_uniq_id, tournament_id, round
+        )
+        if web_context.error:
+            return web_context.error
+
+        tournament = web_context.get_admin_tournament()
+        template_context = web_context.template_context
+        template_context |= {
+            'modal': 'safety-mode',
+            'action': protected_action,
+            'required_mode': (
+                tournament.pairing_system.permission_handler.required_mode(
+                    web_context.round_status, protected_action
+                )
+            ),
+            'redirect_method': redirect_method,
+            'redirect_route': redirect_route,
+        }
+        return self._admin_event_render(template_context)
+
+    @post(
+        path=[
+            '/admin/pairings/update-safety-mode/'
+            '{event_uniq_id:str}/{tournament_id:int}/{round:int}',
+            '/admin/pairings/update-safety-mode/{event_uniq_id:str}'
+            '/{tournament_id:int}/{round:int}/{mode:str}',
+        ],
+        name='admin-pairings-update-safety-mode',
+    )
+    async def admin_pairings_update_safety_mode(
+        self,
+        request: HTMXRequest,
+        data: Annotated[
+            dict[str, str],
+            Body(media_type=RequestEncodingType.URL_ENCODED),
+        ],
+        event_uniq_id: str,
+        tournament_id: int,
+        round: int,
+    ) -> Template | ClientRedirect:
+        mode = WebContext.form_data_to_str(data, 'mode') or ''
+        try:
+            SessionHandler.set_session_admin_pairings_safety_mode(
+                request, SafetyMode(mode)
+            )
+        except ValueError:
+            return self.redirect_error(request, f'Unknown safety mode [{mode}]')
         return self._admin_event_pairings_render(
             request,
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=round,
-            modal=modal,
-            protected_action=protected_action,
         )
 
     @get(
@@ -1166,18 +1052,9 @@ class PairingsAdminController(BaseEventAdminController):
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=round,
-            board_id=None,
-            player_id=None,
-            data=None,
         )
-
         if web_context.error:
             return web_context.error
-        if web_context.admin_event is None:
-            raise RuntimeError('admin_event not defined')
-        if web_context.admin_tournament is None:
-            raise RuntimeError('admin_tournament not defined')
-
         return self._admin_event_pairings_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1205,19 +1082,14 @@ class PairingsAdminController(BaseEventAdminController):
             tournament_id=tournament_id,
             player_id=player_id,
             round_=round,
-            board_id=None,
-            data=None,
         )
 
-        admin_player = web_context.admin_player
         if web_context.error:
             return web_context.error
-        if admin_player is None:
-            raise RuntimeError('admin_player not defined')
 
-        tournament = admin_player.tournament
-        assert tournament is not None
-        tournament.check_in_player(admin_player, bool(check_in))
+        player = web_context.get_admin_player()
+        tournament = web_context.get_admin_tournament()
+        tournament.check_in_player(player, bool(check_in))
         return self._admin_event_pairings_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1237,16 +1109,9 @@ class PairingsAdminController(BaseEventAdminController):
         round: int,
     ) -> Template | ClientRedirect:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
-            request,
-            event_uniq_id=event_uniq_id,
-            tournament_id=tournament_id,
-            round_=None,
-            board_id=None,
-            player_id=None,
-            data=None,
+            request, event_uniq_id, tournament_id, round
         )
-        tournament = web_context.admin_tournament
-        assert tournament is not None
+        tournament = web_context.get_admin_tournament()
         data: dict[str, str] = {}
         for setting in tournament.pairing_variation.settings:
             data |= setting.get_form_data(tournament)
@@ -1279,12 +1144,9 @@ class PairingsAdminController(BaseEventAdminController):
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=round,
-            board_id=None,
-            player_id=None,
             data=data,
         )
-        tournament = web_context.admin_tournament
-        assert tournament is not None
+        tournament = web_context.get_admin_tournament()
         if errors := self._validate_pairing_settings(tournament, data):
             return self._admin_event_pairings_render(
                 request,
@@ -1299,14 +1161,7 @@ class PairingsAdminController(BaseEventAdminController):
         tournament.pairing_variation.engine.generate_pairings(
             tournament, web_context.admin_round
         )
-        Message.success(
-            request,
-            _(
-                'Pairings of round {round} generated for tournament [{tournament_uniq_id}].'
-            ).format(
-                round=web_context.admin_round, tournament_uniq_id=tournament.uniq_id
-            ),
-        )
+        Message.success(request, _('Pairings successfully generated!'))
         return self._admin_event_pairings_render(
             request,
             event_uniq_id=event_uniq_id,

--- a/src/web/templates/admin/pairings/pairing_modal.html
+++ b/src/web/templates/admin/pairings/pairing_modal.html
@@ -7,35 +7,96 @@
                 <div class="modal-title fs-4 fw-bold">{{ _('Board %(board_number)s', board_number=board.number) }}</div>
             </div>
             <div class="modal-body">
+                {% set action = 'RESULT_UPDATE' %}
                 <div class="row d-flex align-items-center justify-content-center">
+                    {% set action_route = url_for(
+                        'admin-pairings-set-result',
+                        event_uniq_id=admin_event.uniq_id,
+                        tournament_id=admin_tournament.id,
+                        round=admin_round,
+                        board_id=board.id,
+                        result=3,
+                    ) %}
                     <button
                         class="result-button white col-3 ms-auto me-auto btn fs-6 fw-bold p-3"
                         {% if board.exempt %}
                             disabled
                         {% endif %}
-                        hx-put="{{ url_for('admin-set-result', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, board_id=board.id, result=3) }}"
+                        {% if action in allowed_actions %}
+                            hx-put="{{ action_route }}"
+                        {% else %}
+                            hx-get="{{ url_for(
+                                'admin-pairings-safety-mode-modal',
+                                event_uniq_id=admin_event.uniq_id,
+                                tournament_id=admin_tournament.id,
+                                round=admin_round,
+                                action=action,
+                                redirect_method='PUT',
+                                redirect_route=action_route,
+                            ) }}"
+                        {% endif %}
                         hx-target="body"
                         hx-indicator="#please-wait"
                     >
                         <div class="text-center">{{ _('WHITE WINS') }}<br/>1 - 0<br/><br/>{{ wp.last_name }}<br/>{{ wp.first_name }}<br/>{{ wp.rating_str }}</div>
                     </button>
+                    {% set action_route = url_for(
+                        'admin-pairings-set-result',
+                        event_uniq_id=admin_event.uniq_id,
+                        tournament_id=admin_tournament.id,
+                        round=admin_round,
+                        board_id=board.id,
+                        result=2,
+                    ) %}
                     <button
                         class="result-button draw col-3 ms-auto me-auto btn fs-6 fw-bold p-3"
                         {% if board.exempt %}
                             disabled
                         {% endif %}
-                        hx-put="{{ url_for('admin-set-result', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, board_id=board.id, result=2) }}"
+                        {% if action in allowed_actions %}
+                            hx-put="{{ action_route }}"
+                        {% else %}
+                            hx-get="{{ url_for(
+                                'admin-pairings-safety-mode-modal',
+                                event_uniq_id=admin_event.uniq_id,
+                                tournament_id=admin_tournament.id,
+                                round=admin_round,
+                                action=action,
+                                redirect_method='PUT',
+                                redirect_route=action_route,
+                            ) }}"
+                        {% endif %}
                         hx-target="body"
                         hx-indicator="#please-wait"
                     >
                         <div>{{ _('DRAW') }}<br/>½ - ½</div>
                     </button>
+                    {% set action_route = url_for(
+                        'admin-pairings-set-result',
+                        event_uniq_id=admin_event.uniq_id,
+                        tournament_id=admin_tournament.id,
+                        round=admin_round,
+                        board_id=board.id,
+                        result=1,
+                    ) %}
                     <button
                         class="result-button black col-3 ms-auto me-auto btn fs-6 fw-bold p-3"
                         {% if board.exempt %}
                             disabled
                         {% endif %}
-                        hx-put="{{ url_for('admin-set-result', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, board_id=board.id, result=1) }}"
+                        {% if action in allowed_actions %}
+                            hx-put="{{ action_route }}"
+                        {% else %}
+                            hx-get="{{ url_for(
+                                'admin-pairings-safety-mode-modal',
+                                event_uniq_id=admin_event.uniq_id,
+                                tournament_id=admin_tournament.id,
+                                round=admin_round,
+                                action=action,
+                                redirect_method='PUT',
+                                redirect_route=action_route,
+                            ) }}"
+                        {% endif %}
                         hx-target="body"
                         hx-indicator="#please-wait"
                     >
@@ -43,34 +104,94 @@
                     </button>
                 </div>
                 <div class="row d-flex align-items-center justify-content-center mt-3">
+                    {% set action_route = url_for(
+                        'admin-pairings-set-result',
+                        event_uniq_id=admin_event.uniq_id,
+                        tournament_id=admin_tournament.id,
+                        round=admin_round,
+                        board_id=board.id,
+                        result=6,
+                    ) %}
                     <button
                         class="admin-result-button white col-3 ms-auto me-auto btn fs-6 fw-bold p-3"
                         {% if board.exempt %}
                             disabled
                         {% endif %}
-                        hx-put="{{ url_for('admin-set-result', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, board_id=board.id, result=6) }}"
+                        {% if action in allowed_actions %}
+                            hx-put="{{ action_route }}"
+                        {% else %}
+                            hx-get="{{ url_for(
+                                'admin-pairings-safety-mode-modal',
+                                event_uniq_id=admin_event.uniq_id,
+                                tournament_id=admin_tournament.id,
+                                round=admin_round,
+                                action=action,
+                                redirect_method='PUT',
+                                redirect_route=action_route,
+                            ) }}"
+                        {% endif %}
                         hx-target="body"
                         hx-indicator="#please-wait"
                     >
                         <div>{{ _('WHITE WINS') }}<br/>{{ _('BY FORFEIT') }}<br/>1 - F</div>
                     </button>
+                    {% set action_route = url_for(
+                        'admin-pairings-set-result',
+                        event_uniq_id=admin_event.uniq_id,
+                        tournament_id=admin_tournament.id,
+                        round=admin_round,
+                        board_id=board.id,
+                        result=5,
+                    ) %}
                     <button
                         class="admin-result-button draw col-3 ms-auto me-auto btn fs-6 fw-bold p-3"
                         {% if board.exempt %}
                             disabled
                         {% endif %}
-                        hx-put="{{ url_for('admin-set-result', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, board_id=board.id, result=5) }}"
+                        {% if action in allowed_actions %}
+                            hx-put="{{ action_route }}"
+                        {% else %}
+                            hx-get="{{ url_for(
+                                'admin-pairings-safety-mode-modal',
+                                event_uniq_id=admin_event.uniq_id,
+                                tournament_id=admin_tournament.id,
+                                round=admin_round,
+                                action=action,
+                                redirect_method='PUT',
+                                redirect_route=action_route,
+                            ) }}"
+                        {% endif %}
                         hx-target="body"
                         hx-indicator="#please-wait"
                     >
                         <div>{{ _('DOUBLE') }}<br/>{{ _('FORFEIT') }}<br/>F - F</div>
                     </button>
+                    {% set action_route = url_for(
+                        'admin-pairings-set-result',
+                        event_uniq_id=admin_event.uniq_id,
+                        tournament_id=admin_tournament.id,
+                        round=admin_round,
+                        board_id=board.id,
+                        result=4,
+                    ) %}
                     <button
                         class="admin-result-button black col-3 ms-auto me-auto btn fs-6 fw-bold p-3"
                         {% if board.exempt %}
                             disabled
                         {% endif %}
-                         hx-put="{{ url_for('admin-set-result', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, board_id=board.id, result=4) }}"
+                        {% if action in allowed_actions %}
+                            hx-put="{{ action_route }}"
+                        {% else %}
+                            hx-get="{{ url_for(
+                                'admin-pairings-safety-mode-modal',
+                                event_uniq_id=admin_event.uniq_id,
+                                tournament_id=admin_tournament.id,
+                                round=admin_round,
+                                action=action,
+                                redirect_method='PUT',
+                                redirect_route=action_route,
+                            ) }}"
+                        {% endif %}
                         hx-target="body"
                         hx-indicator="#please-wait"
                     >
@@ -81,13 +202,33 @@
                 <hr class="my-3" />
 
                 <div class="row d-flex align-items-center justify-content-center mt-3">
+                    {% set action = 'MANUAL_UNPAIRING' %}
+                    {% set action_route = url_for(
+                        'admin-pairings-unpair-board',
+                        event_uniq_id=admin_event.uniq_id,
+                        tournament_id=admin_tournament.id,
+                        round=admin_round,
+                        board_id=board.id
+                    ) %}
                     <button
                         hx-trigger="click"
                         class="admin-result-button danger col-3 ms-auto me-auto btn fs-6 fw-bold p-3"
-                        hx-delete="{{ url_for('admin-unpair', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, board_id=board.id) }}"
+                        {% if action in allowed_actions %}
+                            hx-delete="{{ action_route }}"
+                        {% else %}
+                            hx-get="{{ url_for(
+                                'admin-pairings-safety-mode-modal',
+                                event_uniq_id=admin_event.uniq_id,
+                                tournament_id=admin_tournament.id,
+                                round=admin_round,
+                                action=action,
+                                redirect_method='DELETE',
+                                redirect_route=action_route,
+                            ) }}"
+                        {% endif %}
                         hx-target="body"
                         hx-indicator="#please-wait"
-                        {% if 'MANUAL_UNPAIRING' not in existing_actions or (not board.no_result and not board.exempt) %}
+                        {% if action not in existing_actions or (not board.no_result and not board.exempt) %}
                             disabled
                         {% endif %}
                     >
@@ -95,10 +236,31 @@
                             {{ _('UNPAIR') }}
                         </div>
                     </button>
+                    {% set action = 'RESULT_UPDATE' %}
+                    {% set action_route = url_for(
+                        'admin-pairings-set-result',
+                        event_uniq_id=admin_event.uniq_id,
+                        tournament_id=admin_tournament.id,
+                        round=admin_round,
+                        board_id=board.id,
+                        result=0,
+                    ) %}
                     <button
                         hx-trigger="click"
                         class="admin-result-button danger col-3 ms-auto me-auto btn fs-6 fw-bold p-3"
-                        hx-delete="{{ url_for('admin-delete-result', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, board_id=board.id) }}"
+                        {% if action in allowed_actions %}
+                            hx-put="{{ action_route }}"
+                        {% else %}
+                            hx-get="{{ url_for(
+                                'admin-pairings-safety-mode-modal',
+                                event_uniq_id=admin_event.uniq_id,
+                                tournament_id=admin_tournament.id,
+                                round=admin_round,
+                                action=action,
+                                redirect_method='PUT',
+                                redirect_route=action_route,
+                            ) }}"
+                        {% endif %}
                         hx-target="body"
                         hx-indicator="#please-wait"
                         {% if board.no_result or board.exempt %}
@@ -110,13 +272,33 @@
                             {{ _('CLEAR THE RESULT') }}
                         </div>
                     </button>
+                    {% set action = 'COLOR_PERMUTE' %}
+                    {% set action_route = url_for(
+                        'admin-pairings-permute',
+                        event_uniq_id=admin_event.uniq_id,
+                        tournament_id=admin_tournament.id,
+                        round=admin_round,
+                        board_id=board.id
+                    ) %}
                     <button
                         hx-trigger="click"
                         class="admin-result-button col-3 ms-auto me-auto btn fs-6 fw-bold p-3"
                         {% if board.exempt %}
                             disabled
                         {% endif %}
-                        hx-patch="{{ url_for('admin-permute', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, board_id=board.id) }}"
+                        {% if action in allowed_actions %}
+                            hx-patch="{{ action_route }}"
+                        {% else %}
+                            hx-get="{{ url_for(
+                                'admin-pairings-safety-mode-modal',
+                                event_uniq_id=admin_event.uniq_id,
+                                tournament_id=admin_tournament.id,
+                                round=admin_round,
+                                action=action,
+                                redirect_method='PATCH',
+                                redirect_route=action_route,
+                            ) }}"
+                        {% endif %}
                         hx-target="body"
                         hx-indicator="#please-wait"
                     >
@@ -133,7 +315,7 @@
                     data-bs-dismiss="modal"
                 >
                     <i class="bi-x-circle-fill"></i>
-                    {{ _('Cancel') }}
+                    {{ _('Close') }}
                 </button>
             </div>
         </div>

--- a/src/web/templates/admin/pairings/safety_mode_modal.html
+++ b/src/web/templates/admin/pairings/safety_mode_modal.html
@@ -81,40 +81,24 @@
                 <i class="bi-x-circle-fill pe-1"></i>
                 {{ _('Cancel') }}
             </button>
-            {% if action == 'FULL_UNPAIRING' %}
-                <button
-                    class="btn btn-primary text-nowrap"
-                    hx-post="{{ url_for('admin-pairings-unpair', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round) }}"
-                    hx-target="body"
-                    hx-indicator="#please-wait"
-                >
-                    {{ _('Unpair round #%(round)d', round=admin_round) }}
-                </button>
-            {% elif action == 'PARTIAL_PAIRING' %}
-                <button
-                    class="btn btn-primary text-nowrap"
-                    hx-post="{{ url_for('admin-generate-round-partial-pairings', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round) }}"
-                    hx-target="body"
-                    hx-indicator="#please-wait"
-                >
-                    <i class="bi-shuffle pe-1"></i>
-                    {{ _('Generate complementary pairings') }}
-                </button>
-            {% else %}
-                <button
-                    class="btn btn-primary text-nowrap"
-                    hx-post="{{ url_for('admin-pairings-update-safety-mode', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, mode=required_mode) }}"
-                    hx-target="body"
-                    hx-indicator="#please-wait"
-                >
-                        <i class="bi-check-circle-fill pe-1"></i>
-                        {% if required_mode == 'FIDE_INCOMPATIBLE' %}
-                            {{ _('Allow') }}
-                        {% else %}
-                            {{ _('Proceed') }}
-                        {% endif %}
-                </button>
-            {% endif %}
+            <button
+                class="btn btn-primary text-nowrap"
+                {% if redirect_method == 'POST' %}
+                    hx-post="{{ redirect_route }}"
+                {% elif redirect_method == 'PATCH' %}
+                    hx-patch="{{ redirect_route }}"
+                {% elif redirect_method == 'PUT' %}
+                    hx-put="{{ redirect_route }}"
+                {% elif redirect_method == 'DELETE' %}
+                    hx-delete="{{ redirect_route }}"
+                {% endif %}
+                hx-vals='{"mode": "{{ required_mode }}"}'
+                hx-target="body"
+                hx-indicator="#please-wait"
+            >
+                <i class="bi-check-circle-fill pe-1"></i>
+                {{ _('Proceed') }}
+            </button>
         </div>
     </div>
 </div>

--- a/src/web/templates/admin/pairings/safety_mode_modal.html
+++ b/src/web/templates/admin/pairings/safety_mode_modal.html
@@ -15,8 +15,7 @@
                 <p>
                     {{ _(
                         'Unpairing a published round can be very inconvenient for players. '
-                        'Additionally, you will lose all data associated with this round, '
-                        'including results and manual adjustments.'
+                        'Additionally, you will lose any manual adjustments.'
                     ) }}
                 </p>
                 <p>
@@ -33,9 +32,6 @@
                         'pairing manually is strongly discouraged.'
                     ) }}
                 </p>
-                <h6>
-                    {{ _('Do you want to allow manual pairings for this round?') }}
-                </h6>
             {% else %}
                 <h6>
                     {{
@@ -53,9 +49,6 @@
                             'and solely for the computation of the FIDE ratings.'
                         ) }}
                     </p>
-                    <h6>
-                        {{ _('Do you want to allow the pairings to be edited for this round?') }}
-                    </h6>
                 {% elif required_mode == 'UNSAFE' %}
                     <p>
                         {% if round_status == 'PREVIOUS' %}
@@ -70,11 +63,14 @@
                             ) }}
                         {% endif %}
                     </p>
-                    <h6>
-                        {{ _('Are you sure you wish to proceed?') }}
-                    </h6>
                 {% endif %}
             {% endif %}
+            <p>
+                {{ _(
+                    'By executing this operation, you are enabling an unsafe mode '
+                    'for this round, allowing other unsafe operations.'
+                ) }}
+            </p>
         </div>
         <div class="modal-footer">
             <button class="btn btn-secondary text-nowrap" data-bs-dismiss="modal">

--- a/src/web/templates/admin/pairings/swiss_pairing_buttons.html
+++ b/src/web/templates/admin/pairings/swiss_pairing_buttons.html
@@ -5,7 +5,7 @@
         hx-swap-oob="true"
     {% endif %}
 >
-    {% if 'FULL_PAIRING' in existing_actions %}
+    {% if 'FULL_PAIRING' in allowed_actions %}
         <div
             {{ macros.tooltip_attributes(
                 'info',
@@ -47,6 +47,12 @@
         </div>
     {% endif %}
     {% set action = 'PARTIAL_PAIRING' %}
+    {% set action_route = url_for(
+        'admin-generate-round-partial-pairings',
+        event_uniq_id=admin_event.uniq_id,
+        tournament_id=admin_tournament.id,
+        round=admin_round,
+    ) %}
     {% if action in existing_actions and admin_tournament.is_round_partially_paired(admin_round) %}
         <div
             {{ macros.tooltip_attributes(
@@ -59,12 +65,7 @@
             <button
                 class="btn btn-outline-primary text-nowrap"
                 {% if action in allowed_actions %}
-                    hx-post="{{ url_for(
-                        'admin-generate-round-partial-pairings',
-                        event_uniq_id=admin_event.uniq_id,
-                        tournament_id=admin_tournament.id,
-                        round=admin_round,
-                    ) }}"
+                    hx-post="{{ action_route }}"
                 {% else %}
                     hx-get="{{ url_for(
                         'admin-pairings-safety-mode-modal',
@@ -72,6 +73,8 @@
                         tournament_id=admin_tournament.id,
                         round=admin_round,
                         action=action,
+                        redirect_method='POST',
+                        redirect_route=action_route,
                     ) }}"
                     hx-trigger="click"
                     preload
@@ -90,6 +93,12 @@
         </div>
     {% endif %}
     {% set action='FULL_UNPAIRING' %}
+    {% set action_route = url_for(
+        'admin-pairings-unpair-round',
+        event_uniq_id=admin_event.uniq_id,
+        tournament_id=admin_tournament.id,
+        round=admin_round,
+    ) %}
     {% if action in existing_actions %}
         {% set allowed=not admin_tournament.round_has_result(admin_round) %}
         <div {{ macros.tooltip_attributes(
@@ -105,19 +114,16 @@
                     disabled
                 {% else %}
                     {% if action in allowed_actions %}
-                        hx-post="{{ url_for(
-                            'admin-pairings-unpair',
-                            event_uniq_id=admin_event.uniq_id,
-                            tournament_id=admin_tournament.id,
-                            round=admin_round
-                        ) }}"
+                        hx-post="{{ action_route }}"
                     {% else %}
                         hx-get="{{ url_for(
                             'admin-pairings-safety-mode-modal',
                             event_uniq_id=admin_event.uniq_id,
                             tournament_id=admin_tournament.id,
                             round=admin_round,
-                            action=action
+                            action=action,
+                            redirect_method='POST',
+                            redirect_route=action_route,
                         ) }}"
                         hx-trigger="click"
                         preload

--- a/src/web/templates/admin/pairings/tab.html
+++ b/src/web/templates/admin/pairings/tab.html
@@ -62,7 +62,7 @@
                     {% endif %}
                     {% include admin_tournament.pairing_system.pairing_buttons_template %}
                     {% if admin_boards %}
-                        {% with name='admin_pairings_show_without_results', wo_results=admin_pairings_show_without_results %}
+                        {% with name='show_without_results', wo_results=admin_pairings_show_without_results %}
                             <div class="btn-group">
                                 <button
                                     class="btn btn-outline-primary {% if not wo_results %}active{% endif %}"
@@ -103,50 +103,63 @@
                                     ) }}
                                 ></i>
                             </div>
-                            {% with action='RESULT_UPDATE' %}
-                                <div class="btn-group">
-                                    <span
-                                        {{ macros.tooltip_attributes(
-                                            'info', _('Overwrite the result of the pairing when using the keyboard shortcuts.'), 'top'
-                                        ) }}
-                                    >
-                                        <button
-                                            id="overwrite-mode"
-                                            {% if action in allowed_actions %}
-                                                class="btn btn-outline-primary active"
-                                                hx-on:click="$(this).addClass('active'); $('button[id=\'highlight-mode\']').removeClass('active');"
-                                            {% else %}
-                                                class="btn btn-outline-primary"
-                                                hx-get="{{ url_for('admin-pairings-safety-mode-modal', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, action=action) }}"
-                                                hx-trigger="click"
-                                                data-bs-toggle="modal"
-                                                data-bs-target="#modal-wrapper"
-                                                hx-indicator="#please-wait"
-                                                hx-target="body"
-                                                preload
-                                            {% endif %}
-                                        >
-                                            {{ _('Overwrite') }}
-                                        </button>
-                                    </span>
+                            {% set action = 'RESULT_UPDATE' %}
+                            <div class="btn-group">
+                                <span
+                                    {{ macros.tooltip_attributes(
+                                        'info', _('Overwrite the result of the pairing when using the keyboard shortcuts.'), 'top'
+                                    ) }}
+                                >
+
                                     <button
-                                        id="highlight-mode"
-                                        class="btn btn-outline-primary {% if action not in allowed_actions %}active{% endif %}"
-                                        hx-on:click="$(this).addClass('active'); $('button[id=\'overwrite-mode\']').removeClass('active');"
-                                        {{ macros.tooltip_attributes(
-                                            'info',
-                                            _(
-                                                'Highlights the row if the new result is different '
-                                                'when using the keyboard shortcuts '
-                                                '(useful when re-entering all the results for verification).'
-                                            ),
-                                            'top'
-                                        ) }}
+                                        id="overwrite-mode"
+                                        {% if action in allowed_actions %}
+                                            class="btn btn-outline-primary active"
+                                            hx-on:click="$(this).addClass('active'); $('button[id=\'highlight-mode\']').removeClass('active');"
+                                        {% else %}
+                                            class="btn btn-outline-primary"
+                                            hx-get="{{ url_for(
+                                                'admin-pairings-safety-mode-modal',
+                                                event_uniq_id=admin_event.uniq_id,
+                                                tournament_id=admin_tournament.id,
+                                                round=admin_round,
+                                                action=action,
+                                                redirect_method='POST',
+                                                redirect_route=url_for(
+                                                    'admin-pairings-update-safety-mode',
+                                                    event_uniq_id=admin_event.uniq_id,
+                                                    tournament_id=admin_tournament.id,
+                                                    round=admin_round,
+                                                ),
+                                            ) }}"
+                                            hx-trigger="click"
+                                            data-bs-toggle="modal"
+                                            data-bs-target="#modal-wrapper"
+                                            hx-indicator="#please-wait"
+                                            hx-target="body"
+                                            preload
+                                        {% endif %}
                                     >
-                                        {{ _('Highlight') }}
+                                        {{ _('Overwrite') }}
                                     </button>
-                                </div>
-                            {% endwith %}
+                                </span>
+                                <button
+                                    id="highlight-mode"
+                                    class="btn btn-outline-primary {% if action not in allowed_actions %}active{% endif %}"
+                                    hx-on:click="$(this).addClass('active'); $('button[id=\'overwrite-mode\']').removeClass('active');"
+                                    {{ macros.tooltip_attributes(
+                                        'info',
+                                        _(
+                                            'Highlights the row if the new result is different '
+                                            'when using the keyboard shortcuts '
+                                            '(useful when re-entering all the results for verification).'
+                                        ),
+                                        'top'
+                                    ) }}
+                                >
+                                    {{ _('Highlight') }}
+                                </button>
+                            </div>
                         </div>
                     {% endif %}
                 </div>
@@ -259,7 +272,12 @@
             const { code, pairing_board_id: board_id } = keyQueue.shift();
 
             htmx.ajax('PUT',
-                "{{ url_for('admin-event-set-result-hotkey', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round) }}",
+                "{{ url_for(
+                    'admin-pairings-set-result-hotkey',
+                    event_uniq_id=admin_event.uniq_id,
+                    tournament_id=admin_tournament.id,
+                    round=admin_round
+                ) }}",
                 {
                     target: "body",
                     swap: "outerHTML",

--- a/src/web/templates/admin/pairings/unpaired_player_modal.html
+++ b/src/web/templates/admin/pairings/unpaired_player_modal.html
@@ -11,27 +11,88 @@
             </div>
             <div class="modal-body">
                 <div class="d-flex flex-column align-items-center justify-content-center gap-4">
+                    {% set action = 'BYE_UPDATE' %}
                     {% if not pairing.zero_point_bye %}
+                        {% set action_route = url_for(
+                            'admin-pairings-set-participation',
+                            event_uniq_id=admin_event.uniq_id,
+                            tournament_id=admin_tournament.id,
+                            round=admin_round,
+                            player_id=player.id,
+                            action='ZPB'
+                        ) %}
                         <button
                             class="btn btn-outline-primary w-100"
-                            hx-patch="{{ url_for('admin-set-participation', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, player_id=player.id, action='ZPB') }}"
+                            {% if action in allowed_actions %}
+                                hx-patch="{{ action_route }}"
+                            {% else %}
+                                hx-get="{{ url_for(
+                                    'admin-pairings-safety-mode-modal',
+                                    event_uniq_id=admin_event.uniq_id,
+                                    tournament_id=admin_tournament.id,
+                                    round=admin_round,
+                                    action=action,
+                                    redirect_method='PATCH',
+                                    redirect_route=action_route,
+                                ) }}"
+                            {% endif %}
                             hx-target="body"
                             hx-indicator="#please-wait"
                         >
                             {{ _('Zero-Point Bye') }}
                         </button>
+                        {% set action_route = url_for(
+                            'admin-pairings-set-participation',
+                            event_uniq_id=admin_event.uniq_id,
+                            tournament_id=admin_tournament.id,
+                            round=admin_round,
+                            player_id=player.id,
+                            action='LEAVE'
+                        ) %}
                         <button
                             class="btn btn-outline-primary w-100"
-                            hx-patch="{{ url_for('admin-set-participation', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, player_id=player.id, action='LEAVE') }}"
+                            {% if action in allowed_actions %}
+                                hx-patch="{{ action_route }}"
+                            {% else %}
+                                hx-get="{{ url_for(
+                                    'admin-pairings-safety-mode-modal',
+                                    event_uniq_id=admin_event.uniq_id,
+                                    tournament_id=admin_tournament.id,
+                                    round=admin_round,
+                                    action=action,
+                                    redirect_method='PATCH',
+                                    redirect_route=action_route,
+                                ) }}"
+                            {% endif %}
                             hx-target="body"
                             hx-indicator="#please-wait"
                         >
                             {{ _('Withdraw from tournament') }}
                         </button>
                     {% else %}
+                        {% set action_route = url_for(
+                            'admin-pairings-set-participation',
+                            event_uniq_id=admin_event.uniq_id,
+                            tournament_id=admin_tournament.id,
+                            round=admin_round,
+                            player_id=player.id,
+                            action='RETURN'
+                        ) %}
                         <button
                             class="btn btn-outline-primary w-100"
-                            hx-patch="{{ url_for('admin-set-participation', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, player_id=player.id, action='RETURN') }}"
+                            {% if action in allowed_actions %}
+                                hx-patch="{{ action_route }}"
+                            {% else %}
+                                hx-get="{{ url_for(
+                                    'admin-pairings-safety-mode-modal',
+                                    event_uniq_id=admin_event.uniq_id,
+                                    tournament_id=admin_tournament.id,
+                                    round=admin_round,
+                                    action=action,
+                                    redirect_method='PATCH',
+                                    redirect_route=action_route,
+                                ) }}"
+                            {% endif %}
                             hx-target="body"
                             hx-indicator="#please-wait"
                         >
@@ -43,9 +104,29 @@
                         </button>
                     {% endif %}
                     {% if pairing.half_point_bye %}
+                        {% set action_route = url_for(
+                            'admin-pairings-set-participation',
+                            event_uniq_id=admin_event.uniq_id,
+                            tournament_id=admin_tournament.id,
+                            round=admin_round,
+                            player_id=player.id,
+                            action='RETURN'
+                        ) %}
                         <button
                             class="btn btn-outline-primary w-100"
-                            hx-patch="{{ url_for('admin-set-participation', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, player_id=player.id, action='RETURN') }}"
+                            {% if action in allowed_actions %}
+                                hx-patch="{{ action_route }}"
+                            {% else %}
+                                hx-get="{{ url_for(
+                                    'admin-pairings-safety-mode-modal',
+                                    event_uniq_id=admin_event.uniq_id,
+                                    tournament_id=admin_tournament.id,
+                                    round=admin_round,
+                                    action=action,
+                                    redirect_method='PATCH',
+                                    redirect_route=action_route,
+                                ) }}"
+                            {% endif %}
                             hx-target="body"
                             hx-indicator="#please-wait"
                         >
@@ -60,12 +141,32 @@
                                 {{ macros.tooltip_attributes('info', _('Bye limit (%(limit)d) is already reached for this tournament.', limit=player.tournament.max_byes), 'top') }}
                             {% endif %}
                         >
+                            {% set action_route = url_for(
+                                'admin-pairings-set-participation',
+                                event_uniq_id=admin_event.uniq_id,
+                                tournament_id=admin_tournament.id,
+                                round=admin_round,
+                                player_id=player.id,
+                                action='HPB'
+                            ) %}
                             <button
                                 class="btn btn-outline-primary w-100"
+                                {% if action in allowed_actions %}
+                                    hx-patch="{{ action_route }}"
+                                {% else %}
+                                    hx-get="{{ url_for(
+                                        'admin-pairings-safety-mode-modal',
+                                        event_uniq_id=admin_event.uniq_id,
+                                        tournament_id=admin_tournament.id,
+                                        round=admin_round,
+                                        action=action,
+                                        redirect_method='PATCH',
+                                        redirect_route=action_route,
+                                    ) }}"
+                                {% endif %}
                                 {% if no_bye_possible or not hpb_possible %}
                                     disabled
                                 {% endif %}
-                                hx-patch="{{ url_for('admin-set-participation', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, player_id=player.id, action='HPB') }}"
                                 hx-target="body"
                                 hx-indicator="#please-wait"
                             >
@@ -73,7 +174,16 @@
                             </button>
                         </span>
                     {% endif %}
-                    {% if 'MANUAL_PAIRING' in existing_actions %}
+                    {% set action = 'MANUAL_PAIRING' %}
+                    {% set action_route = url_for(
+                        'admin-pairings-set-participation',
+                        event_uniq_id=admin_event.uniq_id,
+                        tournament_id=admin_tournament.id,
+                        round=admin_round,
+                        player_id=player.id,
+                        action='PAIR'
+                    ) %}
+                    {% if action in existing_actions %}
                         <span
                             class="w-100"
                             {% if admin_tournament.check_in_open %}
@@ -82,7 +192,19 @@
                         >
                             <button
                                 class="btn btn-outline-primary w-100 {% if exempt_player %}d-flex flex-column align-items-center gap-1{% endif %}"
-                                hx-patch="{{ url_for('admin-set-participation', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, round=admin_round, player_id=player.id, action='PAIR') }}"
+                                {% if action in allowed_actions %}
+                                    hx-patch="{{ action_route }}"
+                                {% else %}
+                                    hx-get="{{ url_for(
+                                        'admin-pairings-safety-mode-modal',
+                                        event_uniq_id=admin_event.uniq_id,
+                                        tournament_id=admin_tournament.id,
+                                        round=admin_round,
+                                        action=action,
+                                        redirect_method='PATCH',
+                                        redirect_route=action_route,
+                                    ) }}"
+                                {% endif %}
                                 hx-target="body"
                                 hx-indicator="#please-wait"
                                 {% if admin_tournament.check_in_open %}


### PR DESCRIPTION
Closes #775 

Every feature of the pairings tab potentially impacted, review requires extra checking (I've tried to test everything myself but better be careful especially just before release)