### PR TITLE
Fix foreign key pointers

### DIFF
--- a/src/database/sqlite/event/migrations/m029_fix_foreign_key_pointers.py
+++ b/src/database/sqlite/event/migrations/m029_fix_foreign_key_pointers.py
@@ -1,0 +1,17 @@
+from database.sqlite.migration import BaseMigration
+
+
+class Migration(BaseMigration):
+    def forward(self):
+        self.database.execute('ALTER TABLE `tourament` RENAME TO `tournament_copy`')
+        self.database.execute('ALTER TABLE `tourament_copy` RENAME TO `tournament`')
+
+    def backward(self):
+        # NOTE(Amaras): The database is in a saner state after the migration, which does not
+        # change anything to the behaviour (apart form forgeing keys).
+        # The best thing to do is to make the backwards migration a no-op.
+        # However, note that downgraded databases will not be identical
+        # to databases that did not go through the migration.
+        # This may cause problems if there are behaviours relying on foreign
+        # keys being wrong
+        pass


### PR DESCRIPTION
Up until now, foreign keys pointing to the `tournament` table actually point to `tournament_copy`.

This PR adds a DB migration to make sure all the foreign keys point to the correct table.