### PR TITLE
Fix default FFE ID being None

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
   "colorama ~= 0.4.6",
   "colorlog ~= 6.9.0",
   "cryptography ~= 44.0.0",
-  "python-dateutil ~= 2.9.0",
   "httpdate ~= 1.2.0",
   "iso4217parse ~= 0.6.2",
   "Jinja2 ~= 3.1.5",

--- a/src/plugins/ffe/ffe.py
+++ b/src/plugins/ffe/ffe.py
@@ -9,7 +9,6 @@ from types import ModuleType
 from typing import Any, TYPE_CHECKING, Iterable, Optional, override
 
 from litestar.plugins.htmx import HTMXRequest
-from dateutil.relativedelta import relativedelta
 from packaging.version import Version
 
 from common.exception import SharlyChessException
@@ -46,7 +45,7 @@ from plugins.ffe.ffe_entity import (
 from plugins.ffe.ffe_event_controller import FfeAdminEventController
 from plugins.ffe.ffe_session_handler import FFESessionHandler
 from plugins.ffe.ffe_tie_breaks import papi_performance_bonus
-from plugins.ffe.utils import FFEUtils, PlayerFFELicence
+from plugins.ffe.utils import FFEUtils, PlayerFFELicence, FFE_EPOCH
 from plugins.hookspec import ExtraAdminColumn, hookimpl, ExtraColumn
 from plugins.migration import PluginMigrationManager
 from plugins.utils import Plugin, PluginNavBarItem, PluginUtils
@@ -189,8 +188,10 @@ class FfePlugin(Plugin):
             'RefFFE': self.get_data(
                 pd,
                 'ffe_id',
-                (datetime.now() - relativedelta(years=30)),  # like Papi does :-(
-            ),
+            )
+            or int(
+                (datetime.now() - FFE_EPOCH).total_seconds()
+            ),  # NOTE(Amaras): the Papi epoch starts on 2000-01-01
             'AffType': (
                 self.get_data(pd, 'ffe_licence').to_papi_value
                 if self.get_data(pd, 'ffe_licence')

--- a/src/plugins/ffe/utils.py
+++ b/src/plugins/ffe/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import IntEnum
 from functools import partial
 from typing import Self
@@ -14,6 +15,7 @@ get_data = partial(PluginUtils.get_plugin_data, PLUGIN_NAME)
 
 FFE_MIN_UPLOAD_DELAY = 3
 FFE_DEFAULT_UPLOAD_DELAY = 3
+FFE_EPOCH = datetime(2000, 1, 1)
 
 
 class FFEUtils:


### PR DESCRIPTION
When creating a player from the form, we needed to create a default "RefFFE" value.

However, since all `Player` instances have a `ffe_id` field defaulting to `None`, this value was simply not set in the DB.

As a consequence, this created a problem when modifying players which had a NULL "RefFFE" field in Papi, since there is a UNIQUE index on that field.

Since the `dateutil` dependency was only used in the modified file, and I removed that use, I also removed the depencency from the `pyproject.toml`

- **Change the default RefFFE**
- **Remove unused dateutil dependency**
