### PR TITLE
Fix default RefFFE not being set correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
   "colorama ~= 0.4.6",
   "colorlog ~= 6.9.0",
   "cryptography ~= 44.0.0",
-  "python-dateutil ~= 2.9.0",
   "httpdate ~= 1.2.0",
   "Jinja2 ~= 3.1.5",
   "litestar ~= 2.14.0",

--- a/src/plugins/ffe/ffe.py
+++ b/src/plugins/ffe/ffe.py
@@ -9,7 +9,6 @@ from types import ModuleType
 from typing import Any, TYPE_CHECKING, Iterable, Optional, override
 
 from litestar.plugins.htmx import HTMXRequest
-from dateutil.relativedelta import relativedelta
 from packaging.version import Version
 
 from common.exception import SharlyChessException
@@ -24,7 +23,7 @@ from data.tie_breaks import TieBreak
 from database.sqlite.sqlite_database import SQLiteDatabase
 from plugins.ffe.ffe_background_uploader import FfeBackgroundUploader
 from plugins.ffe.ffe_sql_server import FFESqlServer
-from plugins.ffe.utils import FFE_DEFAULT_UPLOAD_DELAY, FFE_MIN_UPLOAD_DELAY
+from plugins.ffe.utils import FFE_DEFAULT_UPLOAD_DELAY, FFE_EPOCH, FFE_MIN_UPLOAD_DELAY
 from plugins.ffe.ffe_tournament_controller import FfeAdminTournamentController
 from utils.enum import PlayerCategory, PlayerRatingType, ScreenType, TournamentRating
 from data.player import Player, PlayerRating
@@ -183,7 +182,11 @@ class FfePlugin(Plugin):
             'RefFFE': self.get_data(
                 pd,
                 'ffe_id',
-                (datetime.now() - relativedelta(years=30)),  # like Papi does :-(
+            )
+            or int(
+                (
+                    datetime.now() - FFE_EPOCH
+                ).total_seconds(),  # NOTE(Amaras): Papi epoch starts on 2000-01-01
             ),
             'AffType': (
                 self.get_data(pd, 'ffe_licence').to_papi_value

--- a/src/plugins/ffe/utils.py
+++ b/src/plugins/ffe/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import IntEnum
 from functools import partial
 from typing import Self
@@ -14,6 +15,7 @@ get_data = partial(PluginUtils.get_plugin_data, PLUGIN_NAME)
 
 FFE_MIN_UPLOAD_DELAY = 3
 FFE_DEFAULT_UPLOAD_DELAY = 3
+FFE_EPOCH = datetime(2000, 1, 1)
 
 
 class FFEUtils:


### PR DESCRIPTION
This caused problems when creating players from scratch.

See #796 for the same problem's fix in 2.8