### PR TITLE
Require full tests before release

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -9,7 +9,10 @@ permissions:
   contents: write
 
 jobs:
+  tests:
+    uses: ./.github/workflows/full_tests.yml
   export-sharly-chess:
+    needs: tests
     runs-on: windows-latest
     steps:
       # get the current date to set the title of the release

--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -8,9 +8,7 @@ permissions:
 on:
     # schedule:
     #     - cron: '0 2 * * *'  # 2 AM UTC
-    push:
-        tags:
-            - "*"
+    workflow_call:
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Since we now have automated tests, I have created a workflow dependency chain.

The export job cannot run until the full tests have succeeded, ensuring the export is in a relatively sane state, even if the tests cannot catch everything.

If there is a need to create a release without the tests succeeding, the release MUST be created manually.