### PR TITLE
Fix the abstraction level of the Client class

### DIFF
--- a/src/data/auth/client.py
+++ b/src/data/auth/client.py
@@ -12,6 +12,7 @@ from data.auth.entities import (
 )
 from data.auth.managers import RoleManager
 from data.auth.roles import Role
+from utils.enum import Result
 from web.session import SessionHandler
 
 if TYPE_CHECKING:
@@ -236,6 +237,10 @@ class Client:
                 manageable_roles |= role.manageable_roles()
         return [role for role in RoleManager.objects() if role in manageable_roles]
 
+    def can_manage_role(self, role: Role) -> bool:
+        """Returns True if the client can manage the role."""
+        return role in self.manageable_roles
+
     @property
     def can_manage_accounts(self) -> bool:
         """Returns true if the client can manage (add/update/delete) accounts
@@ -254,6 +259,10 @@ class Client:
             if all(role in self.manageable_roles for role in account.roles)
         ]
 
+    def can_manage_account(self, account_id: int) -> bool:
+        """Returns True if the client can mange the account."""
+        return account_id in self.manageable_account_ids
+
     @property
     def can_manage_devices(self) -> bool:
         """Returns true if the client can manage (add/update/delete) accounts."""
@@ -269,6 +278,11 @@ class Client:
             for device in self.event.devices_by_id.values()
             if all(role in self.manageable_roles for role in device.roles)
         ]
+
+    def can_manage_device(self, device_id: int) -> bool:
+        """Returns true if the client can manage the device (the client must
+        be able to manage all the roles of the device)."""
+        return device_id in self.manageable_device_ids
 
     @property
     def can_manage_roles(self) -> bool:
@@ -335,12 +349,11 @@ class Client:
         (including with local or remote databases)."""
         return AuthAction.UPDATE_PLAYERS in self.allowed_actions
 
-    @property
-    def tournament_ids_allowing_update_players_history(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        update the players' history (byes).
-        See also tournament_ids_allowing_set_xxx_point_bye()."""
-        return self.tournament_ids_allowing_action(AuthAction.UPDATE_PLAYERS_HISTORY)
+    def can_update_players_history(self, tournament_id: int) -> bool:
+        """Returns True if the client can update the players's history."""
+        return self._action_allowed_for_tournament(
+            AuthAction.UPDATE_PLAYERS_HISTORY, tournament_id
+        )
 
     @property
     def can_delete_players(self) -> bool:
@@ -357,10 +370,11 @@ class Client:
         """Returns true if the client can open and close the check-in."""
         return AuthAction.OPEN_CLOSE_CHECK_IN in self.allowed_actions
 
-    @property
-    def tournament_ids_allowing_check_in_players(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can check-in players."""
-        return self.tournament_ids_allowing_action(AuthAction.CHECK_IN_PLAYERS)
+    def can_check_in_players(self, tournament_id: int) -> bool:
+        """Returns True if the client can check-in players for a tournament."""
+        return self._action_allowed_for_tournament(
+            AuthAction.CHECK_IN_PLAYERS, tournament_id
+        )
 
     # ---------------------------------------------------------------------------------
     # Pairings
@@ -371,91 +385,91 @@ class Client:
         """Returns true if the client can access the Pairings tab."""
         return AuthAction.VIEW_PAIRINGS_TAB in self.allowed_actions
 
-    @property
-    def tournament_ids_allowing_use_pairing_engine(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        use the pairing engine."""
-        return self.tournament_ids_allowing_action(AuthAction.USE_PAIRING_ENGINE)
+    def can_use_paring_engine(self, tournament_id: int) -> bool:
+        """Returns True if the client can use the pairing engine for a tournament."""
+        return self._action_allowed_for_tournament(
+            AuthAction.USE_PAIRING_ENGINE, tournament_id
+        )
 
-    @property
-    def tournament_ids_allowing_manually_pair_players(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        use manually pair players."""
-        return self.tournament_ids_allowing_action(AuthAction.MANUALLY_PAIR_PLAYERS)
+    def can_manually_pair_players(self, tournament_id: int) -> bool:
+        """Returns True if the client can manually pair players for a tournament."""
+        return self._action_allowed_for_tournament(
+            AuthAction.MANUALLY_PAIR_PLAYERS, tournament_id
+        )
 
-    @property
-    def tournament_ids_allowing_unpair_round(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        unpair all the boards of a round."""
-        return self.tournament_ids_allowing_action(AuthAction.UNPAIR_ROUND)
+    def can_unpair_round(self, tournament_id: int) -> bool:
+        """Returns True if the client can unpair all the boards of a round."""
+        return self._action_allowed_for_tournament(
+            AuthAction.UNPAIR_ROUND, tournament_id
+        )
 
-    @property
-    def tournament_ids_allowing_unpair_board(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        (manually) unpair boards."""
-        return self.tournament_ids_allowing_action(AuthAction.UNPAIR_BOARD)
+    def can_unpair_board(self, tournament_id: int) -> bool:
+        """Returns True if the client can unpair a board."""
+        return self._action_allowed_for_tournament(
+            AuthAction.UNPAIR_BOARD, tournament_id
+        )
 
-    @property
-    def tournament_ids_allowing_permute_board(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        permute paired players."""
-        return self.tournament_ids_allowing_action(AuthAction.PERMUTE_BOARD)
+    def can_permute_board(self, tournament_id: int) -> bool:
+        """Returns True if the client can permute paired players."""
+        return self._action_allowed_for_tournament(
+            AuthAction.PERMUTE_BOARD, tournament_id
+        )
 
-    @property
-    def tournament_ids_allowing_set_current_round(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        set the current round."""
-        return self.tournament_ids_allowing_action(AuthAction.SET_CURRENT_ROUND)
+    def can_set_current_round(self, tournament_id: int) -> bool:
+        """Returns True if the client can set the current round of a tournament."""
+        return self._action_allowed_for_tournament(
+            AuthAction.SET_CURRENT_ROUND, tournament_id
+        )
 
-    @property
-    def tournament_ids_allowing_set_zero_point_bye(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        set HPB to players."""
-        return self.tournament_ids_allowing_action(AuthAction.SET_ZPB)
+    def can_set_zero_point_bye(self, tournament_id: int) -> bool:
+        """Returns True if the client can set a zero point bye to a player."""
+        return self._action_allowed_for_tournament(AuthAction.SET_ZPB, tournament_id)
 
-    @property
-    def tournament_ids_allowing_set_half_point_bye(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        set HPB to players."""
-        return self.tournament_ids_allowing_action(AuthAction.SET_HPB)
+    def can_set_half_point_bye(self, tournament_id: int) -> bool:
+        """Returns True if the client can set a half point bye to a player."""
+        return self._action_allowed_for_tournament(AuthAction.SET_HPB, tournament_id)
 
-    @property
-    def tournament_ids_allowing_set_full_point_bye(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        set FPB to players."""
-        return self.tournament_ids_allowing_action(AuthAction.SET_FPB)
+    def can_set_full_point_bye(self, tournament_id: int) -> bool:
+        """Returns True if the client can set a full point bye to a player."""
+        return self._action_allowed_for_tournament(AuthAction.SET_FPB, tournament_id)
 
-    @property
-    def tournament_ids_allowing_view_draft_pairings(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        view draft pairings (before they are published)."""
-        return self.tournament_ids_allowing_action(AuthAction.VIEW_DRAFT_PAIRINGS)
+    def can_view_draft_pairings(self, tournament_id: int) -> bool:
+        """Returns True if the client can view draft pairings (before they are published)."""
+        return self._action_allowed_for_tournament(
+            AuthAction.VIEW_DRAFT_PAIRINGS, tournament_id
+        )
 
-    @property
-    def tournament_ids_allowing_publish_pairings(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        publish pairings."""
-        return self.tournament_ids_allowing_action(AuthAction.PUBLISH_PAIRINGS)
+    def can_publish_pairings(self, tournament_id: int) -> bool:
+        """Returns True if the client can publish pairings."""
+        return self._action_allowed_for_tournament(
+            AuthAction.PUBLISH_PAIRINGS, tournament_id
+        )
 
     # ---------------------------------------------------------------------------------
     # Rankings
     # ---------------------------------------------------------------------------------
 
-    @property
-    def tournament_ids_alowing_view_draft_rankings(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        view draft rankings (before they are published)."""
-        return self.tournament_ids_allowing_action(AuthAction.VIEW_DRAFT_RANKINGS)
+    def can_view_draft_rankings(self, tournament_id: int) -> bool:
+        """Returns True if the client can view draft rankings (before they are published)."""
+        return self._action_allowed_for_tournament(
+            AuthAction.VIEW_DRAFT_RANKINGS, tournament_id
+        )
 
-    @property
-    def tournament_ids_allowing_publish_rankings(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        publish rankings."""
-        return self.tournament_ids_allowing_action(AuthAction.PUBLISH_RANKINGS)
+    def can_publish_rankings(self, tournament_id: int) -> bool:
+        """Returns True if the client can publish rankings."""
+        return self._action_allowed_for_tournament(
+            AuthAction.PUBLISH_RANKINGS, tournament_id
+        )
 
     # ---------------------------------------------------------------------------------
     # Results
     # ---------------------------------------------------------------------------------
+
+    def can_enter_results(self, tournament_id: int) -> bool:
+        """Returns True if the client can enter results for a tournament."""
+        return self._action_allowed_for_tournament(
+            AuthAction.ENTER_RESULTS, tournament_id
+        )
 
     @property
     def tournament_ids_allowing_enter_results(self) -> list[int]:
@@ -463,17 +477,35 @@ class Client:
         enter results."""
         return self.tournament_ids_allowing_action(AuthAction.ENTER_RESULTS)
 
+    def can_update_results(self, tournament_id: int) -> bool:
+        """Returns True if the client can update previously entered results."""
+        return self._action_allowed_for_tournament(
+            AuthAction.UPDATE_RESULTS, tournament_id
+        )
+
     @property
     def tournament_ids_allowing_update_results(self) -> list[int]:
         """Returns the IDs of the tournaments of which the client can
         update previously entered results."""
         return self.tournament_ids_allowing_action(AuthAction.UPDATE_RESULTS)
 
+    def can_set_special_results(self, tournament_id: int) -> bool:
+        """Returns True if the client can set special results (such as O.0-F, 0.0-0.5)."""
+        return self._action_allowed_for_tournament(
+            AuthAction.SET_SPECIAL_RESULTS, tournament_id
+        )
+
     @property
     def tournament_ids_allowing_set_special_results(self) -> list[int]:
         """Returns the IDs of the tournaments of which the client can
         set special results (such as O.0-F, 0.0-0.5)."""
         return self.tournament_ids_allowing_action(AuthAction.SET_SPECIAL_RESULTS)
+
+    def imputable_results_for_tournament(self, tournament_id: int) -> list[Result]:
+        if self.can_set_special_results(tournament_id):
+            return Result.user_imputable_results()
+        else:
+            return Result.admin_imputable_results()
 
     # ---------------------------------------------------------------------------------
     # Screens

--- a/src/data/auth/client.py
+++ b/src/data/auth/client.py
@@ -134,18 +134,6 @@ class Client:
                 actions |= role.allowed_actions()
         return actions
 
-    def tournament_ids_allowing_action(self, action: AuthAction) -> list[int]:
-        """Returns the IDs of the tournaments for which the action is allowed."""
-        assert self.event is not None
-        return list(
-            filter(
-                lambda tournament_id: self._action_allowed_for_tournament(
-                    action, tournament_id
-                ),
-                self.event.tournaments_by_id.keys(),
-            )
-        )
-
     def _action_allowed_for_tournament(
         self, action: AuthAction, tournament_id: int
     ) -> bool:
@@ -471,35 +459,17 @@ class Client:
             AuthAction.ENTER_RESULTS, tournament_id
         )
 
-    @property
-    def tournament_ids_allowing_enter_results(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        enter results."""
-        return self.tournament_ids_allowing_action(AuthAction.ENTER_RESULTS)
-
     def can_update_results(self, tournament_id: int) -> bool:
         """Returns True if the client can update previously entered results."""
         return self._action_allowed_for_tournament(
             AuthAction.UPDATE_RESULTS, tournament_id
         )
 
-    @property
-    def tournament_ids_allowing_update_results(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        update previously entered results."""
-        return self.tournament_ids_allowing_action(AuthAction.UPDATE_RESULTS)
-
     def can_set_special_results(self, tournament_id: int) -> bool:
         """Returns True if the client can set special results (such as O.0-F, 0.0-0.5)."""
         return self._action_allowed_for_tournament(
             AuthAction.SET_SPECIAL_RESULTS, tournament_id
         )
-
-    @property
-    def tournament_ids_allowing_set_special_results(self) -> list[int]:
-        """Returns the IDs of the tournaments of which the client can
-        set special results (such as O.0-F, 0.0-0.5)."""
-        return self.tournament_ids_allowing_action(AuthAction.SET_SPECIAL_RESULTS)
 
     def imputable_results_for_tournament(self, tournament_id: int) -> list[Result]:
         if self.can_set_special_results(tournament_id):

--- a/src/web/controllers/user/tournament_user_controller.py
+++ b/src/web/controllers/user/tournament_user_controller.py
@@ -421,20 +421,17 @@ class ResultUserController(BaseInputUserController):
                 request, f'Invalid round number [{round_}].'
             )
         if result is None:
-            if not board_web_context.client.tournament_ids_allowing_update_results[
+            if not board_web_context.client.can_update_results(
                 board_web_context.tournament.id
-            ]:
+            ):
                 return BaseController.redirect_error(
                     request, 'Result deletion is not allowed.'
                 )
             with suppress(ValueError):
                 board_web_context.tournament.delete_result(board_web_context.board)
         else:
-            if result not in (
-                Result.admin_imputable_results()
-                if board_web_context.tournament.id
-                in board_web_context.client.tournament_ids_allowing_set_special_results
-                else Result.user_imputable_results()
+            if result not in board_web_context.client.imputable_results_for_tournament(
+                board_web_context.tournament.id
             ):
                 return BaseController.redirect_error(
                     request, f'Invalid result [{result}].'

--- a/src/web/templates/admin/pairings/pairing_modal.html
+++ b/src/web/templates/admin/pairings/pairing_modal.html
@@ -22,9 +22,9 @@
                         {% if
                             board.exempt
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_enter_results)
+                            client.can_enter_results(admin_tournament.id)
                             or
-                            (board.result and (admin_tournament.id not in client.tournament_ids_allowing_update_results))
+                            (board.result and not client.can_update_results(admin_tournament.id))
                         %}
                             disabled
                         {% else %}
@@ -60,9 +60,9 @@
                         {% if
                             board.exempt
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_enter_results)
+                            client.can_enter_results(admin_tournament.id)
                             or
-                            (board.result and (admin_tournament.id not in client.tournament_ids_allowing_update_results))
+                            (board.result and not client.can_update_results(admin_tournament.id))
                         %}
                             disabled
                         {% else %}
@@ -98,9 +98,9 @@
                         {% if
                             board.exempt
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_enter_results)
+                            not client.can_enter_results(admin_tournament.id)
                             or
-                            (board.result and (admin_tournament.id not in client.tournament_ids_allowing_update_results))
+                            (board.result and not client.can_update_results(admin_tournament.id))
                         %}
                             disabled
                         {% else %}
@@ -138,11 +138,11 @@
                         {% if
                             board.exempt
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_set_special_results)
+                            not client.can_set_special_results(admin_tournament.id)
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_enter_results)
+                            not client.can_enter_results(admin_tournament.id)
                             or
-                            (board.result and (admin_tournament.id not in client.tournament_ids_allowing_update_results))
+                            (board.result and not client.can_update_results(admin_tournament.id))
                         %}
                             disabled
                         {% else %}
@@ -306,7 +306,7 @@
                             or
                             board.exempt
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_update_results)
+                            not client.can_update_results(admin_tournament.id)
                         %}
                             disabled
                         {% else %}

--- a/src/web/templates/admin/pairings/pairing_modal.html
+++ b/src/web/templates/admin/pairings/pairing_modal.html
@@ -22,7 +22,7 @@
                         {% if
                             board.exempt
                             or
-                            client.can_enter_results(admin_tournament.id)
+                            not client.can_enter_results(admin_tournament.id)
                             or
                             (board.result and not client.can_update_results(admin_tournament.id))
                         %}
@@ -60,7 +60,7 @@
                         {% if
                             board.exempt
                             or
-                            client.can_enter_results(admin_tournament.id)
+                            not client.can_enter_results(admin_tournament.id)
                             or
                             (board.result and not client.can_update_results(admin_tournament.id))
                         %}

--- a/src/web/templates/admin/pairings/pairing_modal.html
+++ b/src/web/templates/admin/pairings/pairing_modal.html
@@ -178,11 +178,11 @@
                         {% if
                             board.exempt
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_set_special_results)
+                            not client.can_set_special_results(admin_tournament.id)
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_enter_results)
+                            not client.can_enter_results(admin_tournament.id)
                             or
-                            (board.result and (admin_tournament.id not in client.tournament_ids_allowing_update_results))
+                            (board.result and not client.can_update_results(admin_tournament.id))
                         %}
                             disabled
                         {% else %}
@@ -218,11 +218,11 @@
                         {% if
                             board.exempt
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_set_special_results)
+                            not client.can_set_special_results(admin_tournament.id)
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_enter_results)
+                            not client.can_enter_results(admin_tournament.id)
                             or
-                            (board.result and (admin_tournament.id not in client.tournament_ids_allowing_update_results))
+                            (board.result and not client.can_update_results(admin_tournament.id))
                         %}
                             disabled
                         {% else %}
@@ -264,7 +264,7 @@
                             or
                             (not board.no_result and not board.exempt)
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_unpair_board)
+                            not client.can_unpair_board(admin_tournament.id)
                         %}
                             disabled
                         {% else %}
@@ -349,7 +349,7 @@
                         {% if
                             board.exempt
                             or
-                            (admin_tournament.id not in client.tournament_ids_allowing_permute_board)
+                            not client.can_permute_boards(admin_tournament.id)
                         %}
                             disabled
                         {% else %}

--- a/src/web/templates/admin/pairings/pairing_row.html
+++ b/src/web/templates/admin/pairings/pairing_row.html
@@ -15,10 +15,10 @@
     <td>{{ wp.full_name }} ({{ wp.rating_str }})</td>
     <td class="text-center" style="width: 3rem;">
         <span
-            {% if admin_tournament.id not in client.tournament_ids_allowing_enter_results %}
+            {% if not client.can_enter_results(admin_tournament.id) %}
                 {{ macros.tooltip_attributes('warning', _('You are not allowed to enter results.'), 'top') }}
                 {% set allowed=false %}
-            {% elif board.result_str and (admin_tournament.id not in client.tournament_ids_allowing_update_results) %}
+            {% elif board.result_str and not client.can_update_results(admin_tournament.id) %}
                 {{ macros.tooltip_attributes('warning', _('You are not allowed to update results.'), 'top') }}
                 {% set allowed=false %}
             {% else %}

--- a/src/web/templates/admin/pairings/round_robin_pairing_buttons.html
+++ b/src/web/templates/admin/pairings/round_robin_pairing_buttons.html
@@ -7,7 +7,7 @@
 >
     {% if not admin_tournament.has_pairings %}
         <div
-            {% if admin_tournament.id not in client.tournament_ids_allowing_use_pairing_engine %}
+            {% if not client.can_use_pairing_engine(admin_tournament.id) %}
                 {{ macros.tooltip_attributes('warning', _('You are not allowed to generate the pairings.'), 'top') }}
             {% elif pairings_generation_disabled_message %}
                 {{ macros.tooltip_attributes('warning', pairings_generation_disabled_message, 'top') }}
@@ -18,7 +18,7 @@
             <button
                 class="btn btn-outline-primary text-nowrap"
                 {% if
-                    (admin_tournament.id not in client.tournament_ids_allowing_use_pairing_engine)
+                    not client.can_use_pairing_engine(admin_tournament.id)
                     or
                     pairings_generation_disabled_message
                 %}
@@ -41,7 +41,7 @@
 
     {% if admin_tournament.has_pairings and not admin_tournament.has_results %}
         <div
-            {% if admin_tournament.id not in client.tournament_ids_allowing_unpair_round %}
+            {% if not client.can_unpair_round(admin_tournament.id) %}
                 {{ macros.tooltip_attributes('warning', _('You are not allowed to unpair rounds.'), 'top') }}
             {% else %}
                 {{ macros.tooltip_attributes('info', _('Unpair all the rounds of the tournament.'), 'top') }}
@@ -49,7 +49,7 @@
         >
             <button
                 class="btn btn-outline-primary text-nowrap"
-                {% if admin_tournament.id not in client.tournament_ids_allowing_unpair_round %}
+                {% if not client.can_unpair_round(admin_tournament.id) %}
                     disabled
                 {% else %}
                     hx-post="{{ url_for('admin-pairings-unpair-tournament', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id) }}"
@@ -64,7 +64,7 @@
 
     {% if round_status == 'CURRENT' and not admin_tournament.playing and not admin_tournament.finished %}
         <div
-            {% if admin_tournament.id not in client.tournament_ids_allowing_set_current_round %}
+            {% if not client.can_set_current_round(admin_tournament.id) %}
                 {{ macros.tooltip_attributes('warning', _('You are not allowed to set the current round.'), 'top') }}
             {% else %}
                 {{ macros.tooltip_attributes('info', _('Mark this round as over and define the next one as the current round.'), 'top') }}
@@ -72,7 +72,7 @@
         >
             <button
                 class="btn btn-outline-primary text-nowrap"
-                {% if admin_tournament.id not in client.tournament_ids_allowing_set_current_round %}
+                {% if not client.can_set_current_round(admin_tournament.id) %}
                     disabled
                 {% else %}
                     hx-put="{{ url_for('admin-tournament-set-current-round', event_uniq_id=admin_event.uniq_id, tournament_id=admin_tournament.id, current_round=admin_round + 1) }}"

--- a/src/web/templates/admin/pairings/swiss_pairing_buttons.html
+++ b/src/web/templates/admin/pairings/swiss_pairing_buttons.html
@@ -7,7 +7,7 @@
 >
     {% if 'FULL_PAIRING' in allowed_actions %}
         <div
-            {% if admin_tournament.id not in client.tournament_ids_allowing_use_pairing_engine %}
+            {% if not client.can_use_pairing_engine(admin_tournament.id) %}
                 {{ macros.tooltip_attributes('warning', _('You are not allowed to generate the pairings.'), 'top') }}
             {% elif pairings_generation_disabled_message %}
                 {{ macros.tooltip_attributes('warning', pairings_generation_disabled_message, 'top') }}
@@ -18,7 +18,7 @@
             <button
                 class="btn btn-outline-primary text-nowrap"
                 {% if
-                    (admin_tournament.id not in client.tournament_ids_allowing_use_pairing_engine)
+                    not client.can_use_pairing_engine(admin_tournament.id)
                     or
                     pairings_generation_disabled_message
                 %}
@@ -61,7 +61,7 @@
     ) %}
     {% if action in existing_actions and admin_tournament.is_round_partially_paired(admin_round) %}
         <div
-            {% if admin_tournament.id not in client.tournament_ids_allowing_use_pairing_engine %}
+            {% if not client.can_use_pairing_engine(admin_tournament.id) %}
                 {{ macros.tooltip_attributes('warning', _('You are not allowed to generate complementary pairings.'), 'top') }}
             {% elif pairings_generation_disabled_message %}
                 {{ macros.tooltip_attributes('warning', pairings_generation_disabled_message, 'top') }}
@@ -72,7 +72,7 @@
             <button
                 class="btn btn-outline-primary text-nowrap"
                 {% if
-                    (admin_tournament.id not in client.tournament_ids_allowing_use_pairing_engine)
+                    not client.can_use_pairing_engine(admin_tournament.id)
                     or
                     pairings_generation_disabled_message
                 %}
@@ -114,7 +114,7 @@
     {% if action in existing_actions %}
         {% set allowed=not admin_tournament.round_has_result(admin_round) %}
             <div
-                {% if admin_tournament.id not in client.tournament_ids_allowing_unpair_round %}
+                {% if not client.can_unpair_round(admin_tournament.id) %}
                     {{ macros.tooltip_attributes('warning', _('You are not allowed to unpair rounds.'), 'top') }}
                 {% elif allowed %}
                     {{ macros.tooltip_attributes('info', _('Unpair all the boards of this round.'), 'top') }}
@@ -125,7 +125,7 @@
             <button
                 class="btn btn-outline-primary text-nowrap"
                 {% if
-                    (admin_tournament.id not in client.tournament_ids_allowing_unpair_round)
+                    not client.can_unpair_round(admin_tournament.id)
                     or
                     not allowed
                 %}

--- a/src/web/templates/admin/pairings/unpaired_player_modal.html
+++ b/src/web/templates/admin/pairings/unpaired_player_modal.html
@@ -22,13 +22,13 @@
                             action='ZPB'
                         ) %}
                         <span
-                            {% if admin_tournament.id not in client.tournament_ids_allowing_set_zero_point_bye %}
+                            {% if not client.can_set_zero_point_bye(admin_tournament.id) %}
                                 {{ macros.tooltip_attributes('warning', _('You are not allowed to set/unset Zero-Point Byes.'), 'right') }}
                             {% endif %}
                         >
                             <button
                                 class="btn btn-outline-primary w-100"
-                                {% if admin_tournament.id not in client.tournament_ids_allowing_set_zero_point_bye %}
+                                {% if not client.can_set_zero_point_bye(admin_tournament.id) %}
                                     disabled
                                 {% else %}
                                     {% if action in allowed_actions %}
@@ -60,13 +60,13 @@
                             action='LEAVE'
                         ) %}
                         <span
-                            {% if admin_tournament.id not in client.tournament_ids_allowing_set_zero_point_bye %}
+                            {% if not client.can_set_zero_point_bye(admin_tournament.id) %}
                                 {{ macros.tooltip_attributes('warning', _('You are not allowed to set/unset Zero-Point Byes.'), 'right') }}
                             {% endif %}
                         >
                             <button
                                 class="btn btn-outline-primary w-100"
-                                {% if admin_tournament.id not in client.tournament_ids_allowing_set_zero_point_bye %}
+                                {% if not client.can_set_zero_point_bye(admin_tournament.id) %}
                                     disabled
                                 {% else %}
                                     {% if action in allowed_actions %}
@@ -99,13 +99,13 @@
                             action='RETURN'
                         ) %}
                         <span
-                            {% if admin_tournament.id not in client.tournament_ids_allowing_set_zero_point_bye %}
+                            {% if not client.can_set_zero_point_bye(admin_tournament.id) %}
                                 {{ macros.tooltip_attributes('warning', _('You are not allowed to set/unset Zero-Point Byes.'), 'right') }}
                             {% endif %}
                         >
                             <button
                                 class="btn btn-outline-primary w-100"
-                                {% if admin_tournament.id not in client.tournament_ids_allowing_set_zero_point_bye %}
+                                {% if not client.can_set_zero_point_bye(admin_tournament.id) %}
                                     disabled
                                 {% else %}
                                     {% if action in allowed_actions %}
@@ -143,13 +143,13 @@
                             action='RETURN'
                         ) %}
                         <span
-                            {% if admin_tournament.id not in client.tournament_ids_allowing_set_half_point_bye %}
+                            {% if not client.can_set_half_point_bye(admin_tournament.id) %}
                                 {{ macros.tooltip_attributes('warning', _('You are not allowed to set/unset Half-Point Byes.'), 'right') }}
                             {% endif %}
                         >
                             <button
                                 class="btn btn-outline-primary w-100"
-                                {% if admin_tournament.id not in client.tournament_ids_allowing_set_half_point_bye %}
+                                {% if not client.can_set_half_point_bye(admin_tournament.id) %}
                                     disabled
                                 {% else %}
                                     {% if action in allowed_actions %}
@@ -175,7 +175,7 @@
                     {% else %}
                         <span
                             class="w-100"
-                            {% if admin_tournament.id not in client.tournament_ids_allowing_set_half_point_bye %}
+                            {% if not client.can_set_half_point_bye(admin_tournament.id) %}
                                 {{ macros.tooltip_attributes('warning', _('You are not allowed to set/unset Half-Point Byes.'), 'right') }}
                             {% elif no_bye_possible %}
                                 {{ macros.tooltip_attributes('info', _('Impossible to set a bye in the last %(rounds)d rounds of the tournament', rounds=player.tournament.last_rounds_no_byes), 'top') }}
@@ -194,7 +194,7 @@
                             <button
                                 class="btn btn-outline-primary w-100"
                                 {% if
-                                    (admin_tournament.id not in client.tournament_ids_allowing_set_half_point_bye)
+                                    not client.can_set_half_point_bye(admin_tournament.id)
                                     or
                                     no_bye_possible
                                     or
@@ -233,7 +233,7 @@
                     {% if action in existing_actions %}
                         <span
                             class="w-100"
-                            {% if admin_tournament.id not in client.tournament_ids_allowing_manually_pair_players %}
+                            {% if not client.can_manually_pair_players(admin_tournament.id) %}
                                 {{ macros.tooltip_attributes('warning', _('You are not allowed to pair players.'), 'right') }}
                             {% elif admin_tournament.check_in_open %}
                                 {{ macros.tooltip_attributes('info', _('Pairings disabled while check-in is open.'), 'top') }}
@@ -242,7 +242,7 @@
                             <button
                                 class="btn btn-outline-primary w-100 {% if exempt_player %}d-flex flex-column align-items-center gap-1{% endif %}"
                                 {% if
-                                    (admin_tournament.id not in client.tournament_ids_allowing_manually_pair_players)
+                                    not client.can_manually_pair_players(admin_tournament.id)
                                     or
                                     admin_tournament.check_in_open
                                 %}

--- a/src/web/templates/admin/pairings/unpaired_table.html
+++ b/src/web/templates/admin/pairings/unpaired_table.html
@@ -16,7 +16,7 @@
         </tr>
     </thead>
     <tbody>
-        {% set can_check_in=admin_tournament.id in client.tournament_ids_allowing_check_in_players %}
+        {% set can_check_in=client.can_check_in_players(admin_tournament.id) %}
         {% for player in unpaired %}
             {% with pairing=player.pairings[admin_round], class="bye" if admin_round and pairing and (pairing.zero_point_bye or pairing.half_point_bye or pairing.full_point_bye) else '' %}
                 <tr id="player-{{ player.id }}" class="player-row" data-player-id="{{ player.id }}">

--- a/src/web/templates/admin/players/record_modal.html
+++ b/src/web/templates/admin/players/record_modal.html
@@ -127,11 +127,11 @@
                                                             selected
                                                         {% endif %}
                                                         {% if
-                                                            (admin_player.tournament.id not in client.tournament_ids_allowing_set_half_point_bye)
+                                                            not client.can_set_half_point_bye(admin_player.tournament.id)
                                                             or
-                                                            (half_point_bye and (admin_player.tournament.id not in client.tournament_ids_allowing_set_half_point_bye))
+                                                            (half_point_bye and not client.can_set_half_point_bye(admin_player.tournament.id))
                                                             or
-                                                            (full_point_bye and (admin_player.tournament.id not in client.tournament_ids_allowing_set_full_point_bye))
+                                                            (full_point_bye and not client.can_set_full_point_bye(admin_player.tournament.id))
                                                         %}
                                                             disabled
                                                         {% endif %}
@@ -144,11 +144,11 @@
                                                             selected
                                                         {% endif %}
                                                         {% if
-                                                            (admin_player.tournament.id not in client.tournament_ids_allowing_set_half_point_bye)
+                                                            not client.can_set_half_point_bye(admin_player.tournament.id)
                                                             or
-                                                            (half_point_bye and (admin_player.tournament.id not in client.tournament_ids_allowing_set_half_point_bye))
+                                                            (half_point_bye and not client.can_set_half_point_bye(admin_player.tournament.id))
                                                             or
-                                                            (full_point_bye and (admin_player.tournament.id not in client.tournament_ids_allowing_set_full_point_bye))
+                                                            (full_point_bye and not client.can_set_full_point_bye(admin_player.tournament.id))
                                                         %}
                                                             disabled
                                                         {% endif %}
@@ -162,9 +162,9 @@
                                                                 selected
                                                             {% endif %}
                                                             {% if
-                                                                (admin_player.tournament.id not in client.tournament_ids_allowing_set_half_point_bye)
+                                                                not client.can_set_half_point_bye(admin_player.tournament.id)
                                                                 or
-                                                                (full_point_bye and (admin_player.tournament.id not in client.tournament_ids_allowing_set_full_point_bye))
+                                                                (full_point_bye and client.can_set_full_point_bye(admin_player.tournament.id))
                                                             %}
                                                                 disabled
                                                             {% endif %}
@@ -177,7 +177,7 @@
                                                             {% if data[name] == '10' %}
                                                                 selected
                                                             {% endif %}
-                                                            {% if admin_player.tournament.id not in client.tournament_ids_allowing_set_full_point_bye %}
+                                                            {% if not client.can_set_full_point_bye(admin_player.tournament.id) %}
                                                                 disabled
                                                             {% endif %}
                                                     >

--- a/src/web/templates/admin/players/table_player_row.html
+++ b/src/web/templates/admin/players/table_player_row.html
@@ -6,7 +6,7 @@
 >
     <td class="text-nowrap text-start w-1 ps-2">
         {% set can_update = client.can_update_players %}
-        {% set can_update_history=player.tournament.id in client.tournament_ids_allowing_update_players_history %}
+        {% set can_update_history=client.can_update_players_history(player.tournament.id) %}
         {% set can_delete=client.can_delete_players and not player.has_real_pairings %}
         {% if can_update or can_update_history or can_delete %}
             <span class="dropdown">
@@ -87,7 +87,7 @@
     {{ admin_macros.extra_admin_column_cell("check-in", player, admin_players_extra_columns)}}
     {% if 'check_in' in admin_players_filter_columns %}
         <td class="text-nowrap text-center">
-            {% set can_check_in=player.tournament_id in client.tournament_ids_allowing_check_in_players %}
+            {% set can_check_in=client.can_check_in_players(player.tournament.id) %}
             <i
                 {% if player.tournament.finished %}
                     class="bi-ban text-secondary"

--- a/src/web/templates/user/modals.html
+++ b/src/web/templates/user/modals.html
@@ -6,7 +6,7 @@
         and
         not board.exempt
         and
-        (board.white_player.tournament.id in client.tournament_ids_allowing_enter_results)
+        client.can_enter_results(board.white_player.tournament.id)
     %}
         {% with wp=board.white_player, bp=board.black_player %}
             <div class="modal-dialog modal-dialog-centered input-screen-result-modal">
@@ -98,7 +98,7 @@
     {% elif
         player
         and
-        player.tournament.id in client.tournament_ids_allowing_check_in_players
+        client.can_check_in_players(player.tournament.id)
     %}
         <div class="modal-dialog modal-dialog-centered input-screen-result-modal">
             <div class="modal-content bg-secondary-subtle">

--- a/src/web/templates/user/modals.html
+++ b/src/web/templates/user/modals.html
@@ -38,7 +38,7 @@
                             >{{ _('DRAW') }}<br/>½ - ½<br/><br/><br/><br/><br/></button>
                             <button
                                 class="result-button black text-white bg-black col-3 ms-auto me-auto btn fs-4 fw-bold p-3"
-                                {% if board.result and client.can_update_results(wp.tournament.id) %}
+                                {% if board.result and not client.can_update_results(wp.tournament.id) %}
                                     disabled
                                 {% else %}
                                     hx-put="{{ url_for('user-add-result', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, round=tournament.current_round, board_id=board.id, result=1) }}"

--- a/src/web/templates/user/modals.html
+++ b/src/web/templates/user/modals.html
@@ -18,7 +18,7 @@
                         <div class="row d-flex align-items-center justify-content-center">
                             <button
                                 class="result-button white text-black bg-white col-3 ms-auto me-auto btn fs-4 fw-bold p-3"
-                                {% if board.result and (wp.tournament.id not in client.tournament_ids_allowing_update_results) %}
+                                {% if board.result and not client.can_update_results(wp.tournament.id) %}
                                     disabled
                                 {% else %}
                                     hx-put="{{ url_for('user-add-result', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, round=tournament.current_round, board_id=board.id, result=3) }}"
@@ -28,7 +28,7 @@
                             >{{ _('WHITE WINS') }}<br/>1 - 0<br/><br/>{{ wp.last_name }}<br/>{{ wp.first_name }}<br/>{{ wp.rating_str }}</button>
                             <button
                                 class="result-button draw col-3 ms-auto me-auto btn fs-4 fw-bold p-3"
-                                {% if board.result and (wp.tournament.id not in client.tournament_ids_allowing_update_results) %}
+                                {% if board.result and not client.can_update_results(wp.tournament.id) %}
                                     disabled
                                 {% else %}
                                     hx-put="{{ url_for('user-add-result', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, round=tournament.current_round, board_id=board.id, result=2) }}"
@@ -38,7 +38,7 @@
                             >{{ _('DRAW') }}<br/>½ - ½<br/><br/><br/><br/><br/></button>
                             <button
                                 class="result-button black text-white bg-black col-3 ms-auto me-auto btn fs-4 fw-bold p-3"
-                                {% if board.result and (wp.tournament.id not in client.tournament_ids_allowing_update_results) %}
+                                {% if board.result and client.can_update_results(wp.tournament.id) %}
                                     disabled
                                 {% else %}
                                     hx-put="{{ url_for('user-add-result', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, round=tournament.current_round, board_id=board.id, result=1) }}"
@@ -47,7 +47,7 @@
                                 {% endif %}
                             >{{ _('BLACK WINS') }}<br/>0 - 1<br/><br/>{{ bp.last_name }}<br/>{{ bp.first_name }}<br/>{{ bp.rating_str }}</button>
                         </div>
-                        {% if wp.tournament.id in client.tournament_ids_allowing_set_special_results %}
+                        {% if client.can_set_special_results(wp.tournament.id) %}
                             <div class="row d-flex align-items-center justify-content-center mt-3">
                                 <button
                                     class="admin-result-button white text-black bg-white col-3 ms-auto me-auto btn fs-4 fw-bold p-3"
@@ -71,7 +71,7 @@
                         {% endif %}
                     </div>
                     <div class="modal-footer row d-flex align-items-center justify-content-center">
-                        {% if (wp.tournament.id in client.tournament_ids_allowing_update_results) and board.result_str %}
+                        {% if client.can_update_results(wp.tournament.id) and board.result_str %}
                             <button
                                 class="admin-result-button col-3 ms-auto me-auto btn fs-4 fw-bold p-3"
                                 {% if board.result_str %}

--- a/src/web/templates/user/screen/boards/board_row_illegal_moves_cell.html
+++ b/src/web/templates/user/screen/boards/board_row_illegal_moves_cell.html
@@ -1,7 +1,7 @@
 {% if
     screen.type == 'input'
     and
-    (tournament.id in client.tournament_ids_allowing_enter_results)
+    client.can_enter_results(tournament.id)
     and
     tournament.record_illegal_moves
 %}

--- a/src/web/templates/user/screen/boards/set.html
+++ b/src/web/templates/user/screen/boards/set.html
@@ -20,9 +20,9 @@
                                         <th scope="col" class="board-number">Ech</th>
                                         <th scope="col" class="points">Pts</th>
                                         {% if tournament.print_real_points %}<th scope="col" class="points">&nbsp;</th>{% endif %}
-                                        <th scope="col" class="player w-50" {% if screen.type == 'input' and (tournament.id in client.tournament_ids_allowing_enter_results) and tournament.record_illegal_moves %}colspan="2"{% endif %}>{{ _('White') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}</th>
+                                        <th scope="col" class="player w-50" {% if screen.type == 'input' and client.can_enter_results(tournament.id) and tournament.record_illegal_moves %}colspan="2"{% endif %}>{{ _('White') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}</th>
                                         <th scope="col" class="score">Score</th>
-                                        <th scope="col" class="player w-50" {% if screen.type == 'input' and (tournament.id in client.tournament_ids_allowing_enter_results) and tournament.record_illegal_moves %}colspan="2"{% endif %}>{{ _('Black') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}</th>
+                                        <th scope="col" class="player w-50" {% if screen.type == 'input' and client.can_enter_results(tournament.id) and tournament.record_illegal_moves %}colspan="2"{% endif %}>{{ _('Black') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}</th>
                                         {% if tournament.print_real_points %}<th scope="col" class="points">&nbsp;</th>{% endif %}
                                         <th scope="col" class="points">Pts</th>
                                     </tr>
@@ -33,9 +33,9 @@
                                     {% set editable =
                                         screen.type == 'input'
                                         and (
-                                            tournament.id in client.tournament_ids_allowing_update_results
+                                            client.can_update_results(tournament.id)
                                             or
-                                            (not board.result_str and (tournament.id in client.tournament_ids_allowing_enter_results))
+                                            (not board.result_str and client.can_enter_results(tournament.id))
                                         )
                                     %}
                                     <tr
@@ -43,7 +43,7 @@
                                         class="
                                             board-row
                                             {% if editable %}editable{% endif %}
-                                            {% if tournament.id in client.tournament_ids_allowing_set_special_results %}special-results-allowed{% endif %}
+                                            {% if client.can_set_special_results(tournament.id) %}special-results-allowed{% endif %}
                                             {% if board.result_str %}result-set{% else %}result-not-set fw-bold{% endif %}
                                             {% if last_result_updated and last_result_updated.expiration > now and last_result_updated.tournament_id == tournament.id and last_result_updated.round == tournament.current_round and last_result_updated.board_id == board.id %}last_result_updated{% endif %}"
                                         >

--- a/tests/e2e/roles/test_anonymous_role.py
+++ b/tests/e2e/roles/test_anonymous_role.py
@@ -18,6 +18,11 @@ class TestAnonymousRole(BaseRoleTest):
             lan_page.locator(f"div.card:has-text('{PUBLIC_EVENT_ID}')")
         ).to_be_visible()
 
+    # FIXME(Amaras): this is supposed to be unmarked before merging.
+    # It is currently marked because I am working on reworking the level
+    # of abstractions of the client and want to isolate failing tests not
+    # related to my changes
+    @pytest.mark.skip(reason='Test is expected to fail')
     def test_access_to_visible_screens(
         self,
         lan_page: Page,

--- a/tests/e2e/roles/test_anonymous_role.py
+++ b/tests/e2e/roles/test_anonymous_role.py
@@ -18,11 +18,6 @@ class TestAnonymousRole(BaseRoleTest):
             lan_page.locator(f"div.card:has-text('{PUBLIC_EVENT_ID}')")
         ).to_be_visible()
 
-    # FIXME(Amaras): this is supposed to be unmarked before merging.
-    # It is currently marked because I am working on reworking the level
-    # of abstractions of the client and want to isolate failing tests not
-    # related to my changes
-    @pytest.mark.skip(reason='Test is expected to fail')
     def test_access_to_visible_screens(
         self,
         lan_page: Page,


### PR DESCRIPTION
Currently, the `Client` class uses tournament ids as a part of its main interface to check for permissions.

This is completely the wrong level of abstraction, as it should be an implementation detail.

I have started to change the templates to use the higher abstraction methods.

FIXME: I have skipped a test that was not passing, but it should be reactivated before merging on `feature/roles`.