### PR TITLE
Correctly show real points

### DIFF
--- a/src/data/print_documents/documents.py
+++ b/src/data/print_documents/documents.py
@@ -368,6 +368,7 @@ class BoardPrintDocument(PrintDocument, ABC):
         return {
             'show_result': self.show_results,
             'boards': self.boards,
+            'selected_round': self.at_round,
         }
 
     @property

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -560,9 +560,10 @@ class Tournament:
 
         return related_screens
 
-    @cached_property
-    def print_real_points(self) -> bool:
-        return self.pairing_variation.print_real_points(self.current_round, self.rounds)
+    def print_real_points(self, round_: int | None = None) -> bool:
+        if round_ is None:
+            round_ = self.current_round
+        return self.pairing_variation.print_real_points(round_, self.rounds)
 
     @property
     def point_values(self) -> dict[Result, float]:

--- a/src/web/templates/admin/pairings/pairing_row.html
+++ b/src/web/templates/admin/pairings/pairing_row.html
@@ -9,7 +9,7 @@
 >
     <td class="text-center text-nowrap">{{ board.number }}{% if board.number != board.id %} ({{ board.id }}){% endif %}</td>
     <td class="text-center">{{ wp.vpoints_str }}</td>
-    {% if admin_tournament.print_real_points %}
+    {% if admin_tournament.print_real_points(admin_round) %}
         <td class="text-start">[{{ wp.points_str }}]</td>
     {% endif %}
     <td>{{ wp.full_name }} ({{ wp.rating_str }})</td>
@@ -33,7 +33,7 @@
     </td>
     {% if bp %}
         <td>{{ bp.full_name }} ({{ bp.rating_str }})</td>
-        {% if admin_tournament.print_real_points %}
+        {% if admin_tournament.print_real_points(admin_round) %}
             <td class="text-end">[{{ bp.points_str }}]</td>
         {% endif %}
         <td class="text-center">{{ bp.vpoints_str }}</td>
@@ -50,6 +50,6 @@
             {% endif %}
         </td>
         <td></td>
-        {% if admin_tournament.print_real_points %}<td></td>{% endif %}
+        {% if admin_tournament.print_real_points(admin_round) %}<td></td>{% endif %}
     {% endif %}
 </tr>

--- a/src/web/templates/admin/pairings/pairing_table_header.html
+++ b/src/web/templates/admin/pairings/pairing_table_header.html
@@ -9,13 +9,13 @@
     <tr>
         <th>{{ _('Board (%(remaining)d)', remaining=admin_tournament.boards_without_result(admin_round)|length) }}</th>
         <th>{{ _('Pts *** POINTS FOR TABLE HEADER') }}</th>
-        {% if admin_tournament.print_real_points %}
+        {% if admin_tournament.print_real_points(admin_round) %}
             <th>&nbsp;</th>
         {% endif %}
         <th>{{ _('White') }}</th>
         <th class="text-center">{{ _('Result') }}</th>
         <th>{{ _('Black') }}</th>
-        {% if admin_tournament.print_real_points %}
+        {% if admin_tournament.print_real_points(admin_round) %}
             <th>&nbsp;</th>
         {% endif %}
         <th>{{ _('Pts *** POINTS FOR TABLE HEADER') }}</th>

--- a/src/web/templates/admin/print/boards.html
+++ b/src/web/templates/admin/print/boards.html
@@ -10,7 +10,7 @@
             <tr class="board-header">
                 <th class="board-number">{{ _('Bd. *** BOARD NUMBER FOR TABLE HEADER') }}</th>
                 <th class="points">{{ _('Pts *** POINTS FOR TABLE HEADER') }}</th>
-                {% if document.tournament.print_real_points %}
+                {% if document.tournament.print_real_points(selected_round) %}
                     <th class="points">&nbsp;</th>
                 {% endif %}
                 <th class="player">{{ _('White') }}</th>
@@ -22,7 +22,7 @@
                 </th>
                 <th class="player">{{ _('Black') }}</th>
                 <th class="rating"></th>
-                {% if document.tournament.print_real_points %}
+                {% if document.tournament.print_real_points(selected_round) %}
                     <th class="points">&nbsp;</th>
                 {% endif %}
                 <th class="points">{{ _('Pts *** POINTS FOR TABLE HEADER') }}</th>
@@ -36,7 +36,7 @@
                 >
                     <td class="board-number">{{ board.number }}{% if board.number != board.id %} ({{ board.id }}){% endif %}</td>
                     <td class="points">{{ board.white_player.vpoints_str }}</td>
-                    {% if document.tournament.print_real_points %}
+                    {% if document.tournament.print_real_points(selected_round) %}
                         <td class="points">[{{ board.white_player.points_str }}]</td>
                     {% endif %}
                     <td class="player">
@@ -57,7 +57,7 @@
                         <td class="rating">
                             {{ board.black_player.rating_str }}
                         </td>
-                        {% if document.tournament.print_real_points %}
+                        {% if document.tournament.print_real_points(selected_round) %}
                             <td class="points">[{{ board.black_player.points_str }}]</td>
                         {% endif %}
                         <td class="points">{{ board.black_player.vpoints_str }}</td>
@@ -65,7 +65,7 @@
                         <td class="player">{{ board.white_player.exempt_str }}</td>
                         <td></td>
                         <td></td>
-                        {% if document.tournament.print_real_points %}<td></td>{% endif %}
+                        {% if document.tournament.print_real_points(selected_round) %}<td></td>{% endif %}
                     {% endif %}
 
                 </tr>

--- a/src/web/templates/user/screen/boards/set.html
+++ b/src/web/templates/user/screen/boards/set.html
@@ -6,13 +6,14 @@
             <div class="boards-set">
                 <h2 class="set-title text-center">
                     {% if tournament.current_round %}
-                        {% set remaining=tournament.boards_without_result(tournament.current_round)|length %}
+                        {% set current_round = tournament.current_round %}
+                        {% set remaining=tournament.boards_without_result(current_round)|length %}
                         {{ ngettext(
                             "%(set_name)s (round #%(round)d, %(remaining)d board remaining)",
                             "%(set_name)s (round #%(round)d, %(remaining)d boards remaining)",
                             remaining,
                             set_name=screen_set.name_for_boards,
-                            round=tournament.current_round,
+                            round=current_round,
                             remaining=remaining
                         ) }}
                     {% else %}
@@ -27,11 +28,11 @@
                                     <tr>
                                         <th scope="col" class="board-number">Ech</th>
                                         <th scope="col" class="points">Pts</th>
-                                        {% if tournament.print_real_points %}<th scope="col" class="points">&nbsp;</th>{% endif %}
+                                        {% if tournament.print_real_points(current_round) %}<th scope="col" class="points">&nbsp;</th>{% endif %}
                                         <th scope="col" class="player w-50" {% if screen.type == 'input' and tournament.record_illegal_moves %}colspan="2"{% endif %}>{{ _('White') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}</th>
                                         <th scope="col" class="score">Score</th>
                                         <th scope="col" class="player w-50" {% if screen.type == 'input' and tournament.record_illegal_moves %}colspan="2"{% endif %}>{{ _('Black') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}</th>
-                                        {% if tournament.print_real_points %}<th scope="col" class="points">&nbsp;</th>{% endif %}
+                                        {% if tournament.print_real_points(current_round) %}<th scope="col" class="points">&nbsp;</th>{% endif %}
                                         <th scope="col" class="points">Pts</th>
                                     </tr>
                                 </thead>
@@ -72,7 +73,7 @@
                                         >
                                             {{ wp.vpoints_str }}
                                         </td>
-                                        {% if tournament.print_real_points %}
+                                        {% if tournament.print_real_points(current_round) %}
                                             <td
                                                 class="points bg-transparent text-center"
                                                 {% if editable %}
@@ -108,7 +109,7 @@
                                             {% include 'board_row_illegal_moves_cell.html' %}
                                             {% include 'board_row_player_cell.html' %}
                                         {% endwith %}
-                                        {% if tournament.print_real_points %}
+                                        {% if tournament.print_real_points(current_round) %}
                                             <td
                                                 class="points bg-transparent text-center"
                                                 {% if editable %}


### PR DESCRIPTION
Currently, reals points are only shown and printed if the tournament's
current round is a round where the real points should be printed.
This is incorrect in the case where you want to check the pairings of
e.g. round 2 during the last round of the tournament.

This commit makes sure the real points are computed at the correct time.
