### PR TITLE
Fix player movement

### DIFF
--- a/src/data/event.py
+++ b/src/data/event.py
@@ -495,6 +495,25 @@ class Event:
                 counter[check_in] += tournament.check_in_counts[check_in]
         return counter
 
+    def move_player_to_tournament(
+        self,
+        player: Player,
+        source_tournament: Tournament,
+        destination_tournament: Tournament,
+    ):
+        """Moves the given player from tournament *source_tournament* to *destination_tournament*."""
+        stored_tournament_player = player.stored_tournament_player
+        with EventDatabase(self.uniq_id, write=True) as database:
+            database.move_tournament_player(
+                stored_tournament_player, destination_tournament.id
+            )
+            del source_tournament.players_by_id[player.id]
+            player.stored_tournament_player = (
+                database.load_player_stored_tournament_player(player.id)
+            )
+            destination_tournament.players_by_id[player.id] = player
+            database.commit()
+
     def get_unused_tournament_uniq_id(
         self,
         base_uniq_id: str | None = None,

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -1026,6 +1026,27 @@ class EventDatabase(MigrationDatabase):
             ),
         )
 
+    def move_tournament_player(
+        self,
+        stored_tournament_player: StoredTournamentPlayer,
+        destination_tournament_id: int,
+    ):
+        params = {
+            'new_tournament_id': destination_tournament_id,
+            'old_tournament_id': stored_tournament_player.tournament_id,
+            'player_id': stored_tournament_player.player_id,
+        }
+        self.execute(
+            'UPDATE `tournament_player` '
+            'SET `tournament_id` = :new_tournament_id '
+            'WHERE `tournament_id` = :old_tournament_id AND `player_id` = :player_id',
+            params,
+        )
+        self.execute(
+            'DELETE FROM `pairing` WHERE `tournament_id` = :old_tournament_id AND `player_id` = :player_id',
+            params,
+        )
+
     def set_tournament_players_manual_tiebreak(
         self,
         tournament_id: int,

--- a/src/web/controllers/admin/player_admin_controller.py
+++ b/src/web/controllers/admin/player_admin_controller.py
@@ -1226,10 +1226,12 @@ class PlayerAdminController(BaseEventAdminController):
         admin_player = web_context.get_admin_player()
         dst_tournament = web_context.get_admin_tournament()
         src_tournament = admin_player.tournament
+        admin_event = web_context.get_admin_event()
         try:
             self._validate_player_tournament_move(admin_player, dst_tournament)
-            src_tournament.delete_player_from_tournament(admin_player.id)
-            dst_tournament.add_player_to_tournament(admin_player.stored_player)
+            admin_event.move_player_to_tournament(
+                admin_player, src_tournament, dst_tournament
+            )
             if not self.filtered_players(request, event_uniq_id, [admin_player]):
                 self.delete_from_search_results(request, admin_player.id)
             Message.success(


### PR DESCRIPTION
Before this commit, tournament players were deleted from the source
tournament before being added to the destination tournament.
However, when tournament players are deleted, the player is also
deleted.
This means that the player is not moved, unless they are in at least two
tournaments, which is a rare use case.

This commit fixes that by adding an event-level function to move players
between tournament
