### PR TITLE
Really force to set federation at app-level

### DIFF
--- a/src/database/sqlite/config/migrations/m006_force_edit_federation.py
+++ b/src/database/sqlite/config/migrations/m006_force_edit_federation.py
@@ -1,0 +1,11 @@
+from database.sqlite.migration import BaseMigration
+
+
+class Migration(BaseMigration):
+    def forward(self):
+        self.database.execute('SELECT `federation` FROM `info`')
+        if not self.database.fetchone()['federation']:
+            self.database.execute('UPDATE `info` SET `force_edit` = 1')
+
+    def backward(self):
+        pass

--- a/src/web/controllers/admin/index_admin_controller.py
+++ b/src/web/controllers/admin/index_admin_controller.py
@@ -516,12 +516,14 @@ class IndexAdminController(BaseAdminController):
         for plugin in stored_plugins:
             errors |= plugin.errors
         if errors:
+            sharly_chess_config: SharlyChessConfig = SharlyChessConfig()
             return self._admin_render(
                 request=request,
                 admin_tab='config',
                 modal='config',
                 data=data,
                 errors=errors,
+                keep_modal_open=sharly_chess_config.force_edit,
             )
         with ConfigDatabase(write=True) as config_database:
             stored_config.force_edit = False


### PR DESCRIPTION
In #981 we forced the user to choose the federation at app-level: OK
However the user is not really forced to set the federation (can use the Cancel button or dismiss the modal by clicking outside)
so I added m006_force_edit_federation (branch bugfix/force-edit-federation) to set force_edit to 1 if the federation is not set (may not be the appropriate place but it works): OK, now force_edit is set to 1
The problem is:
- The cancel button disappeared from the config modal and I can not not dismiss the modal when I click outside of it: OK
- But when I try to save the config with no federation set, the modal re-appears with an error message and no cancel button and **I can dismiss the modal by clicking outside of it** and the federation is not set.