### PR TITLE
Fix unique Name constraint violated on tournament import

### DIFF
--- a/src/data/input_output/tournament_importers.py
+++ b/src/data/input_output/tournament_importers.py
@@ -52,6 +52,10 @@ class TournamentImporter(IdentifiableEntity, ABC):
         with EventDatabase(event.uniq_id, True) as database:
             if tournament:
                 database.delete_players_in_tournament(tournament.id)
+            else:
+                stored_tournament.name = event.get_unused_tournament_name(
+                    stored_tournament.name
+                )
             tournament_id = self._write_stored_tournament(
                 stored_tournament, stored_players, database
             )


### PR DESCRIPTION
Happens when importing twice the same papi file into an event