### PR TITLE
Remove screen type from section title in family modal

### DIFF
--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -4002,18 +4002,6 @@ msgstr ""
 msgid "Properties"
 msgstr ""
 
-msgid "Properties (check-in and results entry)"
-msgstr ""
-
-msgid "Properties (pairings by board)"
-msgstr ""
-
-msgid "Properties (pairings by player)"
-msgstr ""
-
-msgid "Properties (ranking)"
-msgstr ""
-
 msgid "Protected pairings editing"
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -4002,18 +4002,6 @@ msgstr "Cumulatif"
 msgid "Properties"
 msgstr "Propriétés"
 
-msgid "Properties (check-in and results entry)"
-msgstr "Propriétés (pointage et saisie des résultats)"
-
-msgid "Properties (pairings by board)"
-msgstr "Propriétés (appariements par échiquier)"
-
-msgid "Properties (pairings by player)"
-msgstr "Propriétés (appariements par ordre alphabétique)"
-
-msgid "Properties (ranking)"
-msgstr "Propriétés (classement)"
-
 msgid "Protected pairings editing"
 msgstr "Édition d'appariements protégés"
 

--- a/src/web/templates/admin/families/family_modal.html
+++ b/src/web/templates/admin/families/family_modal.html
@@ -48,19 +48,7 @@
                         {{ _('Warning: the deletion is permanent!') }}
                     </h4>
                 {% else %}
-                    <h4>
-                        {% if family_type == 'input' %}
-                            {{ _('Properties (check-in and results entry)') }}
-                        {% elif family_type == 'boards' %}
-                            {{ _('Properties (pairings by board)') }}
-                        {% elif family_type == 'players' %}
-                            {{ _('Properties (pairings by player)') }}
-                        {% elif family_type == 'ranking' %}
-                            {{ _('Properties (ranking)') }}
-                        {% else %}
-                            ?
-                        {% endif %}
-                    </h4>
+                    <h4>{{ _('Properties') }}</h4>
                     <div class="row">
                         <div class="col-12 col-md-6 mb-3">
                             {{ admin_macros.switch_input(

--- a/src/web/templates/admin/screens/screen_modal.html
+++ b/src/web/templates/admin/screens/screen_modal.html
@@ -48,10 +48,7 @@
                         {{ _('Warning: the deletion is permanent!') }}
                     </h4>
                 {% else %}
-                    <h4>
-                        {{ _('Properties') }}
-                    </h4>
-
+                    <h4>{{ _('Properties') }}</h4>
                     {% set col = 6 if action == 'create' and screen_type.value in ['input', 'boards', 'players', 'ranking', ] else 4 %}
                     <div class="row">
                         <div class="col-12 col-xl-{{col}} mb-3">


### PR DESCRIPTION
The type is now in the header, this duplicates it (it had already been applied to screens, this uniformizes it)