### PR TITLE
Merge back 3.0.6

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -121,7 +121,7 @@ English version below
 - Added FIDE titles on prize assignments (3.0.0)
 - Added tie-breaks to Berger grids (3.0.0)
 - Fixed printing of pairings in alphabetical order (3.0.2)
-- Re-added board 1 players to pairings in alphabetcal order (3.0.3)
+- Re-added board #1 players to pairings in alphabetical order (3.0.3)
 
 ## ChessEvent
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ English version below
 - Amélioration des temps de réponses de l'interface utilisateur (3.0.0)
 - Signature des exécutables Windows (3.0.0)
 - Correction de la récupération des versions précédentes (3.0.1)
+- Optimisation des requêtes d'écriture dans la base de données (3.0.5)
 
 ## Évènements
 
@@ -78,6 +79,7 @@ English version below
 - Improved UI response times (3.0.0)
 - Use signed programs on Windows (3.0.0)
 - Fixed previous versions recovering (3.0.1)
+- Optimized the write queries in the database (3.0.5)
 
 ## Events
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,7 +20,7 @@ English version below
 - Export des tournois au format Papi (3.0.0)
 - Éditeur interactif de la cadence de jeu (3.0.0)
 
-### Joueur·euses
+## Joueur·euses
 
 - Suppression de la limite à 10 caractères des numéros de téléphone (3.0.0)
 
@@ -31,6 +31,7 @@ English version below
 - Suppression de la renumérotation automatique des échiquiers en cas d'appariement manuel (3.0.0)
 - Saisie des résultats non comptabilisés et des pénalités (3.0.0)
 - Ajout de la recherche de joueur·euse sur l'onglet Appariements (3.0.0)
+- Correction de la recherche des joueur·euses sur l'onglet Appariements (3.0.2)
 
 ## Écrans
 
@@ -48,6 +49,10 @@ English version below
 - Amélioration des appariements par ordre alphabétique (3.0.0)
 - Ajout des titres FIDE dans les attributions de prix (3.0.0)
 - Ajout des départages sur les grilles Berger (3.0.0)
+
+## ChessEvent
+
+- Correction du téléversement FFE après mise à jour ChessEvent (3.0.1)
 
 ---
 
@@ -83,6 +88,7 @@ English version below
 - Removed automatic renumbering of boards when manually pairing (3.0.0)
 - Entry of unrated and penalty results (3.0.0)
 - Added player search on the pairings tab (3.0.0)
+- Fixed player search on the Pairings tab (3.0.2)
 
 ## Screens
 
@@ -100,3 +106,7 @@ English version below
 - Improved alphabétical pairings (3.0.0)
 - Added FIDE titles on prize assignments (3.0.0)
 - Added tie-breaks to Berger grids (3.0.0)
+
+## ChessEvent
+
+- Fixed FFE upload after ChessEvent update (3.0.1)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,6 +58,10 @@ English version below
 - Correction de l'impression des appariements par ordre alphabétique (3.0.2)
 - Affichage des joueur⋅euses de la table 1 dans l'impression des appariements par ordre alphabétique (3.0.3)
 
+## FFE
+
+- Correction des données de classement utilisées lors de l'export Papi (3.0.4)
+
 ## ChessEvent
 
 - Correction du téléversement FFE après mise à jour ChessEvent (3.0.1)
@@ -122,6 +126,10 @@ English version below
 - Added tie-breaks to Berger grids (3.0.0)
 - Fixed printing of pairings in alphabetical order (3.0.2)
 - Re-added board #1 players to pairings in alphabetical order (3.0.3)
+
+## FFE
+
+- Fixed a data difference on rankings in the Papi export (3.0.4)
 
 ## ChessEvent
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ English version below
 - Support de macOS (Apple Silicon Macs seulement, 3.0.0)
 - Amélioration des temps de réponses de l'interface utilisateur (3.0.0)
 - Signature des exécutables Windows (3.0.0)
+- Correction de la récupération des versions précédentes (3.0.1)
 
 ## Évènements
 
@@ -34,7 +35,7 @@ English version below
 ## Écrans
 
 - Ajout du numéro dans le cas des échiquiers fixes (3.0.0)
-- Correction d'un bug sur l'affichage des chronomètres sur les écrans rotatifs et les pilotes d'afficheurs (3.0.1)
+- Correction de l'affichage des chronomètres sur les écrans rotatifs et les pilotes d'afficheurs (3.0.1)
 
 ## Classements
 
@@ -58,6 +59,7 @@ English version below
 - Native macOS support (Apple Silicon Macs only, 3.0.0)
 - Improved UI response times (3.0.0)
 - Use signed programs on Windows (3.0.0)
+- Fixed previous versions recovering (3.0.1)
 
 ## Events
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -63,6 +63,7 @@ English version below
 
 - Correction des données de classement utilisées lors de l'export Papi (3.0.4)
 - Correction de l'import du numéro d'homologation depuis Papi (3.0.5)
+- Correction du téléversement FFE (3.0.6)
 
 ## ChessEvent
 
@@ -134,6 +135,7 @@ English version below
 
 - Fixed a data difference on rankings in the Papi export (3.0.4)
 - Fixed the import of the Papi homologation number (3.0.5)
+- Fix a bug preventing upload (3.0.6)
 
 ## ChessEvent
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,6 +53,7 @@ English version below
 - Amélioration des appariements par ordre alphabétique (3.0.0)
 - Ajout des titres FIDE dans les attributions de prix (3.0.0)
 - Ajout des départages sur les grilles Berger (3.0.0)
+- Correction du document d'appariements par joueur·euse (3.0.2)
 
 ## ChessEvent
 
@@ -114,6 +115,7 @@ English version below
 - Improved alphabétical pairings (3.0.0)
 - Added FIDE titles on prize assignments (3.0.0)
 - Added tie-breaks to Berger grids (3.0.0)
+- Fixed the player pairings document (3.0.2)
 
 ## ChessEvent
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,7 +53,7 @@ English version below
 - Amélioration des appariements par ordre alphabétique (3.0.0)
 - Ajout des titres FIDE dans les attributions de prix (3.0.0)
 - Ajout des départages sur les grilles Berger (3.0.0)
-- Correction du document d'appariements par joueur·euse (3.0.2)
+- Correction de l'impression des appariements par ordre alphabétique (3.0.2)
 
 ## ChessEvent
 
@@ -115,7 +115,7 @@ English version below
 - Improved alphabétical pairings (3.0.0)
 - Added FIDE titles on prize assignments (3.0.0)
 - Added tie-breaks to Berger grids (3.0.0)
-- Fixed the player pairings document (3.0.2)
+- Fixed printing of pairings in alphabetical order (3.0.2)
 
 ## ChessEvent
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,7 +35,6 @@ English version below
 - Saisie des résultats non comptabilisés et des pénalités (3.0.0)
 - Ajout de la recherche de joueur·euse sur l'onglet Appariements (3.0.0)
 - Correction de la recherche des joueur·euses sur l'onglet Appariements (3.0.2)
-- Amélioration de la navigation sur l'onglet Appariements (3.0.2)
 
 ## Écrans
 
@@ -97,7 +96,6 @@ English version below
 - Entry of unrated and penalty results (3.0.0)
 - Added player search on the Pairings tab (3.0.0)
 - Fixed player search on the Pairings tab (3.0.2)
-- Improved navigation on the Pairings tab (3.0.2)
 
 ## Screens
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,6 +53,7 @@ English version below
 - Ajout des titres FIDE dans les attributions de prix (3.0.0)
 - Ajout des départages sur les grilles Berger (3.0.0)
 - Correction de l'impression des appariements par ordre alphabétique (3.0.2)
+- Affichage des joueur⋅euses de la table 1 dans l'impression des appariements par ordre alphabétique (3.0.3)
 
 ## ChessEvent
 
@@ -114,6 +115,7 @@ English version below
 - Added FIDE titles on prize assignments (3.0.0)
 - Added tie-breaks to Berger grids (3.0.0)
 - Fixed printing of pairings in alphabetical order (3.0.2)
+- Re-added board 1 players to pairings in alphabetcal order (3.0.3)
 
 ## ChessEvent
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,10 +19,12 @@ English version below
 - Création des tournois par import d'un fichier Papi (3.0.0)
 - Export des tournois au format Papi (3.0.0)
 - Éditeur interactif de la cadence de jeu (3.0.0)
+- Correction de l'import Papi (3.0.2)
 
 ## Joueur·euses
 
 - Suppression de la limite à 10 caractères des numéros de téléphone (3.0.0)
+- Prise en compte des accents dans la recherche dans la base locale FFE (3.0.2)
 
 ## Appariements
 
@@ -31,7 +33,7 @@ English version below
 - Suppression de la renumérotation automatique des échiquiers en cas d'appariement manuel (3.0.0)
 - Saisie des résultats non comptabilisés et des pénalités (3.0.0)
 - Ajout de la recherche de joueur·euse sur l'onglet Appariements (3.0.0)
-- Correction de la recherche des joueur·euses sur l'onglet Appariements (3.0.2)
+- Correction de la recherche des joueur·euses et amélioration de la navigation sur l'onglet Appariements (3.0.2)
 
 ## Écrans
 
@@ -76,10 +78,12 @@ English version below
 - Create tournaments from Papi files (3.0.0)
 - Export tournaments to Papi format (3.0.0)
 - Interactive time control editor (3.0.0)
+- Fixed Papi import (3.0.2)
 
 ## Players
 
 - Removed the 10-character limit on phone numbers (3.0.0)
+- Accents handling for local FFE database search (3.0.2)
 
 ## Pairings
 
@@ -88,7 +92,7 @@ English version below
 - Removed automatic renumbering of boards when manually pairing (3.0.0)
 - Entry of unrated and penalty results (3.0.0)
 - Added player search on the pairings tab (3.0.0)
-- Fixed player search on the Pairings tab (3.0.2)
+- Fixed player search and improved navigation on the Pairings tab (3.0.2)
 
 ## Screens
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -61,6 +61,7 @@ English version below
 ## FFE
 
 - Correction des données de classement utilisées lors de l'export Papi (3.0.4)
+- Correction de l'import du numéro d'homologation depuis Papi (3.0.5)
 
 ## ChessEvent
 
@@ -130,6 +131,7 @@ English version below
 ## FFE
 
 - Fixed a data difference on rankings in the Papi export (3.0.4)
+- Fixed the import of the Papi homologation number (3.0.5)
 
 ## ChessEvent
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,6 +34,7 @@ English version below
 ## Écrans
 
 - Ajout du numéro dans le cas des échiquiers fixes (3.0.0)
+- Correction d'un bug sur l'affichage des chronomètres sur les écrans rotatifs et les pilotes d'afficheurs (3.0.1)
 
 ## Classements
 
@@ -84,6 +85,7 @@ English version below
 ## Screens
 
 - Added board IDs in case of fixed boards (3.0.0)
+- Fixed the display of timers on rotators and display controllers (3.0.1)
 
 ## Rankings
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,7 @@ English version below
 - Export des tournois au format Papi (3.0.0)
 - Éditeur interactif de la cadence de jeu (3.0.0)
 - Correction de l'import Papi (3.0.2)
+- Correction des boutons d'export exportant le mauvais tournoi (3.0.2)
 
 ## Joueur·euses
 
@@ -79,6 +80,7 @@ English version below
 - Export tournaments to Papi format (3.0.0)
 - Interactive time control editor (3.0.0)
 - Fixed Papi import (3.0.2)
+- Fixed export buttons exporting the wrong tournament (3.0.2)
 
 ## Players
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,7 +26,6 @@ English version below
 ## Appariements
 
 - Affichage des informations d'appariement : groupes, flotteurs, historiques et préférences couleurs (3.0.0)
-– Affichage du classement du tournoi dans l’onglet Appariements après la dernière ronde (3.0.0)
 - Remplacement des classements estimés rapide/blitz par les classements standards (3.0.0)
 - Suppression de la renumérotation automatique des échiquiers en cas d'appariement manuel (3.0.0)
 - Saisie des résultats non comptabilisés et des pénalités (3.0.0)
@@ -77,7 +76,6 @@ English version below
 ## Pairings
 
 - Display pairing information: groups, floaters, history and colour preferences (3.0.0)
-- Display of tournament rankings in Pairings tab after last round (3.0.0)
 - Allow overriding of unrated rapid/blitz ratings by standard ratings (3.0.0)
 - Removed automatic renumbering of boards when manually pairing (3.0.0)
 - Entry of unrated and penalty results (3.0.0)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,8 @@ English version below
 
 - Suppression de la limite à 10 caractères des numéros de téléphone (3.0.0)
 - Prise en compte des accents dans la recherche dans la base locale FFE (3.0.2)
+- Correction du tri des joueur·euses sans prénom (3.0.3)
+- Correction de la recherche des joueur·euses avec des prénoms multiples (3.0.3)
 
 ## Appariements
 
@@ -40,6 +42,7 @@ English version below
 
 - Ajout du numéro dans le cas des échiquiers fixes (3.0.0)
 - Correction de l'affichage des chronomètres sur les écrans rotatifs et les pilotes d'afficheurs (3.0.1)
+- Correction de l'affichage des écrans rotatifs lorsqu'aucun écran n'est sélectionné (3.0.3)
 
 ## Classements
 
@@ -88,6 +91,8 @@ English version below
 
 - Removed the 10-character limit on phone numbers (3.0.0)
 - Accents handling for local FFE database search (3.0.2)
+- Fixed players sort with no firstname (3.0.3)
+- Fixed player search on split names (3.0.3)
 
 ## Pairings
 
@@ -102,6 +107,7 @@ English version below
 
 - Added board IDs in case of fixed boards (3.0.0)
 - Fixed the display of timers on rotators and display controllers (3.0.1)
+- Fixed the display of rotators when no screen is selected (3.0.3)
 
 ## Rankings
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,7 +34,8 @@ English version below
 - Suppression de la renumérotation automatique des échiquiers en cas d'appariement manuel (3.0.0)
 - Saisie des résultats non comptabilisés et des pénalités (3.0.0)
 - Ajout de la recherche de joueur·euse sur l'onglet Appariements (3.0.0)
-- Correction de la recherche des joueur·euses et amélioration de la navigation sur l'onglet Appariements (3.0.2)
+- Correction de la recherche des joueur·euses sur l'onglet Appariements (3.0.2)
+- Amélioration de la navigation sur l'onglet Appariements (3.0.2)
 
 ## Écrans
 
@@ -93,8 +94,9 @@ English version below
 - Allow overriding of unrated rapid/blitz ratings by standard ratings (3.0.0)
 - Removed automatic renumbering of boards when manually pairing (3.0.0)
 - Entry of unrated and penalty results (3.0.0)
-- Added player search on the pairings tab (3.0.0)
-- Fixed player search and improved navigation on the Pairings tab (3.0.2)
+- Added player search on the Pairings tab (3.0.0)
+- Fixed player search on the Pairings tab (3.0.2)
+- Improved navigation on the Pairings tab (3.0.2)
 
 ## Screens
 

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -5662,9 +5662,3 @@ msgstr ""
 msgid "½ - ½ (U)"
 msgstr ""
 
-#~ msgid "Password to enter results:"
-#~ msgstr ""
-
-#~ msgid "The password required on input screens to enter results (optional)."
-#~ msgstr ""
-

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -331,6 +331,9 @@ msgstr ""
 msgid "Add a display controller to the event."
 msgstr ""
 
+msgid "Add a family of screens to check-in players or enter results."
+msgstr ""
+
 msgid "Add a family of screens to display the pairings by alphabetical order."
 msgstr ""
 
@@ -338,9 +341,6 @@ msgid "Add a family of screens to display the pairings by board."
 msgstr ""
 
 msgid "Add a family of screens to display the ranking."
-msgstr ""
-
-msgid "Add a family of screens to enter the results."
 msgstr ""
 
 msgid "Add a group to the list."
@@ -361,6 +361,9 @@ msgstr ""
 msgid "Add a rotator to the event."
 msgstr ""
 
+msgid "Add a screen to check-in players or enter results."
+msgstr ""
+
 msgid "Add a screen to display an image."
 msgstr ""
 
@@ -374,9 +377,6 @@ msgid "Add a screen to display the pairings by board."
 msgstr ""
 
 msgid "Add a screen to display the ranking."
-msgstr ""
-
-msgid "Add a screen to enter the results."
 msgstr ""
 
 msgid "Add a set"
@@ -762,6 +762,15 @@ msgstr ""
 
 msgid "Check-in *** CHECK-IN FOR PLAYERS COLUMNS"
 msgstr "Check-in"
+
+msgid "Check-in / Results entry"
+msgstr ""
+
+msgid "Check-in / Results entry ({num})"
+msgstr ""
+
+msgid "Check-in / Results entry ({tournament_name})"
+msgstr ""
 
 #, python-format
 msgid "Check-in is closed for tournament [%(tournament)s]."
@@ -3303,9 +3312,6 @@ msgstr ""
 msgid "Password to enter results"
 msgstr ""
 
-msgid "Password to enter results:"
-msgstr ""
-
 msgid "Penalties require a time control with a single period."
 msgstr ""
 
@@ -3656,6 +3662,9 @@ msgstr ""
 msgid "Properties"
 msgstr ""
 
+msgid "Properties (check-in and results entry)"
+msgstr ""
+
 msgid "Properties (pairings by board)"
 msgstr ""
 
@@ -3663,9 +3672,6 @@ msgid "Properties (pairings by player)"
 msgstr ""
 
 msgid "Properties (ranking)"
-msgstr ""
-
-msgid "Properties (results entry)"
 msgstr ""
 
 msgid "Protected pairings editing"
@@ -3858,15 +3864,6 @@ msgid "Result [{result}] is not compatible with the PAPI format."
 msgstr ""
 
 msgid "Results"
-msgstr ""
-
-msgid "Results entry"
-msgstr ""
-
-msgid "Results entry ({num})"
-msgstr ""
-
-msgid "Results entry ({tournament_name})"
 msgstr ""
 
 msgid "Results for round #{round}"
@@ -4518,9 +4515,6 @@ msgid "The password is made of 10 uppercase letters, it is used to connect to th
 msgstr ""
 
 msgid "The password of the tournament on the FFE website is made of 10 uppercase letters."
-msgstr ""
-
-msgid "The password required on input screens to enter results (optional)."
 msgstr ""
 
 msgid "The password used to connect to the ChessEvent platform (by default the password defined for the Sharly Chess event of the tournament)."
@@ -5667,4 +5661,10 @@ msgstr ""
 
 msgid "½ - ½ (U)"
 msgstr ""
+
+#~ msgid "Password to enter results:"
+#~ msgstr ""
+
+#~ msgid "The password required on input screens to enter results (optional)."
+#~ msgstr ""
 

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "Organize your prizes into groups to manage how they’re awarded. A player can win only one prize per group, but can win prizes in multiple groups."
 msgstr ""
 
-msgid "Other players in this score group are not included since the share would be less than the threshold."
+msgid "Other players in this score group are not awarded prizes, as their share would be less than the minimum threshold."
 msgstr ""
 
 msgid "Other tie-breaks should not be used unless you really know what you do."

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -331,6 +331,9 @@ msgstr "Ajouter un critère à la liste."
 msgid "Add a display controller to the event."
 msgstr "Ajouter un pilote d'afficheurs."
 
+msgid "Add a family of screens to check-in players or enter results."
+msgstr "Ajouter une famille d'écrans à l'évènement."
+
 msgid "Add a family of screens to display the pairings by alphabetical order."
 msgstr "Ajouter à l'évènement une nouvelle famille d'écrans d'affichage des appariements par échiquier."
 
@@ -339,9 +342,6 @@ msgstr "Ajouter à l'évènement une nouvelle famille d'écrans de saisie des r�
 
 msgid "Add a family of screens to display the ranking."
 msgstr "Ajouter à l'évènement une nouvelle famille d'écrans d'affichage du classement."
-
-msgid "Add a family of screens to enter the results."
-msgstr "Ajouter une famille d'écrans à l'évènement."
 
 msgid "Add a group to the list."
 msgstr "Ajouter un groupe à la liste"
@@ -361,6 +361,9 @@ msgstr "Ajouter un prix à la liste."
 msgid "Add a rotator to the event."
 msgstr "Ajouter un écran rotatif à l'évènement."
 
+msgid "Add a screen to check-in players or enter results."
+msgstr "Ajouter un écran de saisie des résultats."
+
 msgid "Add a screen to display an image."
 msgstr "Ajouter un écran d'affichage d'une image."
 
@@ -375,9 +378,6 @@ msgstr "Ajouter un écran d'affichage des appariements par échiquier."
 
 msgid "Add a screen to display the ranking."
 msgstr "Ajouter un écran d'affichage du classement."
-
-msgid "Add a screen to enter the results."
-msgstr "Ajouter un écran de saisie des résultats."
 
 msgid "Add a set"
 msgstr "Ajouter un ensemble"
@@ -762,6 +762,15 @@ msgstr "Pointage"
 
 msgid "Check-in *** CHECK-IN FOR PLAYERS COLUMNS"
 msgstr "Pointage"
+
+msgid "Check-in / Results entry"
+msgstr "Pointage / Saisie des résultats"
+
+msgid "Check-in / Results entry ({num})"
+msgstr "Pointage / Saisie des résultats ({num})"
+
+msgid "Check-in / Results entry ({tournament_name})"
+msgstr "Pointage / Saisie des résultats ({tournament_name})"
 
 #, python-format
 msgid "Check-in is closed for tournament [%(tournament)s]."
@@ -3303,9 +3312,6 @@ msgstr "Mot de passe"
 msgid "Password to enter results"
 msgstr "Mot de passe de saisie des résultats"
 
-msgid "Password to enter results:"
-msgstr "Mot de passe de saisie des résultats :"
-
 msgid "Penalties require a time control with a single period."
 msgstr "Les pénalités nécessitent une cadence avec une seule période."
 
@@ -3656,6 +3662,9 @@ msgstr "Cumulatif"
 msgid "Properties"
 msgstr "Propriétés"
 
+msgid "Properties (check-in and results entry)"
+msgstr "Propriétés (pointage et saisie des résultats)"
+
 msgid "Properties (pairings by board)"
 msgstr "Propriétés (appariements par échiquier)"
 
@@ -3664,9 +3673,6 @@ msgstr "Propriétés (appariements par ordre alphabétique)"
 
 msgid "Properties (ranking)"
 msgstr "Propriétés (classement)"
-
-msgid "Properties (results entry)"
-msgstr "Propriétés (saisie des résultats)"
 
 msgid "Protected pairings editing"
 msgstr "Édition d'appariements protégés"
@@ -3859,15 +3865,6 @@ msgstr "Le résultat [{result}] n’est pas compatible avec le format PAPI."
 
 msgid "Results"
 msgstr "Résultats"
-
-msgid "Results entry"
-msgstr "Saisie des résultats"
-
-msgid "Results entry ({num})"
-msgstr "Saisie des résultats ({num})"
-
-msgid "Results entry ({tournament_name})"
-msgstr "Saisie des résultats ({tournament_name})"
 
 msgid "Results for round #{round}"
 msgstr "Résultats de la ronde {round}"
@@ -4519,9 +4516,6 @@ msgstr "La mot de passe est composé de 10 caractères majuscules, il est utilis
 
 msgid "The password of the tournament on the FFE website is made of 10 uppercase letters."
 msgstr "Le mot de passe du tournoi sur le site FFE doit être composé de 10 lettres majuscules."
-
-msgid "The password required on input screens to enter results (optional)."
-msgstr "Le mot de passe qui sera demandé sur les écrans de saisie pour entrer les résultats (facultatif)."
 
 msgid "The password used to connect to the ChessEvent platform (by default the password defined for the Sharly Chess event of the tournament)."
 msgstr "Le mot de passe utilisé pour se connecter sur la plateforme ChessEvent (par défaut le mot de passe ChessEvent défini pour l'évènement Sharly Chess du tournoi)."
@@ -5667,4 +5661,10 @@ msgstr "½ - 0 (NC)"
 
 msgid "½ - ½ (U)"
 msgstr "½ - ½ (NC)"
+
+#~ msgid "Password to enter results:"
+#~ msgstr "Mot de passe de saisie des résultats :"
+
+#~ msgid "The password required on input screens to enter results (optional)."
+#~ msgstr "Le mot de passe qui sera demandé sur les écrans de saisie pour entrer les résultats (facultatif)."
 

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -5662,9 +5662,3 @@ msgstr "½ - 0 (NC)"
 msgid "½ - ½ (U)"
 msgstr "½ - ½ (NC)"
 
-#~ msgid "Password to enter results:"
-#~ msgstr "Mot de passe de saisie des résultats :"
-
-#~ msgid "The password required on input screens to enter results (optional)."
-#~ msgstr "Le mot de passe qui sera demandé sur les écrans de saisie pour entrer les résultats (facultatif)."
-

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -3144,8 +3144,8 @@ msgstr "Adversaires"
 msgid "Organize your prizes into groups to manage how they’re awarded. A player can win only one prize per group, but can win prizes in multiple groups."
 msgstr "Organisez vos prix en groupes pour gérer leur attribution. Un·e joueur·euse ne peut recevoir qu’un seul prix par groupe, mais peut recevoir des prix dans plusieurs groupes."
 
-msgid "Other players in this score group are not included since the share would be less than the threshold."
-msgstr "Les autres joueur·euses de ce groupe de score n'ont pas été inclus·es, car leur part serait inférieure au seuil."
+msgid "Other players in this score group are not awarded prizes, as their share would be less than the minimum threshold."
+msgstr "Les autres joueur·euses de ce groupe de points n'entrent pas dans les prix (prix inférieur au seuil minimum)."
 
 msgid "Other tie-breaks should not be used unless you really know what you do."
 msgstr "Les autres départages ne devraient pas être utilisés à moins que vous ne sachiez réellement ce que vous faites."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "sharly-chess"
 description = "An application to help chess arbiters and organizers manage their tournaments"
 requires-python = ">=3.12.0"
-version = "3.0.1"
+version = "3.0.2"
 
 authors = [
   { name = "Pascal Aubry", email = "support@sharly-chess.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "sharly-chess"
 description = "An application to help chess arbiters and organizers manage their tournaments"
 requires-python = ">=3.12.0"
-version = "3.0.2"
+version = "3.0.3"
 
 authors = [
   { name = "Pascal Aubry", email = "support@sharly-chess.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "sharly-chess"
 description = "An application to help chess arbiters and organizers manage their tournaments"
 requires-python = ">=3.12.0"
-version = "3.0.3"
+version = "3.0.4"
 
 authors = [
   { name = "Pascal Aubry", email = "support@sharly-chess.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "sharly-chess"
 description = "An application to help chess arbiters and organizers manage their tournaments"
 requires-python = ">=3.12.0"
-version = "3.0.0b4"
+version = "3.0.0"
 
 authors = [
   { name = "Pascal Aubry", email = "support@sharly-chess.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "sharly-chess"
 description = "An application to help chess arbiters and organizers manage their tournaments"
 requires-python = ">=3.12.0"
-version = "3.0.4"
+version = "3.0.5"
 
 authors = [
   { name = "Pascal Aubry", email = "support@sharly-chess.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "sharly-chess"
 description = "An application to help chess arbiters and organizers manage their tournaments"
 requires-python = ">=3.12.0"
-version = "3.0.5"
+version = "3.0.6"
 
 authors = [
   { name = "Pascal Aubry", email = "support@sharly-chess.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "sharly-chess"
 description = "An application to help chess arbiters and organizers manage their tournaments"
 requires-python = ">=3.12.0"
-version = "3.0.0"
+version = "3.0.1"
 
 authors = [
   { name = "Pascal Aubry", email = "support@sharly-chess.com" },

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -19,7 +19,7 @@ SHARLY_CHESS_VERSION: Version = Version(importlib.metadata.version(APP_NAME))
 DEVEL_ENV: bool = not getattr(sys, 'frozen', False)
 TEST_ENV: bool = os.getenv('TEST_ENV') == 'true' or Path(sys.argv[0]).stem == 'pytest'
 
-# True when experimental features are enabled (relying on an engine option), False otherwise.
+# True when experimental features are enabled, False otherwise.
 _EXPERIMENTAL_FEATURES_ENABLED: bool = False
 
 
@@ -31,6 +31,19 @@ def enable_experimental_features(enabled: bool):
 def experimental_features_enabled() -> bool:
     global _EXPERIMENTAL_FEATURES_ENABLED
     return _EXPERIMENTAL_FEATURES_ENABLED
+
+
+_IS_SERVER_ENGINE: bool = False
+
+
+def set_is_server_engine(is_server_engine_: bool):
+    global _IS_SERVER_ENGINE
+    _IS_SERVER_ENGINE = is_server_engine_
+
+
+def is_server_engine() -> bool:
+    global _IS_SERVER_ENGINE
+    return _IS_SERVER_ENGINE
 
 
 REQUEST_TIMEOUT: int = 10

--- a/src/data/event.py
+++ b/src/data/event.py
@@ -406,7 +406,7 @@ class Event:
     def players_sorted_by_name(self) -> list[Player]:
         return sorted(
             self.players_by_id.values(),
-            key=lambda player: (player.last_name, player.first_name),
+            key=lambda player: (player.last_name, player.first_name or ''),
         )
 
     @cached_property

--- a/src/data/input_output/tournament_importers.py
+++ b/src/data/input_output/tournament_importers.py
@@ -52,6 +52,10 @@ class TournamentImporter(IdentifiableEntity, ABC):
         with EventDatabase(event.uniq_id, True) as database:
             if tournament:
                 database.delete_players_in_tournament(tournament.id)
+            else:
+                stored_tournament.name = event.get_unused_tournament_name(
+                    stored_tournament.name
+                )
             tournament_id = self._write_stored_tournament(
                 stored_tournament, stored_players, database
             )

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -67,11 +67,11 @@ class EventLoader:
 
     @classmethod
     def _clean_not_existing_event_database_files(cls, event_uniq_ids: set[str]):
-        to_remove = (
+        to_remove = [
             uniq_id
             for uniq_id in event_uniq_ids
             if not EventDatabase.event_database_path(uniq_id).exists()
-        )
+        ]
         for uniq_id in to_remove:
             event_uniq_ids.remove(uniq_id)
 

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -28,8 +28,8 @@ logger: Logger = get_logger()
 
 
 class EventLoader:
-    _valid_event_ids: list[str] = []
-    _invalid_uniq_ids: list[str] = []
+    _valid_event_ids: set[str] = set()
+    _invalid_uniq_ids: set[str] = set()
 
     @classmethod
     def get(cls, request: HTMXRequest | None):
@@ -49,7 +49,7 @@ class EventLoader:
     def load_event_ids(cls, uniq_id: str | None = None):
         cls._clean_not_existing_event_database_files(cls._valid_event_ids)
         cls._clean_not_existing_event_database_files(cls._invalid_uniq_ids)
-        known_event_ids = cls._valid_event_ids + cls._invalid_uniq_ids
+        known_event_ids = cls._valid_event_ids | cls._invalid_uniq_ids
         event_ids = [uniq_id] if uniq_id is not None else cls.all_event_ids()
         for event_id in event_ids:
             if event_id in known_event_ids:
@@ -60,13 +60,13 @@ class EventLoader:
                 if not status:
                     with EventDatabase(event_id, True) as database:
                         database.upgrade()
-                cls._valid_event_ids.append(event_id)
+                cls._valid_event_ids.add(event_id)
             except SharlyChessException as e:
                 logger.error(e)
-                cls._invalid_uniq_ids.append(event_id)
+                cls._invalid_uniq_ids.add(event_id)
 
     @classmethod
-    def _clean_not_existing_event_database_files(cls, event_uniq_ids: list[str]):
+    def _clean_not_existing_event_database_files(cls, event_uniq_ids: set[str]):
         to_remove = (
             uniq_id
             for uniq_id in event_uniq_ids
@@ -78,7 +78,7 @@ class EventLoader:
     @cached_property
     def event_uniq_ids(self) -> list[str]:
         self.load_event_ids()
-        return self._valid_event_ids
+        return list(self._valid_event_ids)
 
     @classmethod
     def all_event_ids(cls) -> list[str]:

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -13,7 +13,6 @@ from packaging.version import Version
 
 from common import (
     format_timestamp_date_time,
-    unicode_normalize,
     SHARLY_CHESS_VERSION,
     EVENTS_DIR,
 )
@@ -23,6 +22,7 @@ from common.logger import get_logger
 from data.event import Event
 from database.sqlite.event.event_database import EventDatabase
 from database.sqlite.event.event_store import EventMetadata
+from utils import StaticUtils
 
 logger: Logger = get_logger()
 
@@ -111,41 +111,12 @@ class EventLoader:
         return ids
 
     def get_unused_event_uniq_id(self, base_uniq_id: str) -> str:
-        """Returns the first unused event uniq_id looking like base_uniq_id:
-        base_uniq_id, or base_uniq_id-2, or base_uniq_id-n+1..."""
-        index: int
-        uniq_id: str
-        base_uniq_id = unicode_normalize(base_uniq_id)
-        if matches := re.match(r'^(.*)-(\d+)$', base_uniq_id):
-            base_uniq_id = matches.group(1)
-            index = int(matches.group(2))
-            uniq_id = f'{base_uniq_id}-{index + 1}'
-        else:
-            index = 1
-            uniq_id = base_uniq_id
-        used_event_ids = self.all_event_ids()
-        while uniq_id in used_event_ids:
-            index += 1
-            uniq_id = f'{base_uniq_id}-{index}'
-        return uniq_id
+        return StaticUtils.get_unused_item_uniq_id(base_uniq_id, self.all_event_ids())
 
     def get_unused_event_name(self, base_name: str) -> str:
-        """Returns the first unused event name looking like base_name:
-        base_name, or base_name (2), or base_name (n+1)..."""
-        index: int
-        name: str
-        if matches := re.match(r'^(.*) \((\d+)\)$', base_name):
-            base_name = matches.group(1)
-            index = int(matches.group(2))
-            name = f'{base_name} ({index + 1})'
-        else:
-            index = 1
-            name = base_name
-        event_names: list[str] = [event.name for event in self.events_by_id.values()]
-        while name in event_names:
-            index += 1
-            name = f'{base_name} ({index})'
-        return name
+        return StaticUtils.get_unused_item_name(
+            base_name, [event.name for event in self.get_events_metadata()]
+        )
 
     def load_event(self, uniq_id: str) -> Event:
         self.load_event_ids(uniq_id)
@@ -154,24 +125,15 @@ class EventLoader:
         return event
 
     @cached_property
-    def events_by_id(self) -> dict[str, Event]:
+    def events_sorted_by_name(self) -> list[Event]:
+        # TODO (Molrn) Remove (loading all the events at once should be avoided at all cost)
         events_by_id: dict[str, Event] = {}
         for uniq_id in self.event_uniq_ids:
             try:
                 events_by_id[uniq_id] = self.load_event(uniq_id)
             except SharlyChessException as pwe:
                 logger.error(pwe)
-        return events_by_id
-
-    @cached_property
-    def events_sorted_by_name(self) -> list[Event]:
-        return sorted(self.events_by_id.values(), key=lambda event: event.name)
-
-    @cached_property
-    def events_with_tournaments_sorted_by_name(self) -> list[Event]:
-        return [
-            event for event in self.events_sorted_by_name if event.tournaments_by_id
-        ]
+        return sorted(events_by_id.values(), key=lambda event: event.name)
 
     @classmethod
     def load_event_metadata(cls, uniq_id: str) -> EventMetadata:

--- a/src/data/print_documents/documents.py
+++ b/src/data/print_documents/documents.py
@@ -473,6 +473,7 @@ class PlayerPairingPrintDocument(PlayerPrintDocument):
     @property
     def ordered_players(self) -> list[Player]:
         assert self.tournament is not None
+        self.tournament.set_for_round(self.at_round)
         return self.tournament.players_by_name_without_unpaired
 
     @override

--- a/src/data/prize/prize_group.py
+++ b/src/data/prize/prize_group.py
@@ -377,7 +377,7 @@ class PrizeGroup:
                 key=lambda prize: (
                     prize.place_index,
                     prize.assigned_to is None,
-                    prize.assigned_to.rank if prize.assigned_to else None,
+                    prize.assigned_to.rank if prize.assigned_to else 0,
                 ),
             )
         return assigned_prizes_by_category_id

--- a/src/data/prize/prize_sharing.py
+++ b/src/data/prize/prize_sharing.py
@@ -95,7 +95,7 @@ class AveragePrizeSharing(PrizeSharing):
                         value=share,
                         is_main=True,
                         warning=_(
-                            'Other players in this score group are not included since the share would be less than the threshold.'
+                            'Other players in this score group are not awarded prizes, as their share would be less than the minimum threshold.'
                         )
                         if is_last and warning
                         else None,
@@ -157,7 +157,7 @@ class HortSystemPrizeSharing(PrizeSharing):
                         value=(own + total / len(players_in_tie)) / 2,
                         is_main=True,
                         warning=_(
-                            'Other players in this score group are not included since the share would be less than the threshold.'
+                            'Other players in this score group are not awarded prizes, as their share would be less than the minimum threshold.'
                         )
                         if is_last and warning
                         else None,

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -428,7 +428,7 @@ class Tournament:
                 player
                 for player in self.players
                 if not self.current_round
-                or player.board_id
+                or player.board_id is not None
                 and player not in self.unpaired_players
             ],
             key=lambda p: (p.last_name, p.first_name or ''),

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -418,7 +418,7 @@ class Tournament:
     def players_by_name_with_unpaired(self) -> list[Player]:
         return sorted(
             self.players,
-            key=lambda player: (player.last_name, player.first_name),
+            key=lambda player: (player.last_name, player.first_name or ''),
         )
 
     @cached_property
@@ -431,7 +431,7 @@ class Tournament:
                 or player.board_id
                 and player not in self.unpaired_players
             ],
-            key=lambda p: (p.last_name, p.first_name),
+            key=lambda p: (p.last_name, p.first_name or ''),
         )
 
     @property

--- a/src/database/sqlite/config/migrations/m006_force_edit_federation.py
+++ b/src/database/sqlite/config/migrations/m006_force_edit_federation.py
@@ -1,0 +1,11 @@
+from database.sqlite.migration import BaseMigration
+
+
+class Migration(BaseMigration):
+    def forward(self):
+        self.database.execute('SELECT `federation` FROM `info`')
+        if not self.database.fetchone()['federation']:
+            self.database.execute('UPDATE `info` SET `force_edit` = 1')
+
+    def backward(self):
+        pass

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -1,5 +1,4 @@
 import shutil
-from sqlite3 import OperationalError
 import time
 from collections.abc import Iterator
 from contextlib import suppress
@@ -79,22 +78,28 @@ class EventDatabase(MigrationDatabase):
             super().__init__(self.event_database_path(self.uniq_id), write)
 
     def __exit__(self, exc_type, exc_value, tb):
-        dirty_tournaments: list[int] = []
-        if self.write and exc_type is None:
-            try:
-                self.execute('SELECT `id` FROM tournament WHERE dirty = 1;')
-                dirty_tournaments = [row['id'] for row in self.fetchall()]
+        dirty_tournaments: list[StoredTournament] = []
+        stored_event: StoredEvent | None = None
+        if self.write and exc_type is None and is_server_engine():
+            self.execute('SELECT * FROM tournament WHERE dirty = 1;')
+            dirty_tournaments = [
+                self._row_to_stored_tournament(row) for row in self.fetchall()
+            ]
+            if dirty_tournaments:
+                self.execute('SELECT * FROM `info`')
+                stored_event = self._row_to_base_stored_event(
+                    self.fetchone(), StoredEvent
+                )
                 self.execute('UPDATE tournament SET dirty = 0 WHERE dirty = 1;')
-            except OperationalError:
-                pass
+
         super().__exit__(exc_type, exc_value, tb)
 
         # We need call the hook on all dirty tournaments after committing the changes above
-        if self.write and exc_type is None and is_server_engine():
-            for tournament_id in dirty_tournaments:
-                plugin_manager.hook.on_tournament_data_updated(
-                    event_uniq_id=self.uniq_id, tournament_id=tournament_id
-                )
+        for stored_tournament in dirty_tournaments:
+            plugin_manager.hook.on_tournament_data_updated(
+                stored_event=stored_event,
+                stored_tournament=stored_tournament,
+            )
 
     @classmethod
     def create_instance(cls, file: Path, write: bool = False) -> Self:

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -80,7 +80,12 @@ class EventDatabase(MigrationDatabase):
     def __exit__(self, exc_type, exc_value, tb):
         dirty_tournaments: list[StoredTournament] = []
         stored_event: StoredEvent | None = None
-        if self.write and exc_type is None and is_server_engine():
+        if (
+            self.write
+            and exc_type is None
+            and is_server_engine()
+            and EVENTS_DIR.resolve() in self.file.resolve().parents
+        ):
             self.execute('SELECT * FROM tournament WHERE dirty = 1;')
             dirty_tournaments = [
                 self._row_to_stored_tournament(row) for row in self.fetchall()

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -10,7 +10,13 @@ from typing import Any, TYPE_CHECKING, override, Self, cast
 
 from packaging.version import Version
 
-from common import format_timestamp_date, format_timestamp_time, DEVEL_ENV, EVENTS_DIR
+from common import (
+    format_timestamp_date,
+    format_timestamp_time,
+    DEVEL_ENV,
+    EVENTS_DIR,
+    is_server_engine,
+)
 from common.logger import get_logger
 from common.sharly_chess_config import SharlyChessConfig
 from database.sqlite.event.event_store import (
@@ -84,7 +90,7 @@ class EventDatabase(MigrationDatabase):
         super().__exit__(exc_type, exc_value, tb)
 
         # We need call the hook on all dirty tournaments after committing the changes above
-        if self.write and exc_type is None:
+        if self.write and exc_type is None and is_server_engine():
             for tournament_id in dirty_tournaments:
                 plugin_manager.hook.on_tournament_data_updated(
                     event_uniq_id=self.uniq_id, tournament_id=tournament_id

--- a/src/database/sqlite/event/migrations/m044_use_sub_second_last_update_triggers.py
+++ b/src/database/sqlite/event/migrations/m044_use_sub_second_last_update_triggers.py
@@ -1,0 +1,121 @@
+from database.sqlite.migration import BaseMigration
+
+
+class Migration(BaseMigration):
+    def forward(self):
+        for trigger in [
+            'set_tournament_last_pairing_update_on_pairing_insert',
+            'set_tournament_last_pairing_update_on_pairing_update',
+            'set_tournament_last_pairing_update_on_pairing_delete',
+            'set_tournament_last_pairing_update_on_board_update',
+            'set_tournament_last_player_update_on_player_update',
+            'set_tournament_last_player_update_on_tournament_player_insert',
+            'set_tournament_last_player_update_on_tournament_player_update',
+            'set_tournament_last_player_update_on_tournament_player_delete',
+        ]:
+            self.database.execute(f'DROP TRIGGER IF EXISTS `{trigger}`')
+
+        # Pairing
+        self.database.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS
+                `set_tournament_last_pairing_update_on_pairing_insert`
+            AFTER INSERT ON `pairing`
+            BEGIN
+                UPDATE `tournament` SET `last_pairing_update` = unixepoch('subsec')
+                WHERE `id` = `NEW`.`tournament_id`;
+            END;
+            """
+        )
+        self.database.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS
+                `set_tournament_last_pairing_update_on_pairing_update`
+            AFTER UPDATE ON `pairing`
+            BEGIN
+                UPDATE `tournament` SET `last_pairing_update` = unixepoch('subsec')
+                WHERE `id` = `NEW`.`tournament_id`;
+            END;
+            """
+        )
+        self.database.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS
+                `set_tournament_last_pairing_update_on_pairing_delete`
+            AFTER DELETE ON `pairing`
+            BEGIN
+                UPDATE `tournament` SET `last_pairing_update` = unixepoch('subsec')
+                WHERE `id` = `OLD`.`tournament_id`;
+            END;
+            """
+        )
+        # Useful for board permutation or renumbering
+        self.database.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS
+                `set_tournament_last_pairing_update_on_board_update`
+            AFTER UPDATE ON `board`
+            BEGIN
+                UPDATE `tournament` SET `last_pairing_update` = unixepoch('subsec')
+                WHERE `id` = (
+                    SELECT `tournament_id` FROM `pairing`
+                    WHERE `board_id` = `NEW`.`id`
+                    LIMIT 1
+                );
+            END;
+            """
+        )
+
+        # Player
+        # Trigger on player delete not needed as it is not yet related to any tournament_player
+        self.database.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS
+                `set_tournament_last_player_update_on_player_update`
+            AFTER UPDATE ON `player`
+            BEGIN
+                UPDATE `tournament` SET `last_player_update` = unixepoch('subsec')
+                WHERE `id` IN (
+                    SELECT `tournament_id` FROM `tournament_player`
+                    WHERE `player_id` = `NEW`.`id`
+                );
+            END;
+            """
+        )
+        # Trigger on player delete not needed as it also deletes the tournament_player records
+        self.database.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS
+                `set_tournament_last_player_update_on_tournament_player_insert`
+            AFTER INSERT ON `tournament_player`
+            BEGIN
+                UPDATE `tournament` SET `last_player_update` = unixepoch('subsec')
+                WHERE `id` = `NEW`.`tournament_id`;
+            END;
+            """
+        )
+        self.database.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS
+                `set_tournament_last_player_update_on_tournament_player_update`
+            AFTER UPDATE ON `tournament_player`
+            BEGIN
+                UPDATE `tournament` SET `last_player_update` = unixepoch('subsec')
+                WHERE `id` = `NEW`.`tournament_id`;
+            END;
+            """
+        )
+        self.database.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS
+                `set_tournament_last_player_update_on_tournament_player_delete`
+            AFTER DELETE ON `tournament_player`
+            BEGIN
+                UPDATE `tournament` SET `last_player_update` = unixepoch('subsec')
+                WHERE `id` = `OLD`.`tournament_id`;
+            END;
+            """
+        )
+
+    def backward(self):
+        pass

--- a/src/database/sqlite/fide/fide_database.py
+++ b/src/database/sqlite/fide/fide_database.py
@@ -248,7 +248,7 @@ class FideDatabase(LocalSourceDatabase):
         tokens: list[str] = string.split(' ')
         str_fields: tuple[tuple[str, str, str], ...] = (
             ('last_name', '%', '%'),
-            ('first_name', '', '%'),
+            ('first_name', '%', '%'),
         )
         int_fields: tuple[str, ...] = ('fide_id',)
         token_conditions: dict[str, str] = {}
@@ -270,10 +270,12 @@ class FideDatabase(LocalSourceDatabase):
         order_conditions = ' OR '.join(
             [
                 '(last_name LIKE ?)',
+                '(first_name LIKE ?)',
             ]
             * len(tokens)
         )
-        params += [f'{token}%' for token in tokens]
+        for token in tokens:
+            params += [f'{token}%'] * 2
         query: str = f'SELECT * FROM player WHERE {conditions} ORDER BY (CASE WHEN {order_conditions} THEN 0 ELSE 1 END), last_name'
         if limit:
             query += ' LIMIT ?'

--- a/src/database/sqlite/sqlite_database.py
+++ b/src/database/sqlite/sqlite_database.py
@@ -8,7 +8,10 @@ from sqlite3 import Connection, Cursor, connect, OperationalError
 from threading import RLock
 from typing import Self, Any
 
+from common.logger import get_logger
 
+
+logger = get_logger()
 locks: defaultdict[Path, RLock] = defaultdict(RLock)
 
 
@@ -71,21 +74,26 @@ class SQLiteDatabase:
         return self
 
     def __exit__(self, exc_type, exc_value, tb):
-        try:
-            which = str(self.file)
-            if self.database and self.write:
-                if exc_type is None:
-                    self.database.commit()
-                else:
-                    print(f'Rolling back {which} due to exception')
-                    self.database.rollback()
-        finally:
-            if self.cursor is not None:
-                self.cursor = None
-            if self.database is not None:
-                self.database.close()
-                self.database = None
-            self.release_lock()
+        if self.database and self.write:
+            if exc_type is None:
+                self.database.commit()
+            else:
+                logger.debug(
+                    'Rolling back [%s] due to exception [%s]: %s',
+                    self.file,
+                    exc_type,
+                    exc_value,
+                )
+                self.database.rollback()
+        if self.cursor is not None:
+            self.cursor.close()
+            del self.cursor
+            self.cursor = None
+        if self.database is not None:
+            self.database.close()
+            del self.database
+            self.database = None
+        self.release_lock()
 
     def execute(self, query: str, params: tuple | dict[str, Any] = ()):
         assert self.cursor is not None

--- a/src/plugins/ffe/ffe.py
+++ b/src/plugins/ffe/ffe.py
@@ -662,12 +662,19 @@ class FfePlugin(Plugin):
     # ---------------------------------------------------------------------------------
 
     @hookimpl
-    def on_tournament_data_updated(self, event_uniq_id: str, tournament_id: int):
-        event = EventLoader().events_by_id.get(event_uniq_id, None)
-        if event and tournament_id in event.tournaments_by_id:
-            tournament = event.tournaments_by_id[tournament_id]
-            if FFEUtils.resolve_auto_upload(tournament):
-                FfeBackgroundUploader.schedule_upload(tournament)
+    def on_tournament_data_updated(
+        self, stored_event: 'StoredEvent', stored_tournament: 'StoredTournament'
+    ):
+        # This hook being called in most database writes, it needs to be optimized
+        if not FfeBackgroundUploader.should_schedule_tournament_upload(
+            stored_event, stored_tournament
+        ):
+            return
+        event = EventLoader().load_event(stored_event.uniq_id)
+        tournament_id = stored_tournament.id
+        assert tournament_id is not None
+        tournament = event.tournaments_by_id[tournament_id]
+        FfeBackgroundUploader.schedule_upload(tournament)
 
     @hookimpl
     def augment_tournament_after_db_fetch(

--- a/src/plugins/ffe/ffe_background_uploader.py
+++ b/src/plugins/ffe/ffe_background_uploader.py
@@ -13,6 +13,7 @@ from common.sharly_chess_config import SharlyChessConfig
 from data.event import Event
 from data.loader import EventLoader
 from data.tournament import Tournament
+from database.sqlite.event.event_store import StoredTournament, StoredEvent
 from plugins.ffe import PLUGIN_NAME
 from plugins.ffe.ffe_session import FFESession
 from plugins.ffe.utils import FFEUtils
@@ -116,11 +117,11 @@ class FfeBackgroundUploader:
         return True
 
     @classmethod
-    def ffe_last_upload(cls, tournament: Tournament) -> float:
+    def ffe_last_upload(cls, tournament: Tournament | StoredTournament) -> float:
         return get_data(tournament.plugin_data, 'ffe_last_upload', 0.0)
 
     @classmethod
-    def ffe_upload_needed(cls, tournament: Tournament) -> bool:
+    def ffe_upload_needed(cls, tournament: Tournament | StoredTournament) -> bool:
         return cls.ffe_last_upload(tournament) < max(
             tournament.last_update,
             tournament.last_player_update,
@@ -152,10 +153,11 @@ class FfeBackgroundUploader:
         set_locale(SharlyChessConfig().locale)
 
         # We refetch the latest event and tournament
-        event = EventLoader().events_by_id.get(event_uniq_id, None)
-        if not event:
+        loader = EventLoader()
+        if event_uniq_id not in loader.event_uniq_ids:
             # The event has been deleted
             return
+        event = loader.load_event(event_uniq_id)
 
         tournament = event.tournaments_by_id.get(tournament_id, None)
         if not tournament:
@@ -275,28 +277,46 @@ class FfeBackgroundUploader:
         uploader.start()
 
     @classmethod
+    def should_schedule_tournament_upload(
+        cls,
+        stored_event: StoredEvent,
+        stored_tournament: StoredTournament,
+    ) -> bool:
+        # Check if the auto upload is enabled
+        tournament_auto_upload = get_data(
+            stored_tournament.plugin_data, 'ffe_auto_upload'
+        )
+        if tournament_auto_upload is None:
+            tournament_auto_upload = get_data(
+                stored_event.plugin_data, 'ffe_auto_upload'
+            )
+        if not tournament_auto_upload:
+            return False
+
+        assert stored_tournament.id is not None
+        result_id = cls.result_id(stored_event.uniq_id, stored_tournament.id)
+        thread = cls.timeout_threads.get(result_id)
+        if thread and thread.is_alive():
+            # There's already a thread running for this tournament
+            return False
+
+        if not cls.ffe_upload_needed(stored_tournament):
+            # Latest version already uploaded
+            return False
+
+        return True
+
+    @classmethod
     def schedule_upload(cls, tournament: Tournament, force=False) -> None:
         """Schedule the upload of a tournament that has been modified."""
-
-        result_id = cls.result_id(tournament.event.uniq_id, tournament.id)
-        if not force:
-            result = cls.get_updated_tournament_upload_result(tournament)
-            if result.status == FfeUploadStatus.SETTINGS_ERROR:
-                # Skip this tournament if we have a SETTINGS_ERROR
-                return
-
-            if not cls.ffe_upload_needed(tournament):
-                # Latest version already uploaded
-                return
-
-            thread = cls.timeout_threads.get(result_id)
-            if thread and thread.is_alive():
-                # There's already a thread running for this tournament
-                return
-
+        result = cls.get_updated_tournament_upload_result(tournament)
+        if result.status == FfeUploadStatus.SETTINGS_ERROR:
+            # Skip this tournament if we have a SETTINGS_ERROR
+            return
         ffe_last_upload = cls.ffe_last_upload(tournament)
         delay = FFEUtils.resolve_auto_upload_delay(tournament.event)
         wait_time = 0.1
+        result_id = cls.result_id(tournament.event.uniq_id, tournament.id)
         if not force and time() < ffe_last_upload + delay * 60:
             wait_time = max(delay * 60 - (time() - ffe_last_upload), 0.1)
             cls.upload_status_messages[result_id] = FfeUploadResult(

--- a/src/plugins/ffe/ffe_database.py
+++ b/src/plugins/ffe/ffe_database.py
@@ -197,7 +197,7 @@ class FfeDatabase(LocalSourceDatabase):
         tokens: list[str] = [unicode_normalize(token) for token in string.split(' ')]
         str_fields: tuple[tuple[str, str, str], ...] = (
             ('last_name', '%', '%'),
-            ('first_name', '', '%'),
+            ('first_name', '%', '%'),
             ('ffe_licence_number', '', ''),
         )
         int_fields: tuple[str, ...] = ('fide_id',)
@@ -220,10 +220,12 @@ class FfeDatabase(LocalSourceDatabase):
         order_conditions = ' OR '.join(
             [
                 '(last_name LIKE ?)',
+                '(first_name LIKE ?)',
             ]
             * len(tokens)
         )
-        params += [f'{token}%' for token in tokens]
+        for token in tokens:
+            params += [f'{token}%'] * 2
         query: str = f'SELECT * FROM player WHERE {conditions} ORDER BY (CASE WHEN {order_conditions} THEN 0 ELSE 1 END), last_name'
         if limit:
             query += ' LIMIT ?'

--- a/src/plugins/ffe/ffe_database.py
+++ b/src/plugins/ffe/ffe_database.py
@@ -11,6 +11,7 @@ from packaging.version import Version
 from requests import Response, get
 from requests.exceptions import ConnectionError
 
+from common import unicode_normalize
 from common.i18n import _
 from common.logger import get_logger
 from data.player import PlayerRating
@@ -193,7 +194,7 @@ class FfeDatabase(LocalSourceDatabase):
     def search_player(
         self, string: str, limit: int | None = None
     ) -> list[StoredPlayer]:
-        tokens: list[str] = string.split(' ')
+        tokens: list[str] = [unicode_normalize(token) for token in string.split(' ')]
         str_fields: tuple[tuple[str, str, str], ...] = (
             ('last_name', '%', '%'),
             ('first_name', '', '%'),

--- a/src/plugins/ffe/ffe_session.py
+++ b/src/plugins/ffe/ffe_session.py
@@ -420,13 +420,14 @@ class FFESession(Session):
             EVENT_VALIDATION_INPUT_ID: self.ffe_state[EVENT_VALIDATION_INPUT_ID],
         }
 
+        event_uniq_id = self.tournament.event.uniq_id
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path: Path = Path(tmpdir)
             tmp_papi_file: Path = tmp_path / 'export.papi'
             tmp_sce_file: Path = tmp_path / 'event.sce'
 
             # Copy the event database to the tmp file
-            with EventDatabase(self.tournament.event.uniq_id) as event_database:
+            with EventDatabase(event_uniq_id) as event_database:
                 try:
                     logger.debug(
                         'Copying [%s] to [%s]...', event_database.file, tmp_sce_file
@@ -486,7 +487,7 @@ class FFESession(Session):
                 self.report_error(_('Upload failed'))
                 return
 
-        with EventDatabase(self.tournament.event.uniq_id, write=True) as event_database:
+        with EventDatabase(event_uniq_id, write=True) as event_database:
             now = time.time()
             event_database.execute(
                 'UPDATE `tournament` SET `ffe_last_upload` = ?, '

--- a/src/plugins/ffe/ffe_sql_server.py
+++ b/src/plugins/ffe/ffe_sql_server.py
@@ -196,7 +196,7 @@ class FFESqlServer(SqlServer):
         tokens: list[str] = string.split(' ')
         str_fields: tuple[tuple[str, str, str], ...] = (
             ('joueur.Nom', '%', '%'),
-            ('joueur.Prenom', '', '%'),
+            ('joueur.Prenom', '%', '%'),
             ('joueur.NrFFE', '', ''),
         )
         conditions: list[str] = [
@@ -225,16 +225,19 @@ class FFESqlServer(SqlServer):
         order = ' OR '.join(
             [
                 '(UPPER(joueur.Nom) LIKE %s)',
+                '(UPPER(joueur.Prenom) LIKE %s)',
             ]
             * len(tokens)
         )
-        params += [f'{token}%' for token in tokens]
+        for token in tokens:
+            params += [f'{token}%'] * 2
         query: str = (
             f'SELECT {", ".join(self.get_player_fields() + self.get_club_fields())} '
             f'FROM joueur LEFT JOIN club on joueur.ClubRef = club.Ref '
             f'WHERE {condition} '
             f'ORDER BY (CASE WHEN {order} THEN 0 ELSE 1 END), Joueur.Nom, Joueur.Prenom'
         )
+        print(query.count('%s'), len(params))
         if limit:
             query += ' OFFSET 0 ROWS FETCH NEXT %s ROWS ONLY'
             params += [

--- a/src/plugins/ffe/papi_converter.py
+++ b/src/plugins/ffe/papi_converter.py
@@ -439,15 +439,16 @@ class PapiConverter:
         stored_tournament.location = variables.venue
         ffe_id = None
         if variables.homologation:
-            if not variables.homologation.isdigit():
+            homologation = variables.homologation.strip()
+            if not homologation.isdigit():
                 # Papi form allows for a non-integer value,
                 # so the value is ignored instead of raising
                 logger.warning(
                     'Homologation number [%s] is not an integer, its value is ignored.',
-                    variables.homologation,
+                    homologation,
                 )
             else:
-                ffe_id = int(variables.homologation)
+                ffe_id = int(homologation)
         plugin_data = stored_tournament.plugin_data or {}
         if PLUGIN_NAME not in plugin_data:
             plugin_data[PLUGIN_NAME] = {}

--- a/src/plugins/ffe/papi_converter.py
+++ b/src/plugins/ffe/papi_converter.py
@@ -860,13 +860,10 @@ class PapiConverter:
     def _get_papi_elo_type(
         self, player: Player, tournament_rating: TournamentRating
     ) -> str:
-        # If we're overriding, export it as estimated
-        rating_type: PlayerRatingType | None
         if player.rating_is_overridden(tournament_rating):
-            rating_type = PlayerRatingType.ESTIMATED
-        else:
-            rating = player.ratings.get(tournament_rating, None)
-            rating_type = rating.type if rating else None
+            tournament_rating = TournamentRating.STANDARD
+        rating = player.ratings.get(tournament_rating, None)
+        rating_type = rating.type if rating else None
         default_rating = PapiPlayerRatingType.get_plugin_value(
             PlayerRatingType.ESTIMATED
         )

--- a/src/plugins/ffe/utils.py
+++ b/src/plugins/ffe/utils.py
@@ -21,7 +21,7 @@ FFE_EPOCH = datetime(2000, 1, 1)
 
 class FFEUtils:
     @staticmethod
-    def resolve_auto_upload(tournament: Tournament) -> str | None:
+    def resolve_auto_upload(tournament: Tournament) -> bool:
         if (
             ffe_auto_upload := get_data(tournament.plugin_data, 'ffe_auto_upload')
         ) is not None:

--- a/src/plugins/hookspec.py
+++ b/src/plugins/hookspec.py
@@ -234,7 +234,9 @@ class AppHookSpecs:
     # ---------------------------------------------------------------------------------
 
     @hookspec
-    def on_tournament_data_updated(self, event_uniq_id: str, tournament_id: int):
+    def on_tournament_data_updated(
+        self, stored_event: 'StoredEvent', stored_tournament: 'StoredTournament'
+    ):
         """Called when the (publishable) data of a tournament is updated"""
 
     @hookspec

--- a/src/utils/enum.py
+++ b/src/utils/enum.py
@@ -927,7 +927,7 @@ class ScreenType(StrEnum):
             case ScreenType.BOARDS:
                 return _('Pairings by board')
             case ScreenType.INPUT:
-                return _('Results entry')
+                return _('Check-in / Results entry')
             case ScreenType.PLAYERS:
                 return _('Parings by player')
             case ScreenType.RESULTS:

--- a/src/web/controllers/admin/base_admin_controller.py
+++ b/src/web/controllers/admin/base_admin_controller.py
@@ -209,7 +209,7 @@ class BaseAdminController(BaseController):
     def _get_screen_type_options(family_screens_only: bool) -> dict[str, str]:
         options: dict[str, str] = {
             '': '-',
-            'input': _('Results entry'),
+            'input': _('Check-in / Results entry'),
             'boards': _('Pairings by board'),
             'players': _('Pairings by player'),
         }

--- a/src/web/controllers/admin/display_controller_admin_controller.py
+++ b/src/web/controllers/admin/display_controller_admin_controller.py
@@ -131,8 +131,8 @@ class DisplayControllerAdminController(BaseEventAdminController):
         sorted_screens: list[Screen] = sorted(
             event.basic_screens_by_id.values(),
             key=lambda screen: (
-                screen.stored_screen.type if screen.stored_screen else None,
-                screen.stored_screen.uniq_id if screen.stored_screen else None,
+                screen.stored_screen.type if screen.stored_screen else '',
+                screen.stored_screen.uniq_id if screen.stored_screen else '',
             ),
         )
 

--- a/src/web/controllers/admin/index_admin_controller.py
+++ b/src/web/controllers/admin/index_admin_controller.py
@@ -516,12 +516,14 @@ class IndexAdminController(BaseAdminController):
         for plugin in stored_plugins:
             errors |= plugin.errors
         if errors:
+            sharly_chess_config: SharlyChessConfig = SharlyChessConfig()
             return self._admin_render(
                 request=request,
                 admin_tab='config',
                 modal='config',
                 data=data,
                 errors=errors,
+                keep_modal_open=sharly_chess_config.force_edit,
             )
         with ConfigDatabase(write=True) as config_database:
             stored_config.force_edit = False

--- a/src/web/controllers/admin/player_admin_controller.py
+++ b/src/web/controllers/admin/player_admin_controller.py
@@ -392,24 +392,32 @@ class PlayerAdminController(BaseEventAdminController):
         def get_sort_key(player: Player) -> tuple:
             match sort_type:
                 case 'alpha':
-                    return player.last_name, player.first_name
+                    return player.last_name, player.first_name or ''
                 case 'rating_desc':
-                    return -player.rating, player.last_name, player.first_name
+                    return -player.rating, player.last_name, player.first_name or ''
                 case 'rating_asc':
-                    return player.rating, player.last_name, player.first_name
+                    return player.rating, player.last_name, player.first_name or ''
                 case 'yob_desc':
-                    return -player.year_of_birth, player.last_name, player.first_name
+                    return (
+                        -player.year_of_birth,
+                        player.last_name,
+                        player.first_name or '',
+                    )
                 case 'yob_asc':
-                    return player.year_of_birth, player.last_name, player.first_name
+                    return (
+                        player.year_of_birth,
+                        player.last_name,
+                        player.first_name or '',
+                    )
                 case 'category_desc':
-                    return -player.category, player.last_name, player.first_name
+                    return -player.category, player.last_name, player.first_name or ''
                 case 'category_asc':
-                    return player.category, player.last_name, player.first_name
+                    return player.category, player.last_name, player.first_name or ''
                 case 'club':
                     return plugin_manager.hook.player_club_sort_key(player=player) or (
                         player.club,
                         player.last_name,
-                        player.first_name,
+                        player.first_name or '',
                     )
                 case 'tournament':
                     assert player.tournament is not None
@@ -417,7 +425,7 @@ class PlayerAdminController(BaseEventAdminController):
                         player.tournament.uniq_id,
                         -player.rating,
                         player.last_name,
-                        player.first_name,
+                        player.first_name or '',
                     )
                 case _:
                     raise ValueError(f'sort={sort_type}')

--- a/src/web/controllers/admin/player_admin_controller.py
+++ b/src/web/controllers/admin/player_admin_controller.py
@@ -1749,6 +1749,7 @@ class PlayerAdminController(BaseEventAdminController):
                 if count
                 else _('No players updated.'),
             )
+        self.set_players_search_results(request, event_uniq_id)
         return self._admin_event_players_render(request, event_uniq_id=event_uniq_id)
 
     @get(

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -846,7 +846,7 @@ class TournamentAdminController(BaseEventAdminController):
                         (
                             'input',
                             '@input',
-                            _('Results entry ({tournament_name})').format(
+                            _('Check-in / Results entry ({tournament_name})').format(
                                 tournament_name=stored_tournament.name
                             ),
                         ),

--- a/src/web/controllers/user/base_screen_user_controller.py
+++ b/src/web/controllers/user/base_screen_user_controller.py
@@ -75,10 +75,11 @@ class ScreenOrRotatorUserWebContext(EventUserWebContext):
                     f'Access denied for rotator [{self.rotator.uniq_id}].'
                 )
                 return
-            self.rotator_screen_index = self.rotator_screen_index % len(
-                self.rotator.rotating_screens
-            )
-            self.screen = self.rotator.rotating_screens[self.rotator_screen_index]
+            if self.rotator.rotating_screens:
+                self.rotator_screen_index = self.rotator_screen_index % len(
+                    self.rotator.rotating_screens
+                )
+                self.screen = self.rotator.rotating_screens[self.rotator_screen_index]
             self.user_event_tab = 'rotators'
         else:
             assert display_controller_id is not None

--- a/src/web/controllers/user/event_user_controller.py
+++ b/src/web/controllers/user/event_user_controller.py
@@ -123,7 +123,7 @@ class EventUserController(BaseUserController):
             )
         nav_tabs: dict[str, dict] = {
             'input': {
-                'title': _('Results entry ({num})').format(
+                'title': _('Check-in / Results entry ({num})').format(
                     num=len(input_screens) or '-'
                 ),
                 'screens': input_screens,

--- a/src/web/server_engine.py
+++ b/src/web/server_engine.py
@@ -16,7 +16,7 @@ from litestar import Litestar
 from litestar.plugins.htmx import HTMXRequest
 from litestar.logging import LoggingConfig
 
-from common import REQUEST_TIMEOUT, LOG_FILE
+from common import REQUEST_TIMEOUT, LOG_FILE, set_is_server_engine
 from common.engine import Engine
 from common.i18n import _, set_locale
 from common.logger import (
@@ -82,6 +82,7 @@ class ServerEngine(Engine):
         if self.error:
             return
 
+        set_is_server_engine(True)
         logger.debug('System information:')
         logger.debug(
             ' - Machine/processor: %s/%s', platform.machine(), platform.processor()

--- a/src/web/static/css/base.css
+++ b/src/web/static/css/base.css
@@ -191,6 +191,19 @@ body[data-bs-theme="dark"] #top-nav-wrapper {
     border-color: var(--bs-form-valid-border-color);
 }
 
+.input-group .form-control:focus {
+  outline: none !important;
+  box-shadow: none !important;
+  border-color: var(--bs-border-color);
+}
+
+[data-bs-theme=dark] .input-group:focus-within {
+    box-shadow: none;
+    outline: 0.15rem solid rgba(var(--bs-primary-rgb), 0.70);
+    outline-offset: 4px;
+    border-radius: var(--bs-border-radius)
+}
+
 .is-invalid {
     scroll-margin-top: 40px
 }

--- a/src/web/templates/admin/event/event_modal.html
+++ b/src/web/templates/admin/event/event_modal.html
@@ -113,18 +113,9 @@
                 </div>
 
                 <h4>
-                    {{ _('Results entry') }}
+                    {{ _('Check-in / Results entry') }}
                 </h4>
                 <div class="row">
-                    <div class="col-12 col-md-6 mb-3">
-                        {{ admin_macros.password_input(
-                            name='update_password',
-                            label=_('Password to enter results:'),
-                            placeholder=_('E.g.: my_password'),
-                            help_text=_('The password required on input screens to enter results (optional).'),
-                            data=data, errors=errors
-                        ) }}
-                    </div>
                     <div class="col-12 col-md-6 mb-3">
                         {{ admin_macros.select_input(
                             name='record_illegal_moves',

--- a/src/web/templates/admin/families/family_modal.html
+++ b/src/web/templates/admin/families/family_modal.html
@@ -50,7 +50,7 @@
                 {% else %}
                     <h4>
                         {% if family_type == 'input' %}
-                            {{ _('Properties (results entry)') }}
+                            {{ _('Properties (check-in and results entry)') }}
                         {% elif family_type == 'boards' %}
                             {{ _('Properties (pairings by board)') }}
                         {% elif family_type == 'players' %}

--- a/src/web/templates/admin/families/tab.html
+++ b/src/web/templates/admin/families/tab.html
@@ -50,7 +50,7 @@
         </button>
         <ul class="dropdown-menu">
             {% for family_type, family_data in {
-                'input': { 'title': _('Results entry'), 'icon_class': 'bi-pencil-fill', 'tooltip_text': _('Add a family of screens to enter the results.'), },
+                'input': { 'title': _('Check-in / Results entry'), 'icon_class': 'bi-pencil-fill', 'tooltip_text': _('Add a family of screens to check-in players or enter results.'), },
                 'boards': { 'title': _('Pairings by board'), 'icon_class': 'bi-card-list', 'tooltip_text': _('Add a family of screens to display the pairings by board.'), },
                 'players': { 'title': _('Pairings by player'), 'icon_class': 'bi-people-fill', 'tooltip_text': _('Add a family of screens to display the pairings by alphabetical order.'), },
                 'ranking': { 'title': _('Ranking'), 'icon_class': 'bi-trophy', 'tooltip_text': _('Add a family of screens to display the ranking.'), },

--- a/src/web/templates/admin/pairings/rankings_table.html
+++ b/src/web/templates/admin/pairings/rankings_table.html
@@ -72,7 +72,7 @@
             <td class="points text-center fw-bold">{{ player.points_str }}</td>
 
             {% for tie_break_value in player.tie_break_values %}
-                <td class="tie-break text-center compact-col cursor-grap">
+                <td class="tie-break text-center compact-col {% if tie_break_value.tie_break.is_manual and sortable %}cursor-grap{% endif %}">
 
                     <span
                         {% if tie_break_value.rank_progress %}

--- a/src/web/templates/admin/pairings/tab.html
+++ b/src/web/templates/admin/pairings/tab.html
@@ -350,7 +350,7 @@
 
         function searchPlayerHandler(e) {
             const value = normalizeText($("#search-player").val().trim());
-            $("table").each(function() {
+            $("table:not([id^='popover-content-'])").each(function() {
                 const $table = $(this);
                 const $rows = $table.find("tbody tr");
 
@@ -362,10 +362,13 @@
 
                 let matchFound = false;
 
-                $("table tbody tr").each(function() {
+                $rows.each(function() {
                     const text = normalizeText($(this).text());
-                    $(this).toggle(text.indexOf(value) > -1);
+                    const isMatch = text.indexOf(value) > -1;
+                    $(this).toggle(isMatch);
+                    if (isMatch) matchFound = true;
                 });
+
 
                 $table.addClass("table-danger-warning");
             });

--- a/src/web/templates/admin/rotators/rotator_card.html
+++ b/src/web/templates/admin/rotators/rotator_card.html
@@ -82,16 +82,22 @@
 {% endblock %}
 
 {% block card_buttons_left %}
-    <span {{ macros.tooltip_attributes('info', _('Go to the rotator.'), 'top') }}>
-        <a
-            class="btn btn-sm btn-outline-primary"
-            href="{{ url_for('user-rotator', event_uniq_id=admin_event.uniq_id, rotator_id=rotator.id) }}"
-            target="_blank"
-        >
-            <i class="bi bi-eye"></i>
-        </a>
-    </span>
-    {{ admin_macros.display_controller_assign_dropdown(admin_event.display_controllers_sorted_by_uniq_id, 'rotator', rotator.uniq_id) }}
+    {% if rotator.families or rotator.screens %}
+        <span {{ macros.tooltip_attributes('info', _('Go to the rotator.'), 'top') }}>
+            <a
+                class="btn btn-sm btn-outline-primary"
+                href="{{ url_for('user-rotator', event_uniq_id=admin_event.uniq_id, rotator_id=rotator.id) }}"
+                target="_blank"
+            >
+                <i class="bi bi-eye"></i>
+            </a>
+        </span>
+        {{ admin_macros.display_controller_assign_dropdown(
+            admin_event.display_controllers_sorted_by_uniq_id,
+            'rotator',
+            rotator.uniq_id,
+        ) }}
+    {% endif %}
 {% endblock %}
 
 {% block card_buttons_right %}

--- a/src/web/templates/admin/screens/tab.html
+++ b/src/web/templates/admin/screens/tab.html
@@ -61,7 +61,7 @@
         </button>
         <ul class="dropdown-menu">
             {% for screen_type, screen_data in {
-                'input': { 'title': _('Results entry'), 'icon_class': 'bi-pencil','tooltip_text': _('Add a screen to enter the results.'),  },
+                'input': { 'title': _('Check-in / Results entry'), 'icon_class': 'bi-pencil','tooltip_text': _('Add a screen to check-in players or enter results.'),  },
                 'boards': { 'title': _('Pairings by board'), 'icon_class': 'bi-card-list', 'tooltip_text': _('Add a screen to display the pairings by board.'), },
                 'players': { 'title': _('Pairings by player'), 'icon_class': 'bi-people', 'tooltip_text': _('Add a screen to display the pairings by alphabetical order.'), },
                 'results': { 'title': _('Last results'), 'icon_class': 'bi-1-square', 'tooltip_text': _('Add a screen to display the last results.'), },
@@ -125,7 +125,7 @@
         {% else %}
             {% for screen_type, screen_data in {
                 'input': {
-                    'title': _('Results entry'),
+                    'title': _('Check-in / Results entry'),
                     'checkbox_tooltip_text': _('Show/hide the input screens.'),
                     'icon_class': 'bi-pencil',
                 },

--- a/src/web/templates/admin/tournaments/tournament_card.html
+++ b/src/web/templates/admin/tournaments/tournament_card.html
@@ -213,11 +213,11 @@
                         {% else %}
                             <li
                                 class="dropdown-item text-start cursor-pointer"
-                                onclick="$('#export-form-{{ exporter.id }}').submit()"
+                                onclick="$('#export-form-{{ tournament.id }}-{{ exporter.id }}').submit()"
                                {{ macros.tooltip_attributes('info', exporter.tooltip, 'right') }}
                             >
                                 <form
-                                    id="export-form-{{ exporter.id }}"
+                                    id="export-form-{{ tournament.id }}-{{ exporter.id }}"
                                     action="{{ url_for(
                                         'admin-tournament-export',
                                         event_uniq_id=admin_event.uniq_id,

--- a/src/web/templates/user/screen.html
+++ b/src/web/templates/user/screen.html
@@ -15,12 +15,12 @@
             </button>
         {% endif %}
         {% if screen.timer %}
-            <script>
-                {% if not screen.timer.error %}
+            {% if not screen.timer.error %}
+                <script>
                     <!-- timer.js -->
                     {% include 'screen/timer.js' %}
-                {% endif %}
-            </script>
+                </script>
+            {% endif %}
         {% endif %}
         {% if display_controller %}
             <div
@@ -73,34 +73,33 @@
 {% endblock %}
 
 {% block content %}
-    {% if not rotator and not display_controller %}
-        {% set menu_screens = screen.admin_menu_screens if admin_auth else screen.public_menu_screens %}
-        <div id="top-nav-wrapper">
-            <div id="top-nav-content">
-                {% if menu_screens %}
-                    <div id="screen-menu" class="screen-menu text-start w-100 m-0 p-2 fw-bold">
-                        {% for entry in menu_screens %}
-                            {% if entry.menu_label is not none %}
-                                <a
-                                    class="screen-menu-item cursor-pointer text-nowrap py-0 px-1 my-0 {% if loop.first %}ms-0{% else %}ms-1{% endif %} {% if loop.last %}me-0{% else %}me-1{% endif %} {% if screen.uniq_id == entry.uniq_id %}selected{% endif %}"
-                                    hx-get="{{ url_for('user-screen', event_uniq_id=user_event.uniq_id, screen_uniq_id=entry.uniq_id) }}"
-                                    preload
-                                    hx-target="body"
-                                    hx-push-url="true"
-                                    hx-indicator="#please-wait"
-                                >{{ entry.menu_label }}</a>
-                            {% endif %}
-                        {% endfor %}
-                    </div>
-                {% endif %}
-            </div>
-
-            {% if screen.timer %}
-                    <!-- timer.html -->
-                {% include 'screen/timer.html' %}
-            {% endif %}
-        </div>
-    {% endif %}
+    <div id="top-nav-wrapper">
+        {% if not rotator and not display_controller %}
+            {% set menu_screens = screen.admin_menu_screens if admin_auth else screen.public_menu_screens %}
+                <div id="top-nav-content">
+                    {% if menu_screens %}
+                        <div id="screen-menu" class="screen-menu text-start w-100 m-0 p-2 fw-bold">
+                            {% for entry in menu_screens %}
+                                {% if entry.menu_label is not none %}
+                                    <a
+                                        class="screen-menu-item cursor-pointer text-nowrap py-0 px-1 my-0 {% if loop.first %}ms-0{% else %}ms-1{% endif %} {% if loop.last %}me-0{% else %}me-1{% endif %} {% if screen.uniq_id == entry.uniq_id %}selected{% endif %}"
+                                        hx-get="{{ url_for('user-screen', event_uniq_id=user_event.uniq_id, screen_uniq_id=entry.uniq_id) }}"
+                                        preload
+                                        hx-target="body"
+                                        hx-push-url="true"
+                                        hx-indicator="#please-wait"
+                                    >{{ entry.menu_label }}</a>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+        {% endif %}
+        {% if screen.timer %}
+                <!-- timer.html -->
+            {% include 'screen/timer.html' %}
+        {% endif %}
+    </div>
     <div
         id="user-screen-content"
         class="content user-content user-screen-content"

--- a/tests/e2e/screens/test_family_screens.py
+++ b/tests/e2e/screens/test_family_screens.py
@@ -33,7 +33,7 @@ class TestFamilyScreensFunctionality:
     def test_create_and_delete_family_screen(self, page: Page):
         page.goto(f'/admin/event/{EVENT_ID}/families')
         TestUtils.button_by_text(page, 'Create a screen family').click()
-        TestUtils.button_by_text(page, 'Results entry').click()
+        TestUtils.button_by_text(page, 'Check-in / Results entry').click()
         modal = page.locator('.modal-dialog')
         expect(modal).to_be_visible()
 

--- a/tests/e2e/screens/test_single_screens.py
+++ b/tests/e2e/screens/test_single_screens.py
@@ -49,7 +49,7 @@ class TestSingleScreensFunctionality:
     ):
         page.goto(f'/admin/event/{EVENT_ID}/screens')
         TestUtils.button_by_text(page, 'Create a screen').click()
-        TestUtils.button_by_text(page, 'Results entry').click()
+        TestUtils.button_by_text(page, 'Check-in / Results entry').click()
         modal = page.locator('.modal-dialog')
         expect(modal).to_be_visible()
         name = 'Test Screen'

--- a/tests/e2e/screens/test_timers.py
+++ b/tests/e2e/screens/test_timers.py
@@ -23,8 +23,11 @@ class TestTimersFunctionality:
         name = 'Test Timer'
         modal.get_by_role('textbox', name='Name:').fill(name)
         modal.locator('button[type=submit]').click()
-        TestUtils.button_by_text(page, 'Cancel').click()
-        TestUtils.button_by_text(page, 'Close').click()
+
+        hours_modal = page.locator('#admin-timer-hours-modal.modal-dialog')
+        expect(hours_modal).to_be_visible()
+        TestUtils.button_by_text(hours_modal, 'Cancel').click()
+        TestUtils.button_by_text(hours_modal, 'Close').click()
 
         card = page.locator(f"div.card:has-text('{name}')")
         expect(card).to_be_visible()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -385,7 +385,9 @@ class TestUtils:
         """
         Returns a button by visible text (case-insensitive), ignoring icons or extra whitespace.
         """
-        return obj.get_by_role('button', name=re.compile(rf'\b{text}\b', re.IGNORECASE))
+        return obj.get_by_role(
+            'button', name=re.compile(rf'\b{text.replace("/", "\\/")}\b', re.IGNORECASE)
+        )
 
     @staticmethod
     def take_screenshot(page, name: str):


### PR DESCRIPTION
- **Release 3.0.0**
- **Prevent event duplication (#1077)**
- **Display the timer on rotators (#1074)**
- **Fix warning on prizes assignment view (#1076)**
- **Updated the release notes**
- **Updated the version number**
- **Fix FFE upload triggered during ChessEvent upload (#1080)**
- **Fix timer test (#1079)**
- **Fix cursor**
- **Fix player search on rankings screen**
- **Fix focus border on input groups**
- **Version 3.0.2 Updated the release notes**
- **Really force to set federation at app-level (#1083)**
- **Fix error on event file deletion (#1082)**
- **Refresh filter after player update (closes #1043)**
- **Fix unique Name constraint violated on tournament import (#1093)**
- **Fix local search (#1095)**
- **Rename the input screens (check-in and result entry) (#1094)**
- **Updated the release notes**
- **Fix the tournament export buttons exporting the wrong tournament (#1097)**
- **Fix test when slashes expected in button labels (#1096)**
- **Updated the release notes**
- **Fix player pairing document (#1098)**
- **Updated the release notes**
- **Updated the release notes**
- **Prevent None in sort keys (#1104)**
- **Fix error on access to rotator without screen (#1110)**
- **Fix alphabetical pairings of board 1**
- **Fix player search on split names (#1112)**
- **Release 3.0.3 (#1111)**
- **Typo**
- **Fix estimated rankings on Papi export (#1119)**
- **Release 3.0.4**
- **Strip the homologation number during the Papi import (#1137)**
- **Optimize DB write hook (#1139)**
- **Fix FFE upload**
