### PR TITLE
Fix select_input() with one option

### DIFF
--- a/src/web/templates/admin/common/macros.j2
+++ b/src/web/templates/admin/common/macros.j2
@@ -265,7 +265,14 @@ with_indicator: display a loading indicator, optional
                 "
             >
                 {% if input_type == 'select' %}
-                    {% set selected=data[name].split(';') if multiple_select else [data[name]] %}
+                    {%
+                        set selected=data[name].split(';')
+                        if multiple_select else [
+                            select_options.keys()|first
+                            if select_options|length == 1
+                            else data[name]
+                        ]
+                    %}
                     <select
                         name="{{ name }}"
                         id="{{ id }}"


### PR DESCRIPTION
When not in a multiple select, the input type is not filled if only one option (and the select is disabled).