### PR TITLE
Remove language from profile button

### DIFF
--- a/src/web/templates/common/profile/profile_button.html
+++ b/src/web/templates/common/profile/profile_button.html
@@ -15,19 +15,17 @@
             data-bs-toggle="modal"
             data-bs-target="#modal-wrapper"
         >
-            {% if admin_event and not client.account.administrator %}
-                <div class="d-block">
-                    <i class="bi bi-person-circle"></i>
-                    <span class="pe-2 expanded-only {% if not client.account.user_account %}fst-italic{% else %}fw-bold{% endif %}">
+            <div class="d-block">
+                <i class="bi bi-person-circle"></i>
+                {% if admin_event or client.account.administrator %}
+                    <span class="pe-2 expanded-only {% if client.account.anonymous %}fst-italic{% else %}fw-bold{% endif %}">
                         {{ client.account.full_name }}
                     </span>
-                </div>
-            {% endif %}
-            <div class="d-block">
-                <i class="bi bi-translate"></i>
-                <span class="pe-2 expanded-only {% if client.account.administrator %}fst-italic{% else %}fw-bold{% endif %}">
-                    {{ locale_infos[locale].name }}
-                </span>
+                {% else %}
+                    <span class="pe-2 expanded-only">
+                        {{ _('Profile') }}
+                    </span>
+                {% endif %}
             </div>
         </button>
     </span>

--- a/src/web/templates/common/profile/profile_button.html
+++ b/src/web/templates/common/profile/profile_button.html
@@ -17,13 +17,13 @@
         >
             <div class="d-block">
                 <i class="bi bi-person-circle"></i>
-                {% if admin_event or client.account.administrator %}
-                    <span class="pe-2 expanded-only {% if client.account.anonymous %}fst-italic{% else %}fw-bold{% endif %}">
-                        {{ client.account.full_name }}
+                {% if client.account.anonymous %}
+                    <span class="pe-2 expanded-only">
+                        {{ _('Profile') }} (<i>{{ _('Anonymous') }}</i>)
                     </span>
                 {% else %}
-                    <span class="pe-2 expanded-only">
-                        {{ _('Profile') }}
+                    <span class="pe-2 expanded-only fw-bold">
+                        {{ client.account.full_name }}
                     </span>
                 {% endif %}
             </div>


### PR DESCRIPTION
I really think it adds nothing in terms of user info: they know which language is active, and the profile is a logical place to change the language.  
Also it is the only button on multiple lines, which feels odd in an already very crowded menu

<img width="289" height="105" alt="image" src="https://github.com/user-attachments/assets/02a9d408-84ee-435e-a678-e985c4503ecb" />