### PR TITLE
Raise an HttpException instead of returning redirect_error

### DIFF
--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -223,6 +223,9 @@ msgstr ""
 msgid "20+"
 msgstr ""
 
+msgid "400 - Bad request"
+msgstr ""
+
 msgid "401 - Authentication failed"
 msgstr ""
 
@@ -1099,6 +1102,9 @@ msgid "Console logging level: {console_log_level}"
 msgstr ""
 
 msgid "Console logs"
+msgstr ""
+
+msgid "Consult the logs for more details."
 msgstr ""
 
 msgid "Consult the players and the prize assignment of this category."
@@ -4018,9 +4024,6 @@ msgstr ""
 msgid "Rename events"
 msgstr ""
 
-msgid "Renaming the database failed: {ex}."
-msgstr ""
-
 #, python-format
 msgid "Replace [%(old)s] by [%(new)s]"
 msgstr ""
@@ -4669,9 +4672,6 @@ msgid "The greater number of wins"
 msgstr ""
 
 msgid "The greater number of wins with Black (unplayed games are counted as played with White)"
-msgstr ""
-
-msgid "The last set of a screen can not be deleted."
 msgstr ""
 
 msgid "The location of the event."
@@ -6101,4 +6101,10 @@ msgstr ""
 
 msgid "½ - ½ (U)"
 msgstr ""
+
+#~ msgid "Renaming the database failed: {ex}."
+#~ msgstr ""
+
+#~ msgid "The last set of a screen can not be deleted."
+#~ msgstr ""
 

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -223,6 +223,9 @@ msgstr "1er jour du mois"
 msgid "20+"
 msgstr "20+"
 
+msgid "400 - Bad request"
+msgstr "400 - Mauvaise requête"
+
 msgid "401 - Authentication failed"
 msgstr "401 - Authentification non valide"
 
@@ -1100,6 +1103,9 @@ msgstr "Niveau de log sur la console : {console_log_level}"
 
 msgid "Console logs"
 msgstr "Logs de la console"
+
+msgid "Consult the logs for more details."
+msgstr "Consultez les logs pour plus d'informations."
 
 msgid "Consult the players and the prize assignment of this category."
 msgstr "Consulter les joueur·euses et l'attribution des prix de la catégorie."
@@ -4018,9 +4024,6 @@ msgstr "Supprimer la redirection du pilote d'afficheurs vers cet écran."
 msgid "Rename events"
 msgstr "Renommer les évènements"
 
-msgid "Renaming the database failed: {ex}."
-msgstr "Le renommage de la base de données a échoué : {ex}"
-
 #, python-format
 msgid "Replace [%(old)s] by [%(new)s]"
 msgstr "Remplacer [%(old)s] par [%(new)s]"
@@ -4670,9 +4673,6 @@ msgstr "Le plus grand nombre de victoires"
 
 msgid "The greater number of wins with Black (unplayed games are counted as played with White)"
 msgstr "Le plus grand nombre de victoires avec les Noirs"
-
-msgid "The last set of a screen can not be deleted."
-msgstr "Le dernier écran ne peut être supprimé."
 
 msgid "The location of the event."
 msgstr "Le lieu de l'évènement."
@@ -6101,4 +6101,10 @@ msgstr "½ - 0 (NC)"
 
 msgid "½ - ½ (U)"
 msgstr "½ - ½ (NC)"
+
+#~ msgid "Renaming the database failed: {ex}."
+#~ msgstr "Le renommage de la base de données a échoué : {ex}"
+
+#~ msgid "The last set of a screen can not be deleted."
+#~ msgstr "Le dernier écran ne peut être supprimé."
 

--- a/src/data/access_levels/actions.py
+++ b/src/data/access_levels/actions.py
@@ -214,6 +214,7 @@ class AuthAction(StrEnum):
             case _:
                 raise ValueError(f'auth={self}')
 
+    @property
     def name(self) -> str:
         return self.localized_name()
 

--- a/src/data/account.py
+++ b/src/data/account.py
@@ -205,12 +205,9 @@ class Account:
         ).get(permission.access_level, None)
         if not other_permission:
             return False
-        if not permission.tournament_ids and other_permission.tournament_ids:
-            return False
-        return (
-            not other_permission.tournament_ids
-            or permission.tournament_ids.issubset(other_permission.tournament_ids)
-        )
+        if permission.tournament_ids and other_permission.tournament_ids:
+            return permission.tournament_ids.issubset(other_permission.tournament_ids)
+        return bool(permission.tournament_ids)
 
     def __repr__(self) -> str:
         return f'Account(id={self.id}, full_name={self.full_name})'

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -2378,7 +2378,9 @@ class EventDatabase(MigrationDatabase):
         account_id: int | None = self._last_inserted_id()
         if account_id is None:
             raise RuntimeError('Account insertion failed')
-        return self.get_stored_account(account_id=account_id)
+        new_stored_account = self.get_stored_account(account_id=account_id)
+        assert new_stored_account is not None
+        return new_stored_account
 
     def update_stored_account(self, stored_account: StoredAccount) -> StoredAccount:
         fields = self._get_fields_dict(
@@ -2430,6 +2432,7 @@ class EventDatabase(MigrationDatabase):
         )
 
     def add_stored_permission(self, stored_permission: StoredPermission):
+        inserted_values: list[int] | list[None]
         if stored_permission.tournament_ids:
             inserted_values = stored_permission.tournament_ids
         else:

--- a/src/plugins/ffe/ffe_event_controller.py
+++ b/src/plugins/ffe/ffe_event_controller.py
@@ -2,7 +2,7 @@ from functools import partial
 from typing import Annotated, Any
 from litestar import get, post
 from litestar.response import Template
-from litestar_htmx import HTMXRequest, ClientRedirect, HTMXTemplate
+from litestar_htmx import HTMXRequest, HTMXTemplate
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
 
@@ -21,7 +21,7 @@ from web.controllers.admin.base_event_admin_controller import (
 )
 from web.controllers.admin.player_admin_controller import PlayerAdminController
 from web.controllers.admin.tournament_admin_controller import TournamentAdminWebContext
-from web.controllers.base_controller import Redirect, WebContext
+from web.controllers.base_controller import WebContext
 
 get_data = partial(PluginUtils.get_plugin_data, PLUGIN_NAME)
 
@@ -37,14 +37,8 @@ class FfeAdminEventController(BaseEventAdminController):
         event_uniq_id: str,
         admin_players_filter_leagues: list[str] | None = None,
         admin_players_filter_licences: list[int] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
-        web_context: BaseEventAdminWebContext = BaseEventAdminWebContext(
-            request,
-            event_uniq_id=event_uniq_id,
-            data=None,
-        )
-        if web_context.error:
-            return web_context.error
+    ) -> Template:
+        BaseEventAdminWebContext(request, event_uniq_id)
 
         if admin_players_filter_leagues is not None:
             FFESessionHandler.set_session_admin_players_filter_leagues(
@@ -65,10 +59,7 @@ class FfeAdminEventController(BaseEventAdminController):
                 ],
             )
         PlayerAdminController.set_players_search_results(request, event_uniq_id)
-        return PlayerAdminController._admin_event_players_render(
-            request,
-            event_uniq_id=event_uniq_id,
-        )
+        return PlayerAdminController._admin_event_players_render(request, event_uniq_id)
 
     @post(
         path='/ffe/test-auth',
@@ -81,7 +72,7 @@ class FfeAdminEventController(BaseEventAdminController):
             dict[str, Any],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         ffe_auth_valid: bool | None = None
 
         if NetworkMonitor.connected():
@@ -124,14 +115,12 @@ class FfeAdminEventController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: BaseEventAdminWebContext = BaseEventAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
         assert web_context.admin_event is not None
 
         FfeBackgroundUploader.update_eligible_tournaments(web_context.admin_event)
@@ -154,7 +143,7 @@ class FfeAdminEventController(BaseEventAdminController):
     def _render_upload_results(
         request: HTMXRequest,
         web_context: BaseEventAdminWebContext,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         assert web_context.admin_event is not None
 
         return HTMXTemplate(
@@ -176,14 +165,12 @@ class FfeAdminEventController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: BaseEventAdminWebContext = BaseEventAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
         return self._render_upload_results(request, web_context)
 
     @post(
@@ -194,14 +181,12 @@ class FfeAdminEventController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: BaseEventAdminWebContext = BaseEventAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
 
         admin_event = web_context.admin_event
         assert admin_event is not None
@@ -218,7 +203,7 @@ class FfeAdminEventController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: TournamentAdminWebContext = TournamentAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -226,9 +211,6 @@ class FfeAdminEventController(BaseEventAdminController):
             criterion_id=None,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
-
         admin_event = web_context.admin_event
         assert admin_event is not None
         tournament = web_context.admin_tournament
@@ -246,14 +228,12 @@ class FfeAdminEventController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: BaseEventAdminWebContext = BaseEventAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
         admin_event = web_context.admin_event
         assert admin_event is not None
 

--- a/src/plugins/ffe/ffe_tournament_controller.py
+++ b/src/plugins/ffe/ffe_tournament_controller.py
@@ -21,7 +21,6 @@ from web.controllers.admin.base_event_admin_controller import (
     BaseEventAdminController,
 )
 from web.controllers.admin.tournament_admin_controller import TournamentAdminWebContext
-from web.controllers.base_controller import Redirect
 from web.messages import Message
 
 logger = get_logger()
@@ -38,7 +37,7 @@ class FfeAdminTournamentController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: TournamentAdminWebContext = TournamentAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -46,8 +45,6 @@ class FfeAdminTournamentController(BaseEventAdminController):
             criterion_id=None,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
 
         admin_event = web_context.admin_event
         assert admin_event is not None
@@ -118,7 +115,7 @@ class FfeAdminTournamentController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: TournamentAdminWebContext = TournamentAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -126,8 +123,6 @@ class FfeAdminTournamentController(BaseEventAdminController):
             criterion_id=None,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
 
         admin_event = web_context.admin_event
         assert admin_event is not None
@@ -214,7 +209,7 @@ class FfeAdminTournamentController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template | ClientRedirect:
         web_context: TournamentAdminWebContext = TournamentAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -222,8 +217,6 @@ class FfeAdminTournamentController(BaseEventAdminController):
             criterion_id=None,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
 
         admin_event = web_context.admin_event
         assert admin_event is not None
@@ -310,7 +303,7 @@ class FfeAdminTournamentController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect | File:
+    ) -> Template | File:
         web_context: TournamentAdminWebContext = TournamentAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -318,8 +311,6 @@ class FfeAdminTournamentController(BaseEventAdminController):
             criterion_id=None,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
 
         admin_event = web_context.admin_event
         assert admin_event is not None

--- a/src/web/controllers/admin/account_admin_controller.py
+++ b/src/web/controllers/admin/account_admin_controller.py
@@ -3,8 +3,9 @@ from typing import Annotated, Any
 from argon2 import PasswordHasher
 from litestar import post, get, delete, patch
 from litestar.enums import RequestEncodingType
+from litestar.exceptions import NotFoundException
 from litestar.params import Body
-from litestar.plugins.htmx import HTMXRequest, ClientRedirect
+from litestar.plugins.htmx import HTMXRequest
 from litestar.response import Template
 from litestar.status_codes import HTTP_200_OK
 
@@ -19,7 +20,7 @@ from web.controllers.admin.base_event_admin_controller import (
     BaseEventAdminWebContext,
     BaseEventAdminController,
 )
-from web.controllers.base_controller import Redirect, WebContext
+from web.controllers.base_controller import WebContext
 from web.messages import Message
 from web.session import SessionHandler
 
@@ -40,14 +41,11 @@ class AccountAdminWebContext(BaseEventAdminWebContext):
         assert self.admin_event is not None
         self.admin_account: Account | None = None
         self.admin_permission: Permission | None = None
-        if self.error:
-            return
         if account_id:
             try:
                 self.admin_account = self.admin_event.accounts_by_id[account_id]
             except KeyError:
-                self._redirect_error(f'Account [{account_id}] not found.')
-                return
+                raise NotFoundException(f'Account [{account_id}] not found.')
         if access_level:
             assert self.admin_account is not None
             self.admin_permission = next(
@@ -59,11 +57,10 @@ class AccountAdminWebContext(BaseEventAdminWebContext):
                 None,
             )
             if not self.admin_permission:
-                self._redirect_error(
+                raise NotFoundException(
                     f'Unknown access level [{access_level}] for '
                     f'account [{self.admin_account.full_name}].'
                 )
-                return
 
     def get_admin_account(self) -> Account:
         assert self.admin_account is not None
@@ -91,9 +88,7 @@ class AccountAdminController(BaseEventAdminController):
         cls,
         web_context: AccountAdminWebContext,
         template_context: dict[str, Any] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
-        if web_context.error:
-            return web_context.error
+    ) -> Template:
         return cls._admin_base_event_render(
             web_context.template_context | (template_context or {})
         )
@@ -107,7 +102,7 @@ class AccountAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         admin_accounts_show_details: bool | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         if admin_accounts_show_details is not None:
             SessionHandler.set_session_admin_accounts_show_details(
                 request, admin_accounts_show_details
@@ -164,10 +159,8 @@ class AccountAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(request, event_uniq_id)
-        if web_context.error:
-            return web_context.error
         template_context = self._account_form_modal_context(FormAction.CREATE, {})
         return self.admin_event_account_render(web_context, template_context)
 
@@ -180,10 +173,8 @@ class AccountAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         account_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(request, event_uniq_id, account_id)
-        if web_context.error:
-            return web_context.error
         template_context = self._account_form_modal_context(
             FormAction.UPDATE,
             self._account_form_data_from_account(web_context.get_admin_account()),
@@ -199,10 +190,8 @@ class AccountAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         account_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(request, event_uniq_id, account_id)
-        if web_context.error:
-            return web_context.error
         account = web_context.get_admin_account()
         template_context = self._account_form_modal_context(
             FormAction.CLONE,
@@ -219,7 +208,7 @@ class AccountAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         account_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self.admin_event_account_render(
             AccountAdminWebContext(request, event_uniq_id, account_id),
             {'modal': 'account_delete'},
@@ -233,10 +222,8 @@ class AccountAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(request, event_uniq_id)
-        if web_context.error:
-            return web_context.error
         web_context.get_admin_event().create_predefined_accounts()
         Message.success(request, _('Default accounts have been created.'))
         return self.admin_event_account_render(web_context)
@@ -288,10 +275,8 @@ class AccountAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(request, event_uniq_id)
-        if web_context.error:
-            return web_context.error
         if errors := self._validate_account_form_data(
             data, web_context, FormAction.CREATE
         ):
@@ -332,10 +317,8 @@ class AccountAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(request, event_uniq_id, account_id)
-        if web_context.error:
-            return web_context.error
         if errors := self._validate_account_form_data(
             data, web_context, FormAction.UPDATE
         ):
@@ -374,10 +357,8 @@ class AccountAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         account_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(request, event_uniq_id, account_id)
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         account = web_context.get_admin_account()
         event.delete_account(account)
@@ -482,10 +463,8 @@ class AccountAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         account_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(request, event_uniq_id, account_id)
-        if web_context.error:
-            return web_context.error
         return self.admin_event_account_render(
             web_context, self._permissions_modal_context(web_context)
         )
@@ -502,10 +481,8 @@ class AccountAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         account_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(request, event_uniq_id, account_id)
-        if web_context.error:
-            return web_context.error
         template_context = self._permission_form_modal_context(
             web_context, FormAction.CREATE
         )
@@ -524,12 +501,10 @@ class AccountAdminController(BaseEventAdminController):
         event_uniq_id: str,
         account_id: int,
         access_level: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(
             request, event_uniq_id, account_id, access_level
         )
-        if web_context.error:
-            return web_context.error
         permission = web_context.get_admin_permission()
         data = WebContext.values_dict_to_form_data(
             {
@@ -604,10 +579,8 @@ class AccountAdminController(BaseEventAdminController):
             dict[str, str | list[str]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(request, event_uniq_id, account_id)
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         account = web_context.get_admin_account()
         flat_data = WebContext.flatten_list_data(data)
@@ -649,12 +622,10 @@ class AccountAdminController(BaseEventAdminController):
             dict[str, str | list[str]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(
             request, event_uniq_id, account_id, access_level
         )
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         account = web_context.get_admin_account()
         permission = web_context.get_admin_permission()
@@ -694,12 +665,10 @@ class AccountAdminController(BaseEventAdminController):
         event_uniq_id: str,
         account_id: int,
         access_level: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AccountAdminWebContext(
             request, event_uniq_id, account_id, access_level
         )
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         account = web_context.get_admin_account()
         permission = web_context.get_admin_permission()

--- a/src/web/controllers/admin/base_admin_controller.py
+++ b/src/web/controllers/admin/base_admin_controller.py
@@ -3,6 +3,7 @@ from typing import Annotated, Any
 
 import requests
 import validators
+from litestar.exceptions import NotFoundException
 from litestar.plugins.htmx import HTMXRequest
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
@@ -35,19 +36,14 @@ class AdminWebContext(WebContext):
         super().__init__(request, data=data)
         self.admin_tab: str | None = admin_tab
         self.admin_event: Event | None = None
-        if self.error:
-            return
         if event_uniq_id:
             try:
                 self.admin_event = EventLoader.get(request=self.request).load_event(
                     event_uniq_id
                 )
             except SharlyChessException as pwe:
-                self._redirect_error(f'Event [{event_uniq_id}] not found: {pwe}')
-                return
+                raise NotFoundException(f'Event [{event_uniq_id}] not found: {pwe}')
 
-        if self.error:
-            return
         self.check_admin_tab()
 
     def get_admin_event(self) -> Event:
@@ -63,7 +59,7 @@ class AdminWebContext(WebContext):
             'coming_events',
             'archives',
         ]:
-            self._redirect_error(
+            raise NotFoundException(
                 f'Invalid value [{self.admin_tab}] for parameter [admin_tab]'
             )
 

--- a/src/web/controllers/admin/display_controller_admin_controller.py
+++ b/src/web/controllers/admin/display_controller_admin_controller.py
@@ -1,7 +1,8 @@
 from typing import Annotated, Any
 
 from litestar import post, get, patch, delete
-from litestar.plugins.htmx import HTMXRequest, ClientRedirect
+from litestar.exceptions import NotFoundException
+from litestar.plugins.htmx import HTMXRequest
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
 from litestar.response import Template
@@ -18,7 +19,7 @@ from web.controllers.admin.base_event_admin_controller import (
     BaseEventAdminWebContext,
     BaseEventAdminController,
 )
-from web.controllers.base_controller import Redirect, WebContext
+from web.controllers.base_controller import WebContext
 from web.messages import Message
 
 
@@ -42,18 +43,15 @@ class DisplayControllerAdminWebContext(BaseEventAdminWebContext):
         if self.admin_event is None:
             raise RuntimeError('admin_event not defined')
         self.admin_display_controller: DisplayController | None = None
-        if self.error:
-            return
         if display_controller_id:
             try:
                 self.admin_display_controller = (
                     self.admin_event.display_controllers_by_id[display_controller_id]
                 )
             except KeyError:
-                self._redirect_error(
+                raise NotFoundException(
                     f'Display controller [{display_controller_id}] not found.'
                 )
-                return
 
     def get_admin_display_controller(self) -> DisplayController:
         assert self.admin_display_controller is not None
@@ -118,15 +116,13 @@ class DisplayControllerAdminController(BaseEventAdminController):
         display_controller_id: int | None = None,
         data: dict[str, str] | None = None,  # type: ignore
         errors: dict[str, str] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = DisplayControllerAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             display_controller_id=display_controller_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         sorted_screens: list[Screen] = sorted(
             event.basic_screens_by_id.values(),
@@ -211,7 +207,7 @@ class DisplayControllerAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_display_controllers_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -225,7 +221,7 @@ class DisplayControllerAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_display_controllers_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -244,7 +240,7 @@ class DisplayControllerAdminController(BaseEventAdminController):
         event_uniq_id: str,
         action: str,
         display_controller_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_display_controllers_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -263,7 +259,7 @@ class DisplayControllerAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         match action:
             case 'update' | 'delete' | 'create':
                 web_context: DisplayControllerAdminWebContext = (
@@ -276,8 +272,6 @@ class DisplayControllerAdminController(BaseEventAdminController):
                 )
             case _:
                 raise ValueError(f'action=[{action}]')
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         stored_display_controller = self._admin_validate_display_controller_update_data(
             action, web_context, data
@@ -348,7 +342,7 @@ class DisplayControllerAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_display_controller_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -370,7 +364,7 @@ class DisplayControllerAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_display_controller_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -393,7 +387,7 @@ class DisplayControllerAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_display_controller_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -413,7 +407,7 @@ class DisplayControllerAdminController(BaseEventAdminController):
         display_controller_id: int | None,
         type: str,
         object_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: DisplayControllerAdminWebContext = (
             DisplayControllerAdminWebContext(
                 request,
@@ -422,8 +416,6 @@ class DisplayControllerAdminController(BaseEventAdminController):
                 data=None,
             )
         )
-        if web_context.error:
-            return web_context.error
         if web_context.admin_event is None:
             raise RuntimeError('admin_event not defined')
         if web_context.admin_display_controller is None:
@@ -482,7 +474,7 @@ class DisplayControllerAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         display_controller_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: DisplayControllerAdminWebContext = (
             DisplayControllerAdminWebContext(
                 request,
@@ -491,8 +483,6 @@ class DisplayControllerAdminController(BaseEventAdminController):
                 data=None,
             )
         )
-        if web_context.error:
-            return web_context.error
         if web_context.admin_event is None:
             raise RuntimeError('admin_event not defined')
         if web_context.admin_display_controller is None:

--- a/src/web/controllers/admin/event_admin_controller.py
+++ b/src/web/controllers/admin/event_admin_controller.py
@@ -3,7 +3,6 @@ from typing import Any
 from litestar import get
 from litestar.plugins.htmx import HTMXRequest
 from litestar.response import Template, Redirect
-from litestar_htmx import ClientRedirect
 
 from data.display_controller import DisplayController
 from data.rotator import Rotator
@@ -27,9 +26,7 @@ class EventAdminController(BaseEventAdminController):
         cls,
         web_context: BaseEventAdminWebContext,
         template_context: dict[str, Any] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
-        if web_context.error:
-            return web_context.error
+    ) -> Template:
         return cls._admin_base_event_render(
             web_context.template_context | (template_context or {}),
         )
@@ -42,14 +39,12 @@ class EventAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | Redirect | ClientRedirect:
+    ) -> Template | Redirect:
         web_context: BaseEventAdminWebContext = BaseEventAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
         if web_context.admin_event is None:
             raise RuntimeError('admin_event not defined')
         started_tournaments: list[Tournament] = [

--- a/src/web/controllers/admin/event_print_controller.py
+++ b/src/web/controllers/admin/event_print_controller.py
@@ -4,8 +4,7 @@ from litestar import get, post
 from litestar.plugins.htmx import HTMXRequest, HTMXTemplate
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
-from litestar.response import Template, Redirect
-from litestar_htmx import ClientRedirect
+from litestar.response import Template
 import urllib
 
 from common.exception import OptionError
@@ -37,9 +36,7 @@ class EventPrintController(BaseEventAdminController):
         cls,
         web_context: BaseEventAdminWebContext,
         template_context: dict[str, Any] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
-        if web_context.error:
-            return web_context.error
+    ) -> Template:
         return cls._admin_base_event_render(
             web_context.template_context | (template_context or {}),
         )
@@ -105,7 +102,7 @@ class EventPrintController(BaseEventAdminController):
         document_id: str | None = None,
         tournament_id: int | None = None,
         round: int | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = BaseEventAdminWebContext(request, event_uniq_id)
         tournament_ids = web_context.default_tournament_for_print_modal(tournament_id)
 
@@ -132,15 +129,13 @@ class EventPrintController(BaseEventAdminController):
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         flat_data = WebContext.flatten_list_data(data)
         web_context: BaseEventAdminWebContext = BaseEventAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             data=flat_data,
         )
-        if web_context.error:
-            return web_context.error
 
         errors: dict[str, str] = {}
 
@@ -222,14 +217,12 @@ class EventPrintController(BaseEventAdminController):
         event_uniq_id: str,
         document: str,
         options: str | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: BaseEventAdminWebContext = BaseEventAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
         document_type = PrintDocumentManager.get_type(document)
         option_data: dict[str, str] = {}
         if options:

--- a/src/web/controllers/admin/family_admin_controller.py
+++ b/src/web/controllers/admin/family_admin_controller.py
@@ -1,7 +1,8 @@
 from typing import Annotated, Any
 
 from litestar import post, get, patch, delete
-from litestar.plugins.htmx import HTMXRequest, ClientRedirect
+from litestar.exceptions import ClientException, NotFoundException
+from litestar.plugins.htmx import HTMXRequest
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
 from litestar.response import Template
@@ -19,7 +20,7 @@ from web.controllers.admin.base_event_admin_controller import (
     BaseEventAdminWebContext,
     BaseEventAdminController,
 )
-from web.controllers.base_controller import Redirect, WebContext
+from web.controllers.base_controller import WebContext
 from web.messages import Message
 from web.session import SessionHandler
 
@@ -45,14 +46,12 @@ class FamilyAdminWebContext(BaseEventAdminWebContext):
         if self.admin_event is None:
             raise RuntimeError('admin_event not defined')
         self.admin_family: Family | None = None
-        if self.error:
-            return
         if family_id:
             try:
                 self.admin_family = self.admin_event.families_by_id[family_id]
             except KeyError:
-                self._redirect_error(f'Family [{family_id}] not found.')
-                return
+                raise NotFoundException(f'Family [{family_id}] not found.')
+
         self.family_type: ScreenType | None = None
         if self.admin_family:
             self.family_type = self.admin_family.type
@@ -60,8 +59,7 @@ class FamilyAdminWebContext(BaseEventAdminWebContext):
             try:
                 self.family_type = ScreenType(family_type)
             except ValueError:
-                self._redirect_error(f'Unknown screen type [{family_type}].')
-                return
+                raise NotFoundException(f'Unknown screen type [{family_type}].')
 
     def get_admin_family(self) -> Family:
         assert self.admin_family is not None
@@ -302,7 +300,7 @@ class FamilyAdminController(BaseEventAdminController):
         family_type: str | None = None,
         data: dict[str, str] | None = None,  # type: ignore
         errors: dict[str, str] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: FamilyAdminWebContext = FamilyAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -310,8 +308,6 @@ class FamilyAdminController(BaseEventAdminController):
             family_type=family_type,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         template_context = web_context.template_context | {
             'admin_event_tab': 'admin-event-families-tab',
@@ -503,7 +499,7 @@ class FamilyAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         admin_families_show_details: bool | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         if admin_families_show_details is not None:
             SessionHandler.set_session_admin_families_show_details(
                 request, admin_families_show_details
@@ -522,7 +518,7 @@ class FamilyAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         family_type: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_families_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -542,7 +538,7 @@ class FamilyAdminController(BaseEventAdminController):
         event_uniq_id: str,
         action: str,
         family_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_families_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -562,7 +558,7 @@ class FamilyAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         match action:
             case 'update' | 'delete' | 'clone' | 'create':
                 web_context: FamilyAdminWebContext = FamilyAdminWebContext(
@@ -574,8 +570,6 @@ class FamilyAdminController(BaseEventAdminController):
                 )
             case _:
                 raise ValueError(f'action=[{action}]')
-        if web_context.error:
-            return web_context.error
         if web_context.admin_event is None:
             raise RuntimeError('admin_event not defined')
         stored_family: StoredFamily = self._admin_validate_family_update_data(
@@ -639,7 +633,7 @@ class FamilyAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_family_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -662,7 +656,7 @@ class FamilyAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_family_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -685,7 +679,7 @@ class FamilyAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_family_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -708,7 +702,7 @@ class FamilyAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         family_id: int,
-    ) -> HTMXTemplate | ClientRedirect | Redirect:
+    ) -> HTMXTemplate:
         web_context = FamilyAdminWebContext(request, event_uniq_id, family_id)
         event = web_context.get_admin_event()
         family = web_context.get_admin_family()
@@ -722,7 +716,7 @@ class FamilyAdminController(BaseEventAdminController):
             )
         ):
             # No precise error (validated in JS)
-            return self.redirect_error(request, f'Invalid uniq ID [{new_uniq_id}].')
+            raise ClientException(f'Invalid uniq ID [{new_uniq_id}].')
         stored_family = family.stored_family
         assert stored_family is not None
         stored_family.uniq_id = new_uniq_id
@@ -753,7 +747,7 @@ class FamilyAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_family_update(
             request,
             event_uniq_id=event_uniq_id,

--- a/src/web/controllers/admin/index_admin_controller.py
+++ b/src/web/controllers/admin/index_admin_controller.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any
 
 import requests
 import validators
+from litestar.exceptions import ClientException, NotFoundException
 
 from common import (
     BASE_DIR,
@@ -56,7 +57,7 @@ from web.controllers.admin.base_admin_controller import (
     AdminWebContext,
     BaseAdminController,
 )
-from web.controllers.base_controller import BaseController, WebContext
+from web.controllers.base_controller import WebContext
 from web.messages import Message
 from web.session import SessionHandler
 from web.urls import admin_event_tournaments_url, admin_event_url
@@ -151,7 +152,7 @@ class IndexAdminController(BaseAdminController):
         web_context: AdminWebContext,
         template_context: dict[str, Any] | None = None,
         keep_modal_open: bool | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         sorted_archives = ArchiveLoader.get_sorted_archives()
         public_only: bool = not web_context.client.can_view_private_events
         passed_events = EventLoader.get_events_metadata(
@@ -291,12 +292,10 @@ class IndexAdminController(BaseAdminController):
         self,
         request: HTMXRequest,
         admin_events_show_details: bool | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AdminWebContext(
             request, data=None, event_uniq_id=None, admin_tab=None
         )
-        if web_context.error:
-            return web_context.error
 
         if admin_events_show_details is not None:
             SessionHandler.set_session_admin_events_show_details(
@@ -316,12 +315,10 @@ class IndexAdminController(BaseAdminController):
         request: HTMXRequest,
         admin_tab: str,
         admin_events_show_details: bool | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AdminWebContext(
             request, data=None, event_uniq_id=None, admin_tab=admin_tab
         )
-        if web_context.error:
-            return web_context.error
 
         if admin_events_show_details is not None:
             SessionHandler.set_session_admin_events_show_details(
@@ -678,7 +675,7 @@ class IndexAdminController(BaseAdminController):
         action: FormAction,
         admin_tab: str | None = None,
         event_uniq_id: str | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AdminWebContext(
             request, data=None, event_uniq_id=event_uniq_id, admin_tab=admin_tab
         )
@@ -702,12 +699,10 @@ class IndexAdminController(BaseAdminController):
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
         admin_tab: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template | Redirect:
         web_context: AdminWebContext = AdminWebContext(
             request, data=data, event_uniq_id=None, admin_tab=admin_tab
         )
-        if web_context.error:
-            return web_context.error
         stored_event, errors = self._admin_get_validate_event_data(
             FormAction.CREATE, web_context, None, data
         )
@@ -738,7 +733,7 @@ class IndexAdminController(BaseAdminController):
         request: HTMXRequest,
         admin_tab: str,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AdminWebContext(
             request, data=None, admin_tab=admin_tab, event_uniq_id=event_uniq_id
         )
@@ -754,19 +749,16 @@ class IndexAdminController(BaseAdminController):
         request: HTMXRequest,
         admin_tab: str,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AdminWebContext(
             request, data=None, admin_tab=admin_tab, event_uniq_id=event_uniq_id
         )
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         try:
             arch = EventDatabase(event.uniq_id).delete()
         except PermissionError as ex:
-            return BaseController.redirect_error(
-                request, f'Archiving the database failed: {ex}'
-            )
+            raise ClientException(f'Archiving the database failed: {ex}')
+
         Message.success(
             request,
             _(
@@ -788,15 +780,13 @@ class IndexAdminController(BaseAdminController):
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template | ClientRedirect:
         web_context: AdminWebContext = AdminWebContext(
             request,
             admin_tab=None,
             event_uniq_id=event_uniq_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
         stored_event, errors = self._admin_get_validate_event_data(
             FormAction.CLONE, web_context, web_context.admin_event, data
         )
@@ -838,15 +828,13 @@ class IndexAdminController(BaseAdminController):
         ],
         admin_tab: str | None,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: AdminWebContext = AdminWebContext(
             request,
             admin_tab=admin_tab,
             event_uniq_id=event_uniq_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
         stored_event, errors = self._admin_get_validate_event_data(
             FormAction.UPDATE, web_context, web_context.admin_event, data
         )
@@ -890,7 +878,7 @@ class IndexAdminController(BaseAdminController):
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> ClientRedirect:
         web_context = AdminWebContext(
             request, admin_tab=None, event_uniq_id=event_uniq_id, data=data
         )
@@ -905,17 +893,12 @@ class IndexAdminController(BaseAdminController):
             )
         ):
             # No precise error (validated in JS)
-            return self.redirect_error(
-                request, f'Invalid event uniq ID [{new_uniq_id}].'
-            )
+            raise ClientException(f'Invalid event uniq ID [{new_uniq_id}].')
         if new_uniq_id != event_uniq_id:
             try:
                 EventDatabase(event.uniq_id).rename(new_uniq_id)
             except PermissionError as ex:
-                return self.redirect_error(
-                    request,
-                    _('Renaming the database failed: {ex}.').format(ex=ex),
-                )
+                raise ClientException(f'Renaming the database failed: {ex}.')
             Message.success(
                 request,
                 _(
@@ -936,13 +919,13 @@ class IndexAdminController(BaseAdminController):
         self,
         request: HTMXRequest,
         archive_name: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AdminWebContext(
             request, data=None, event_uniq_id=None, admin_tab='archives'
         )
         archive = ArchiveLoader.get_archive(archive_name)
         if not archive:
-            return self.redirect_error(request, f'Unknown archive [{archive_name}]')
+            raise NotFoundException(f'Unknown archive [{archive_name}]')
         uniq_id = archive.restore()
         Message.success(
             request,
@@ -960,7 +943,7 @@ class IndexAdminController(BaseAdminController):
         self,
         request: HTMXRequest,
         locale: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AdminWebContext(
             request, data=None, event_uniq_id=None, admin_tab=None
         )
@@ -1028,7 +1011,7 @@ class IndexAdminController(BaseAdminController):
     async def htmx_admin_config_modal(
         self,
         request: HTMXRequest,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         config = SharlyChessConfig()
         web_context = AdminWebContext(
             request, data=None, event_uniq_id=None, admin_tab=None
@@ -1051,7 +1034,7 @@ class IndexAdminController(BaseAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AdminWebContext(
             request, data=data, event_uniq_id=None, admin_tab=None
         )
@@ -1093,7 +1076,7 @@ class IndexAdminController(BaseAdminController):
     async def htmx_admin_status_badge(
         self,
         request: HTMXRequest,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         source_databases: list[LocalSourceDatabase] = (
             LocalSourceDatabaseManager.objects()
         )
@@ -1162,7 +1145,7 @@ class IndexAdminController(BaseAdminController):
     async def htmx_admin_database_modal(
         self,
         request: HTMXRequest,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AdminWebContext(
             request, data=None, event_uniq_id=None, admin_tab=None
         )
@@ -1183,7 +1166,7 @@ class IndexAdminController(BaseAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         source_databases: list[LocalSourceDatabase] = (
             LocalSourceDatabaseManager.objects()
         )
@@ -1233,7 +1216,7 @@ class IndexAdminController(BaseAdminController):
         self,
         request: HTMXRequest,
         database_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         database = LocalSourceDatabaseManager.get_object(database_id)
         return HTMXTemplate(
             template_name='/admin/common/database/database_update_buttons.html',
@@ -1262,12 +1245,12 @@ class IndexAdminController(BaseAdminController):
         self,
         request: HTMXRequest,
         database_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         try:
             database = LocalSourceDatabaseManager.get_object(database_id)
             database.delete()
         except KeyError:
-            return self.redirect_error(request, f'Unknown database [{database_id}].')
+            raise NotFoundException(f'Unknown database [{database_id}].')
         return HTMXTemplate(
             template_name='/admin/common/database/database_update_buttons.html',
             context={'database': database},
@@ -1281,7 +1264,7 @@ class IndexAdminController(BaseAdminController):
         self,
         request: HTMXRequest,
         data_source_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = AdminWebContext(
             request, data=None, event_uniq_id=None, admin_tab=None
         )
@@ -1289,9 +1272,7 @@ class IndexAdminController(BaseAdminController):
             data_source = OnlineDataSourceManager.get_object(data_source_id)
             await data_source.reload_connection_status()
         except KeyError:
-            return self.redirect_error(
-                request, f'Unknown data source [{data_source_id}].'
-            )
+            raise NotFoundException(f'Unknown data source [{data_source_id}].')
         template_context = self._database_modal_context()
         return self._admin_render(
             web_context=web_context,

--- a/src/web/controllers/admin/pairings_admin_controller.py
+++ b/src/web/controllers/admin/pairings_admin_controller.py
@@ -1,3 +1,5 @@
+from litestar.exceptions import NotFoundException, ClientException
+
 from common import experimental_features_enabled
 
 from collections import defaultdict
@@ -9,7 +11,7 @@ from common.i18n.utils import by
 from data.pairings.engines import BbpPairings
 from data.pairings.bbp_history import TournamentHistoryPlayer
 from litestar import delete, get, patch, put, post
-from litestar.plugins.htmx import HTMXRequest, ClientRedirect
+from litestar.plugins.htmx import HTMXRequest
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
 from litestar.response import Template
@@ -36,7 +38,7 @@ from web.controllers.admin.base_event_admin_controller import (
     BaseEventAdminWebContext,
     BaseEventAdminController,
 )
-from web.controllers.base_controller import Redirect, WebContext
+from web.controllers.base_controller import WebContext
 from web.controllers.user.event_user_controller import EventUserController
 from web.guards import Guard
 from web.messages import Message
@@ -85,21 +87,13 @@ class PairingsAdminWebContext(BaseEventAdminWebContext):
     ):
         super().__init__(request, event_uniq_id, data)
         self.admin_tournament: Tournament | None = None
-
-        if not self.admin_event:
-            return
-
-        if self.error:
-            return
-
         event = self.get_admin_event()
         if tournament_id:
             if tournament_id not in event.tournaments_by_id:
-                self._redirect_error(
+                raise NotFoundException(
                     f'Unknown tournament ID [{tournament_id}] '
                     f'for event [{event_uniq_id}]'
                 )
-                return
             self.admin_tournament = event.tournaments_by_id[tournament_id]
         elif event.tournaments:
             session_tournament_id = (
@@ -234,7 +228,7 @@ class PairingsAdminWebContext(BaseEventAdminWebContext):
                     self.safety_mode = required_mode
                     self.requires_refresh = True
             except SharlyChessException:
-                self._redirect_error(
+                raise ClientException(
                     f'Action [{action}] does not exist for '
                     f'round with status [{self.round_status}].'
                 )
@@ -332,10 +326,7 @@ class PairingsAdminController(BaseEventAdminController):
         cls,
         web_context: PairingsAdminWebContext,
         template_context: dict[str, Any] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
-        if web_context.error:
-            return web_context.error
-
+    ) -> Template:
         return cls._admin_base_event_render(
             web_context.template_context | (template_context or {}),
         )
@@ -360,7 +351,7 @@ class PairingsAdminController(BaseEventAdminController):
         tournament_id: int | None,
         round: int | None,
         show_without_results: bool | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         if show_without_results is not None:
             SessionHandler.set_session_admin_pairings_show_without_results(
                 request, show_without_results
@@ -368,8 +359,6 @@ class PairingsAdminController(BaseEventAdminController):
         web_context = PairingsAdminWebContext(
             request, event_uniq_id, tournament_id, round
         )
-        if web_context.error:
-            return web_context.error
 
         if web_context.admin_tournament:
             SessionHandler.set_session_admin_pairings_selected_tournament(
@@ -402,7 +391,7 @@ class PairingsAdminController(BaseEventAdminController):
         tournament_id: int,
         round: int,
         board_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PairingsAdminWebContext(
             request, event_uniq_id, tournament_id, round, board_id
         )
@@ -427,7 +416,7 @@ class PairingsAdminController(BaseEventAdminController):
         tournament_id: int,
         round: int,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PairingsAdminWebContext(
             request, event_uniq_id, tournament_id, round, player_id=player_id
         )
@@ -465,7 +454,7 @@ class PairingsAdminController(BaseEventAdminController):
         result: int,
         trigger_event: str | None = None,
         validate_result: bool = False,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -474,8 +463,6 @@ class PairingsAdminController(BaseEventAdminController):
             board_id=board_id,
             action=None if validate_result else PairingAction.RESULT_UPDATE,
         )
-        if web_context.error:
-            return web_context.error
         tournament = web_context.get_admin_tournament()
         board = web_context.get_admin_board()
 
@@ -484,7 +471,7 @@ class PairingsAdminController(BaseEventAdminController):
 
         target_board_id: int | None
         if result not in (Result.admin_imputable_results()):
-            return self.redirect_error(request, f'Invalid result [{result}].')
+            raise ClientException(f'Invalid result [{result}].')
 
         context = web_context.template_context
 
@@ -552,7 +539,7 @@ class PairingsAdminController(BaseEventAdminController):
         round: int,
         board_id: int,
         result: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_update_result(
             request,
             event_uniq_id=event_uniq_id,
@@ -576,7 +563,7 @@ class PairingsAdminController(BaseEventAdminController):
         tournament_id: int,
         round: int,
         board_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -585,8 +572,6 @@ class PairingsAdminController(BaseEventAdminController):
             board_id=board_id,
             action=PairingAction.MANUAL_UNPAIRING,
         )
-        if web_context.error:
-            return web_context.error
         board = web_context.get_admin_board()
         tournament = web_context.get_admin_tournament()
         tournament.unpair_boards([board])
@@ -612,7 +597,7 @@ class PairingsAdminController(BaseEventAdminController):
         tournament_id: int,
         round: int,
         board_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -621,8 +606,6 @@ class PairingsAdminController(BaseEventAdminController):
             board_id=board_id,
             action=PairingAction.COLOR_PERMUTE,
         )
-        if web_context.error:
-            return web_context.error
         board = web_context.get_admin_board()
         board.permute_colors()
         return self._admin_event_pairings_render(web_context)
@@ -642,7 +625,7 @@ class PairingsAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         board_id: int = int(data['board_id'])
         key: str = data['key']
         match key:
@@ -685,7 +668,7 @@ class PairingsAdminController(BaseEventAdminController):
         round: int,
         player_id: int,
         action: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -698,8 +681,6 @@ class PairingsAdminController(BaseEventAdminController):
                 else PairingAction.BYE_UPDATE
             ),
         )
-        if web_context.error:
-            return web_context.error
         tournament = web_context.get_admin_tournament()
         player = web_context.get_admin_player()
 
@@ -788,7 +769,7 @@ class PairingsAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         round: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -796,8 +777,6 @@ class PairingsAdminController(BaseEventAdminController):
             round_=round,
             action=PairingAction.FULL_PAIRING,
         )
-        if web_context.error:
-            return web_context.error
         tournament = web_context.get_admin_tournament()
         round_ = web_context.admin_round
         if not tournament.are_pairing_settings_valid:
@@ -823,7 +802,7 @@ class PairingsAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         round: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -831,8 +810,6 @@ class PairingsAdminController(BaseEventAdminController):
             round_=round,
             action=PairingAction.PARTIAL_PAIRING,
         )
-        if web_context.error:
-            return web_context.error
         tournament = web_context.get_admin_tournament()
         round_ = web_context.admin_round
         if not tournament.are_pairing_settings_valid:
@@ -891,7 +868,7 @@ class PairingsAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -939,7 +916,7 @@ class PairingsAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         round: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -947,8 +924,6 @@ class PairingsAdminController(BaseEventAdminController):
             round_=round,
             action=PairingAction.FULL_UNPAIRING,
         )
-        if web_context.error:
-            return web_context.error
         tournament = web_context.get_admin_tournament()
         tournament.unpair_boards(web_context.admin_boards)
 
@@ -969,15 +944,13 @@ class PairingsAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=None,
         )
-        if web_context.error:
-            return web_context.error
         tournament = web_context.get_admin_tournament()
         for round_ in reversed(range(1, tournament.rounds + 1)):
             boards = tournament.get_round_boards(round_)
@@ -1008,17 +981,14 @@ class PairingsAdminController(BaseEventAdminController):
         action: str,
         redirect_method: str,
         redirect_route: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         try:
             protected_action = PairingAction(action)
         except ValueError:
-            return self.redirect_error(request, f'Unknown pairing action [{action}]')
+            raise NotFoundException(f'Unknown pairing action [{action}]')
         web_context = PairingsAdminWebContext(
             request, event_uniq_id, tournament_id, round
         )
-        if web_context.error:
-            return web_context.error
-
         tournament = web_context.get_admin_tournament()
         return self._admin_event_pairings_render(
             web_context,
@@ -1054,14 +1024,14 @@ class PairingsAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         round: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         mode = WebContext.form_data_to_str(data, 'mode') or ''
         try:
             SessionHandler.set_session_admin_pairings_safety_mode(
                 request, SafetyMode(mode)
             )
         except ValueError:
-            return self.redirect_error(request, f'Unknown safety mode [{mode}]')
+            raise NotFoundException(f'Unknown safety mode [{mode}]')
         web_context = PairingsAdminWebContext(
             request, event_uniq_id, tournament_id, round, data=data
         )
@@ -1078,15 +1048,14 @@ class PairingsAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         round: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=round,
         )
-        if web_context.error:
-            return web_context.error
+
         return self._admin_event_pairings_render(
             web_context,
             {
@@ -1114,7 +1083,7 @@ class PairingsAdminController(BaseEventAdminController):
         player_id: int,
         check_in: int,
         round: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -1122,9 +1091,6 @@ class PairingsAdminController(BaseEventAdminController):
             player_id=player_id,
             round_=round,
         )
-
-        if web_context.error:
-            return web_context.error
 
         player = web_context.get_admin_player()
         tournament = web_context.get_admin_tournament()
@@ -1141,7 +1107,7 @@ class PairingsAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         round: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request, event_uniq_id, tournament_id, round
         )
@@ -1176,7 +1142,7 @@ class PairingsAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         round: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -1251,7 +1217,7 @@ class PairingsAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         current_round: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -1282,7 +1248,7 @@ class PairingsAdminController(BaseEventAdminController):
         tournament_id: int,
         round: int,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -1310,7 +1276,7 @@ class PairingsAdminController(BaseEventAdminController):
         tournament_id: int,
         round: int,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -1383,7 +1349,7 @@ class PairingsAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         round: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -1443,15 +1409,13 @@ class PairingsAdminController(BaseEventAdminController):
             dict[str, str | list[int]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PairingsAdminWebContext = PairingsAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             round_=None,
         )
-        if web_context.error:
-            return web_context.error
 
         tournament = web_context.get_admin_tournament()
 

--- a/src/web/controllers/admin/player_admin_controller.py
+++ b/src/web/controllers/admin/player_admin_controller.py
@@ -5,6 +5,9 @@ from logging import Logger
 import math
 from tempfile import NamedTemporaryFile
 from typing import Annotated, Any, Iterable
+
+from litestar.exceptions import NotFoundException, ClientException
+
 from common.i18n.utils import normalized_key
 from pyexcel_ods3 import save_data
 import xlsxwriter
@@ -13,7 +16,7 @@ from litestar import get, patch, delete, post, Response
 from litestar.plugins.htmx import HTMXRequest, ClientRedirect
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
-from litestar.response import Template, Redirect, File
+from litestar.response import Template, File
 from litestar.status_codes import HTTP_200_OK
 from litestar_htmx import HTMXTemplate
 from litestar.channels import ChannelsPlugin
@@ -64,6 +67,7 @@ class PlayerAdminWebContext(BaseEventAdminWebContext):
         event_uniq_id: str,
         player_id: int | None = None,
         tournament_id: int | None = None,
+        data_source_id: str | None = None,
         data: Annotated[
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
@@ -73,25 +77,29 @@ class PlayerAdminWebContext(BaseEventAdminWebContext):
         super().__init__(request, event_uniq_id=event_uniq_id, data=data)
         if self.admin_event is None:
             raise RuntimeError('admin_event not defined')
+
         self.admin_player: Player | None = None
-        self.admin_tournament: Tournament | None = None
-        if self.error:
-            return
         if player_id:
             try:
                 self.admin_player = self.admin_event.players_by_id[player_id]
             except KeyError:
-                self._redirect_error(f'Player [{player_id}] not found.')
-                return
+                raise NotFoundException(f'Player [{player_id}] not found.')
 
+        self.admin_tournament: Tournament | None = None
         if tournament_id:
             try:
                 self.admin_tournament = self.admin_event.tournaments_by_id[
                     tournament_id
                 ]
             except KeyError:
-                self._redirect_error(f'Tournament [{tournament_id}] not found.')
-                return
+                raise NotFoundException(f'Tournament [{tournament_id}] not found.')
+
+        self.admin_data_source: DataSource | None = None
+        if data_source_id:
+            try:
+                self.admin_data_source = DataSourceManager.get_object(data_source_id)
+            except KeyError:
+                raise NotFoundException(f'Unknown data source [{data_source_id}].')
 
         print_tournament_ids = self.default_tournament_for_print_modal(
             tournament_id=None
@@ -117,6 +125,10 @@ class PlayerAdminWebContext(BaseEventAdminWebContext):
     def get_admin_player(self) -> Player:
         assert self.admin_player is not None
         return self.admin_player
+
+    def get_admin_data_source(self) -> DataSource:
+        assert self.admin_data_source is not None
+        return self.admin_data_source
 
     @property
     def template_context(self) -> dict[str, Any]:
@@ -495,7 +507,7 @@ class PlayerAdminController(BaseEventAdminController):
         data: dict[str, str] | None = None,
         errors: dict[str, str] | None = None,
         warning_message: str | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PlayerAdminWebContext = PlayerAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -503,8 +515,6 @@ class PlayerAdminController(BaseEventAdminController):
             tournament_id=tournament_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
         if web_context.admin_event is None:
             raise RuntimeError('admin_event not defined')
         admin_event: Event = web_context.admin_event
@@ -924,7 +934,7 @@ class PlayerAdminController(BaseEventAdminController):
         admin_players_filter_categories: list[int] | None = None,
         admin_players_filter_name: str | None = None,
         admin_players_clear_filters: int | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         if admin_players_sort is not None:
             SessionHandler.set_session_admin_players_sort(request, admin_players_sort)
         elif admin_players_filter_columns is not None:
@@ -1027,7 +1037,7 @@ class PlayerAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         page: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_players_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1042,7 +1052,7 @@ class PlayerAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_players_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1066,28 +1076,21 @@ class PlayerAdminController(BaseEventAdminController):
         data_source_id: str,
         player_source_id: str,
         tournament_id: str | None,
-    ) -> Template | ClientRedirect | Redirect:
-        try:
-            data_source = DataSourceManager.get_object(data_source_id)
-        except KeyError:
-            return self.redirect_error(
-                request, f'Unknown data source [{data_source_id}].'
-            )
+    ) -> Template:
+        web_context = PlayerAdminWebContext(
+            request, event_uniq_id, data_source_id=data_source_id
+        )
+        data_source = web_context.get_admin_data_source()
         errors: dict[str, str] = {}
         stored_player: StoredPlayer | None = None
         if not data_source.is_available:
-            return self.redirect_error(
-                request, f'Data source [{data_source_id}] is not available.'
-            )
+            raise ClientException(f'Data source [{data_source_id}] is not available.')
         try:
             stored_player = await data_source.fetch_player(player_source_id)
             if not stored_player:
-                return self.redirect_error(
-                    request,
-                    (
-                        f'Player [{player_source_id}] unexpectedly '
-                        f'not found in data source [{data_source_id}]'
-                    ),
+                raise NotFoundException(
+                    f'Player [{player_source_id}] unexpectedly '
+                    f'not found in data source [{data_source_id}]'
                 )
         except SharlyChessException:
             errors[data_source.search_element_name] = _(
@@ -1114,7 +1117,7 @@ class PlayerAdminController(BaseEventAdminController):
         action: str,
         event_uniq_id: str,
         player_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_players_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1132,7 +1135,7 @@ class PlayerAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         player_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_players_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1150,7 +1153,7 @@ class PlayerAdminController(BaseEventAdminController):
         action: str,
         event_uniq_id: str,
         player_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         match action:
             case 'update' | 'create':
                 web_context: PlayerAdminWebContext = PlayerAdminWebContext(
@@ -1161,8 +1164,6 @@ class PlayerAdminController(BaseEventAdminController):
                 )
             case _:
                 raise ValueError(f'action=[{action}]')
-        if web_context.error:
-            return web_context.error
         if web_context.admin_event is None:
             raise RuntimeError('admin_event not defined')
         add_other = 'add_other' in data
@@ -1266,7 +1267,7 @@ class PlayerAdminController(BaseEventAdminController):
         event_uniq_id: str,
         player_id: int,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PlayerAdminWebContext = PlayerAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -1274,8 +1275,6 @@ class PlayerAdminController(BaseEventAdminController):
             tournament_id=tournament_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
         admin_player = web_context.get_admin_player()
         dst_tournament = web_context.get_admin_tournament()
         src_tournament = admin_player.tournament
@@ -1355,7 +1354,7 @@ class PlayerAdminController(BaseEventAdminController):
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_player_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -1377,7 +1376,7 @@ class PlayerAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_player_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -1468,7 +1467,7 @@ class PlayerAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PlayerAdminWebContext = PlayerAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -1476,8 +1475,6 @@ class PlayerAdminController(BaseEventAdminController):
             tournament_id=None,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
         if web_context.admin_player is None:
             raise RuntimeError('admin_player not defined')
         if web_context.admin_player.tournament is None:
@@ -1502,7 +1499,7 @@ class PlayerAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PlayerAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -1546,15 +1543,14 @@ class PlayerAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PlayerAdminWebContext = PlayerAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
+
         if web_context.admin_tournament is None:
             raise RuntimeError('admin_tournament not defined')
         admin_tournament: Tournament = web_context.admin_tournament
@@ -1576,7 +1572,7 @@ class PlayerAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_players_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1595,15 +1591,14 @@ class PlayerAdminController(BaseEventAdminController):
         tournament_id: int,
         zpbs_next_round: bool = False,
         zpbs_all_rounds: bool = False,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PlayerAdminWebContext = PlayerAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             tournament_id=tournament_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
+
         if web_context.admin_tournament is None:
             raise RuntimeError('admin_tournament not defined')
         admin_tournament: Tournament = web_context.admin_tournament
@@ -1634,7 +1629,7 @@ class PlayerAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         action = WebContext.form_data_to_str(data, 'action') or ''
 
         return self._admin_tournament_close_check_in(
@@ -1656,15 +1651,14 @@ class PlayerAdminController(BaseEventAdminController):
         event_uniq_id: str,
         player_id: int,
         check_in: bool,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PlayerAdminWebContext = PlayerAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
             player_id=player_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
+
         if web_context.admin_player is None:
             raise RuntimeError('admin_player not defined')
         admin_player: Player = web_context.admin_player
@@ -1690,7 +1684,7 @@ class PlayerAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_player_check_in_out(
             request=request,
             data=data,
@@ -1712,7 +1706,7 @@ class PlayerAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_player_check_in_out(
             request=request,
             data=data,
@@ -1735,19 +1729,15 @@ class PlayerAdminController(BaseEventAdminController):
         event_uniq_id: str,
         data_source_id: str,
         tournament_id: int | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PlayerAdminWebContext = PlayerAdminWebContext(
-            request, event_uniq_id=event_uniq_id, tournament_id=tournament_id
+            request,
+            event_uniq_id,
+            tournament_id=tournament_id,
+            data_source_id=data_source_id,
         )
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
-        try:
-            data_source = DataSourceManager.get_object(data_source_id)
-        except KeyError:
-            return self.redirect_error(
-                request, f'Unknown data source [{data_source_id}].'
-            )
+        data_source = web_context.get_admin_data_source()
         player_updater_field_ids: list[str] = [
             field.id for field in data_source.player_updater_fields
         ]
@@ -1797,26 +1787,20 @@ class PlayerAdminController(BaseEventAdminController):
         event_uniq_id: str,
         data_source_id: str,
         tournament_id: int | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PlayerAdminWebContext = PlayerAdminWebContext(
-            request, event_uniq_id=event_uniq_id, tournament_id=tournament_id
+            request,
+            event_uniq_id,
+            tournament_id=tournament_id,
+            data_source_id=data_source_id,
         )
-        if web_context.error:
-            return web_context.error
-        if web_context.admin_event is None:
-            raise RuntimeError('admin_event not defined')
-        try:
-            data_source: DataSource = DataSourceManager.get_object(data_source_id)
-        except KeyError:
-            # should never happen, not translated
-            return self.redirect_error(
-                request, f'Unknown data source [{data_source_id}].'
-            )
+        event = web_context.get_admin_event()
+        data_source = web_context.get_admin_data_source()
         field_ids: list[str] = [field.id for field in data_source.player_updater_fields]
         players = (
             web_context.admin_tournament.players_by_name_with_unpaired
             if web_context.admin_tournament
-            else web_context.admin_event.players_sorted_by_name
+            else event.players_sorted_by_name
         )
         player_matches: (
             list[PlayerComparator] | None
@@ -1904,20 +1888,11 @@ class PlayerAdminController(BaseEventAdminController):
         event_uniq_id: str,
         data_source_id: str,
         page: int = 0,
-    ) -> Template | ClientRedirect | Redirect:
-        web_context: BaseEventAdminWebContext = BaseEventAdminWebContext(
-            request,
-            event_uniq_id=event_uniq_id,
-            data=None,
+    ) -> Template:
+        web_context = PlayerAdminWebContext(
+            request, event_uniq_id, data_source_id=data_source_id
         )
-        if web_context.error:
-            return web_context.error
-        try:
-            data_source = DataSourceManager.get_object(data_source_id)
-        except KeyError:
-            return self.redirect_error(
-                request, f'Unknown data source [{data_source_id}].'
-            )
+        data_source = web_context.get_admin_data_source()
         search = request.query_params.get(data_source.search_element_name)
         players: list[Player] = []
         connection_error: str | None = None
@@ -2158,8 +2133,7 @@ class PlayerAdminController(BaseEventAdminController):
         web_context: BaseEventAdminWebContext = BaseEventAdminWebContext(
             request, event_uniq_id=event_uniq_id, data=None
         )
-        if web_context.error:
-            return web_context.error
+
         if web_context.admin_event is None:
             raise RuntimeError('admin_event not defined')
         players: list[Player] = [

--- a/src/web/controllers/admin/prize_admin_controller.py
+++ b/src/web/controllers/admin/prize_admin_controller.py
@@ -4,10 +4,11 @@ from typing import Any, Annotated
 
 from litestar import get, post, patch, delete
 from litestar.enums import RequestEncodingType
+from litestar.exceptions import NotFoundException
 from litestar.params import Body
 from litestar.response import Template
 from litestar.status_codes import HTTP_200_OK
-from litestar_htmx import HTMXRequest, ClientRedirect
+from litestar_htmx import HTMXRequest
 
 from common.exception import OptionError
 from common.i18n import _
@@ -37,7 +38,7 @@ from web.controllers.admin.base_event_admin_controller import (
     BaseEventAdminWebContext,
     BaseEventAdminController,
 )
-from web.controllers.base_controller import Redirect, WebContext
+from web.controllers.base_controller import WebContext
 from web.messages import Message
 from web.session import SessionHandler
 
@@ -65,17 +66,14 @@ class PrizeAdminWebContext(BaseEventAdminWebContext):
         self.show_details = SessionHandler.get_session_admin_prizes_show_details(
             request
         )
-        if not self.admin_event:
-            return
 
         event = self.get_admin_event()
         if tournament_id:
             if tournament_id not in event.tournaments_by_id:
-                self._redirect_error(
+                raise NotFoundException(
                     f'Unknown tournament ID [{tournament_id}] '
                     f'for event [{event_uniq_id}]'
                 )
-                return
             self.admin_tournament = event.tournaments_by_id[tournament_id]
         elif event.tournaments:
             self.admin_tournament = event.tournaments_sorted_by_uniq_id[0]
@@ -83,11 +81,10 @@ class PrizeAdminWebContext(BaseEventAdminWebContext):
         if prize_group_id:
             tournament = self.get_admin_tournament()
             if prize_group_id not in tournament.prize_groups_by_id:
-                self._redirect_error(
+                raise NotFoundException(
                     f'Unknown prize group ID [{prize_group_id}] for '
                     f'tournament [{tournament_id}] of event [{event_uniq_id}]'
                 )
-                return
             self.admin_prize_group = tournament.prize_groups_by_id[prize_group_id]
         else:
             self.set_default_prize_group()
@@ -95,21 +92,19 @@ class PrizeAdminWebContext(BaseEventAdminWebContext):
         if prize_category_id:
             prize_group = self.get_admin_prize_group()
             if prize_category_id not in prize_group.categories_by_id:
-                self._redirect_error(
+                raise NotFoundException(
                     f'Unknown category ID [{prize_category_id}] for '
                     f'prize group [{prize_group_id}]'
                 )
-                return
             self.admin_prize_category = prize_group.categories_by_id[prize_category_id]
 
         if prize_criterion_id:
             prize_category = self.get_admin_prize_category()
             if prize_criterion_id not in prize_category.criteria_by_id:
-                self._redirect_error(
+                raise NotFoundException(
                     f'Unknown criterion ID [{prize_criterion_id}] for '
                     f'prize category [{prize_category_id}]'
                 )
-                return
             self.admin_prize_criterion = prize_category.criteria_by_id[
                 prize_criterion_id
             ]
@@ -117,11 +112,10 @@ class PrizeAdminWebContext(BaseEventAdminWebContext):
         if prize_id:
             prize_category = self.get_admin_prize_category()
             if prize_id not in prize_category.prizes_by_id:
-                self._redirect_error(
+                raise NotFoundException(
                     f'Unknown prize ID [{prize_id}] for '
                     f'prize category [{prize_category_id}]'
                 )
-                return
             self.admin_prize = prize_category.prizes_by_id[prize_id]
 
     def set_default_prize_group(self):
@@ -189,9 +183,7 @@ class PrizeAdminController(BaseEventAdminController):
         cls,
         web_context: PrizeAdminWebContext,
         template_context: dict[str, Any] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
-        if web_context.error:
-            return web_context.error
+    ) -> Template:
         return cls._admin_base_event_render(
             web_context.template_context | (template_context or {}),
         )
@@ -211,12 +203,11 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int | None,
         prize_group_id: int | None,
         show_details: bool | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         if show_details is not None:
             SessionHandler.set_session_admin_prizes_show_details(request, show_details)
         web_context = PrizeAdminWebContext(request, event_uniq_id, tournament_id)
-        if web_context.error:
-            return web_context.error
+
         if prize_group_id:
             tournament = web_context.get_admin_tournament()
             if prize_group_id in tournament.prize_groups_by_id:
@@ -239,12 +230,11 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id, prize_category_id
         )
-        if web_context.error:
-            return web_context.error
+
         prize_group = web_context.get_admin_prize_group()
         assigned_prizes_by_player_id = {
             assigned_prize.assigned_to.id: assigned_prize
@@ -279,10 +269,9 @@ class PrizeAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(request, event_uniq_id, tournament_id)
-        if web_context.error:
-            return web_context.error
+
         tournament = web_context.get_admin_tournament()
         first_group = len(tournament.prize_groups) == 0
         if first_group:
@@ -326,12 +315,11 @@ class PrizeAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         prize_group_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id
         )
-        if web_context.error:
-            return web_context.error
+
         tournament = web_context.get_admin_tournament()
         prize_group = web_context.get_admin_prize_group()
         prize_group.stored_prize_group.name = (
@@ -356,12 +344,11 @@ class PrizeAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         prize_group_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id
         )
-        if web_context.error:
-            return web_context.error
+
         tournament = web_context.get_admin_tournament()
         tournament.delete_prize_group(prize_group_id)
         return self._admin_event_prizes_render(
@@ -377,7 +364,7 @@ class PrizeAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(request, event_uniq_id, tournament_id)
         tournament = web_context.get_admin_tournament()
         return self._admin_event_prizes_render(
@@ -397,7 +384,7 @@ class PrizeAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         prize_group_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_prizes_render(
             PrizeAdminWebContext(request, event_uniq_id, tournament_id, prize_group_id),
             {'modal': 'prize_group_delete'},
@@ -509,12 +496,11 @@ class PrizeAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         prize_group_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id
         )
-        if web_context.error:
-            return web_context.error
+
         add_other = 'add_other' in data
         SessionHandler.set_session_admin_prize_category_add_other_active(
             request, add_other
@@ -587,12 +573,11 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id, prize_category_id
         )
-        if web_context.error:
-            return web_context.error
+
         prize_category = web_context.get_admin_prize_category()
         if errors := self._validate_prize_category_form_data(
             data, web_context.get_admin_prize_group(), prize_category
@@ -652,12 +637,11 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id, prize_category_id
         )
-        if web_context.error:
-            return web_context.error
+
         prize_group = web_context.get_admin_prize_group()
         prize_category = web_context.get_admin_prize_category()
         prize_group.delete_category(prize_category_id)
@@ -684,12 +668,11 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id, prize_category_id
         )
-        if web_context.error:
-            return web_context.error
+
         prize_group = web_context.get_admin_prize_group()
         copy_category = web_context.get_admin_prize_category()
         stored_category = copy.deepcopy(copy_category.stored_prize_category)
@@ -731,12 +714,11 @@ class PrizeAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         prize_group_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id
         )
-        if web_context.error:
-            return web_context.error
+
         prize_group = web_context.get_admin_prize_group()
         prize_group.reorder_categories(data['item'])
         return self._admin_event_prizes_render(web_context)
@@ -754,12 +736,11 @@ class PrizeAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         prize_group_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id
         )
-        if web_context.error:
-            return web_context.error
+
         data = self._prize_category_default_form_data(
             web_context.get_admin_prize_group()
         )
@@ -782,12 +763,11 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id, prize_category_id
         )
-        if web_context.error:
-            return web_context.error
+
         prize_category = web_context.get_admin_prize_category()
         share_prizes = prize_category.are_prizes_shared
         data = {
@@ -819,7 +799,7 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_prizes_render(
             PrizeAdminWebContext(
                 request, event_uniq_id, tournament_id, prize_group_id, prize_category_id
@@ -912,12 +892,11 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id, prize_category_id
         )
-        if web_context.error:
-            return web_context.error
+
         add_other = 'add_other' in data
         SessionHandler.set_session_admin_prize_criterion_add_other_active(
             request, add_other
@@ -968,7 +947,7 @@ class PrizeAdminController(BaseEventAdminController):
         prize_group_id: int,
         prize_category_id: int,
         prize_criterion_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request,
             event_uniq_id,
@@ -977,8 +956,7 @@ class PrizeAdminController(BaseEventAdminController):
             prize_category_id,
             prize_criterion_id=prize_criterion_id,
         )
-        if web_context.error:
-            return web_context.error
+
         flat_data = WebContext.flatten_list_data(data)
         if errors := self._validate_prize_criterion_form_data(flat_data):
             return self._admin_event_prizes_render(
@@ -1013,7 +991,7 @@ class PrizeAdminController(BaseEventAdminController):
         prize_group_id: int,
         prize_category_id: int,
         prize_criterion_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request,
             event_uniq_id,
@@ -1022,8 +1000,7 @@ class PrizeAdminController(BaseEventAdminController):
             prize_category_id,
             prize_criterion_id=prize_criterion_id,
         )
-        if web_context.error:
-            return web_context.error
+
         prize_category = web_context.get_admin_prize_category()
         prize_category.delete_criterion(prize_criterion_id)
         return self._admin_event_prizes_render(web_context, {'modal': 'prize_criteria'})
@@ -1042,7 +1019,7 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_prizes_render(
             PrizeAdminWebContext(
                 request, event_uniq_id, tournament_id, prize_group_id, prize_category_id
@@ -1064,7 +1041,7 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id, prize_category_id
         )
@@ -1089,7 +1066,7 @@ class PrizeAdminController(BaseEventAdminController):
         prize_group_id: int,
         prize_category_id: int,
         prize_criterion_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request,
             event_uniq_id,
@@ -1098,8 +1075,7 @@ class PrizeAdminController(BaseEventAdminController):
             prize_category_id,
             prize_criterion_id=prize_criterion_id,
         )
-        if web_context.error:
-            return web_context.error
+
         prize_criterion = web_context.get_admin_prize_criterion()
         data = {'type': prize_criterion.player_filter.id} | {
             option.id: WebContext.value_to_form_data(option.value)
@@ -1219,12 +1195,11 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id, prize_category_id
         )
-        if web_context.error:
-            return web_context.error
+
         add_other = 'add_other' in data
         SessionHandler.set_session_admin_prize_add_other_active(request, add_other)
         prize_category = web_context.get_admin_prize_category()
@@ -1282,7 +1257,7 @@ class PrizeAdminController(BaseEventAdminController):
         prize_group_id: int,
         prize_category_id: int,
         prize_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request,
             event_uniq_id,
@@ -1291,8 +1266,7 @@ class PrizeAdminController(BaseEventAdminController):
             prize_category_id,
             prize_id=prize_id,
         )
-        if web_context.error:
-            return web_context.error
+
         prize_category = web_context.get_admin_prize_category()
         if errors := self._validate_prize_form_data(
             data, prize_category, FormAction.UPDATE
@@ -1330,7 +1304,7 @@ class PrizeAdminController(BaseEventAdminController):
         prize_group_id: int,
         prize_category_id: int,
         prize_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request,
             event_uniq_id,
@@ -1339,8 +1313,7 @@ class PrizeAdminController(BaseEventAdminController):
             prize_category_id,
             prize_id=prize_id,
         )
-        if web_context.error:
-            return web_context.error
+
         prize_category = web_context.get_admin_prize_category()
         prize_category.delete_prize(prize_id)
         return self._admin_event_prizes_render(web_context, {'modal': 'prizes'})
@@ -1359,7 +1332,7 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_prizes_render(
             PrizeAdminWebContext(
                 request,
@@ -1385,7 +1358,7 @@ class PrizeAdminController(BaseEventAdminController):
         tournament_id: int,
         prize_group_id: int,
         prize_category_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request, event_uniq_id, tournament_id, prize_group_id, prize_category_id
         )
@@ -1410,7 +1383,7 @@ class PrizeAdminController(BaseEventAdminController):
         prize_group_id: int,
         prize_category_id: int,
         prize_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = PrizeAdminWebContext(
             request,
             event_uniq_id,
@@ -1419,8 +1392,7 @@ class PrizeAdminController(BaseEventAdminController):
             prize_category_id,
             prize_id=prize_id,
         )
-        if web_context.error:
-            return web_context.error
+
         prize = web_context.get_admin_prize()
         data = {
             'value': WebContext.value_to_form_data(prize.value),

--- a/src/web/controllers/admin/rotator_admin_controller.py
+++ b/src/web/controllers/admin/rotator_admin_controller.py
@@ -3,7 +3,8 @@ from operator import attrgetter
 from typing import Annotated, Any
 
 from litestar import post, get, delete, patch
-from litestar.plugins.htmx import HTMXRequest, ClientRedirect
+from litestar.exceptions import NotFoundException, ClientException
+from litestar.plugins.htmx import HTMXRequest
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
 from litestar.response import Template
@@ -19,7 +20,7 @@ from web.controllers.admin.base_event_admin_controller import (
     BaseEventAdminWebContext,
     BaseEventAdminController,
 )
-from web.controllers.base_controller import Redirect, WebContext
+from web.controllers.base_controller import WebContext
 from web.messages import Message
 from web.session import SessionHandler
 
@@ -31,21 +32,14 @@ class RotatorAdminWebContext(BaseEventAdminWebContext):
         event_uniq_id: str,
         rotator_id: int | None = None,
     ):
-        super().__init__(
-            request,
-            data=None,
-            event_uniq_id=event_uniq_id,
-        )
-        assert self.admin_event is not None
+        super().__init__(request, event_uniq_id)
+        event = self.get_admin_event()
         self.admin_rotator: Rotator | None = None
-        if self.error:
-            return
         if rotator_id:
             try:
-                self.admin_rotator = self.admin_event.rotators_by_id[rotator_id]
+                self.admin_rotator = event.rotators_by_id[rotator_id]
             except KeyError:
-                self._redirect_error(f'Rotator [{rotator_id}] not found.')
-                return
+                raise NotFoundException(f'Rotator [{rotator_id}] not found.')
 
     def get_admin_rotator(self) -> Rotator:
         assert self.admin_rotator is not None
@@ -75,9 +69,7 @@ class RotatorAdminController(BaseEventAdminController):
         cls,
         web_context: RotatorAdminWebContext,
         template_context: dict[str, Any] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
-        if web_context.error:
-            return web_context.error
+    ) -> Template:
         return cls._admin_base_event_render(
             web_context.template_context | (template_context or {})
         )
@@ -104,7 +96,7 @@ class RotatorAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         admin_rotators_show_details: bool | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         if admin_rotators_show_details is not None:
             SessionHandler.set_session_admin_rotators_show_details(
                 request, admin_rotators_show_details
@@ -187,10 +179,8 @@ class RotatorAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = RotatorAdminWebContext(request, event_uniq_id)
-        if web_context.error:
-            return web_context.error
         name = web_context.get_admin_event().get_unused_rotator_name()
         template_context = self._rotator_form_modal_context(
             FormAction.CREATE, {'name': name}
@@ -206,10 +196,8 @@ class RotatorAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         rotator_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = RotatorAdminWebContext(request, event_uniq_id, rotator_id)
-        if web_context.error:
-            return web_context.error
         rotator = web_context.get_admin_rotator()
         data = self._rotator_form_data_from_rotator(rotator)
         template_context = self._rotator_form_modal_context(FormAction.UPDATE, data)
@@ -224,10 +212,8 @@ class RotatorAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         rotator_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = RotatorAdminWebContext(request, event_uniq_id, rotator_id)
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         rotator = web_context.get_admin_rotator()
         data = self._rotator_form_data_from_rotator(rotator)
@@ -244,7 +230,7 @@ class RotatorAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         rotator_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_rotator_render(
             RotatorAdminWebContext(request, event_uniq_id, rotator_id),
             {'modal': 'rotator_delete'},
@@ -259,7 +245,7 @@ class RotatorAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         rotator_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = RotatorAdminWebContext(request, event_uniq_id, rotator_id)
         return self._admin_event_rotator_render(
             web_context, self._rotator_screens_modal_context(web_context)
@@ -311,10 +297,8 @@ class RotatorAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = RotatorAdminWebContext(request, event_uniq_id)
-        if web_context.error:
-            return web_context.error
         stored_rotator, errors = self._read_rotator_form_data(
             data, web_context, FormAction.CREATE
         )
@@ -346,10 +330,8 @@ class RotatorAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = RotatorAdminWebContext(request, event_uniq_id, rotator_id)
-        if web_context.error:
-            return web_context.error
         stored_rotator, errors = self._read_rotator_form_data(
             data, web_context, FormAction.CLONE
         )
@@ -385,10 +367,8 @@ class RotatorAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = RotatorAdminWebContext(request, event_uniq_id, rotator_id)
-        if web_context.error:
-            return web_context.error
         new_stored_rotator, errors = self._read_rotator_form_data(
             data, web_context, FormAction.UPDATE
         )
@@ -422,10 +402,8 @@ class RotatorAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         rotator_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = RotatorAdminWebContext(request, event_uniq_id, rotator_id)
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         rotator = web_context.get_admin_rotator()
         event.delete_rotator(rotator)
@@ -449,15 +427,13 @@ class RotatorAdminController(BaseEventAdminController):
         event_uniq_id: str,
         rotator_id: int,
         rotating_screen_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = RotatorAdminWebContext(request, event_uniq_id, rotator_id)
-        if web_context.error:
-            return web_context.error
         rotator = web_context.get_admin_rotator()
         try:
             rotator.delete_rotating_screen(rotating_screen_id)
         except ValueError as error:
-            return self.redirect_error(request, str(error))
+            raise ClientException(error)
         return self._admin_event_rotator_render(
             web_context, self._rotator_screens_modal_context(web_context)
         )
@@ -475,10 +451,8 @@ class RotatorAdminController(BaseEventAdminController):
             dict[str, list[int]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = RotatorAdminWebContext(request, event_uniq_id, rotator_id)
-        if web_context.error:
-            return web_context.error
         rotator = web_context.get_admin_rotator()
         rotator.reorder_rotating_screens(data.get('rotating_screen_ids', []))
         return self._admin_event_rotator_render(
@@ -498,10 +472,8 @@ class RotatorAdminController(BaseEventAdminController):
             dict[str, str | list[str]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = RotatorAdminWebContext(request, event_uniq_id, rotator_id)
-        if web_context.error:
-            return web_context.error
         rotator = web_context.get_admin_rotator()
         flat_data = WebContext.flatten_list_data(data)
         screen_ids = WebContext.form_data_to_list_int(flat_data, 'screen_ids', [])
@@ -509,7 +481,7 @@ class RotatorAdminController(BaseEventAdminController):
         try:
             rotator.add_rotating_screens(screen_ids, family_ids)
         except ValueError as error:
-            return self.redirect_error(request, str(error))
+            raise ClientException(error)
         return self._admin_event_rotator_render(
             web_context, self._rotator_screens_modal_context(web_context)
         )

--- a/src/web/controllers/admin/screen_admin_controller.py
+++ b/src/web/controllers/admin/screen_admin_controller.py
@@ -3,7 +3,8 @@ from typing import Annotated, Any
 import requests
 import validators
 from litestar import post, get, delete, patch
-from litestar.plugins.htmx import HTMXRequest, ClientRedirect
+from litestar.exceptions import NotFoundException, ClientException
+from litestar.plugins.htmx import HTMXRequest
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
 from litestar.response import Template
@@ -23,7 +24,7 @@ from web.controllers.admin.base_event_admin_controller import (
     BaseEventAdminWebContext,
     BaseEventAdminController,
 )
-from web.controllers.base_controller import Redirect, WebContext, BaseController
+from web.controllers.base_controller import WebContext
 from web.messages import Message
 from web.session import SessionHandler
 
@@ -50,14 +51,12 @@ class ScreenAdminWebContext(BaseEventAdminWebContext):
         assert self.admin_event is not None
         self.admin_screen: Screen | None = None
         self.admin_screen_set: ScreenSet | None = None
-        if self.error:
-            return
         if screen_id:
             try:
                 self.admin_screen = self.admin_event.basic_screens_by_id[screen_id]
             except KeyError:
-                self._redirect_error(f'Screen [{screen_id}] not found.')
-                return
+                raise NotFoundException(f'Screen [{screen_id}] not found.')
+
         if screen_set_id:
             assert self.admin_screen is not None
             try:
@@ -65,10 +64,10 @@ class ScreenAdminWebContext(BaseEventAdminWebContext):
                     screen_set_id
                 ]
             except KeyError:
-                self._redirect_error(
+                raise NotFoundException(
                     f'Screen set [{screen_set_id}] not found for screen [{self.admin_screen.uniq_id}]'
                 )
-                return
+
         self.screen_type: ScreenType | None = None
         if self.admin_screen:
             self.screen_type = self.admin_screen.type
@@ -76,8 +75,7 @@ class ScreenAdminWebContext(BaseEventAdminWebContext):
             try:
                 self.screen_type = ScreenType(screen_type)
             except ValueError:
-                self._redirect_error(f'Unknown screen type [{screen_type}].')
-                return
+                raise NotFoundException(f'Unknown screen type [{screen_type}].')
 
     def get_admin_screen(self) -> Screen:
         assert self.admin_screen is not None
@@ -424,7 +422,7 @@ class ScreenAdminController(BaseEventAdminController):
         screen_set_id: int | None = None,
         data: dict[str, str] | None = None,  # type: ignore
         errors: dict[str, str] | None = None,
-    ) -> HTMXTemplate | ClientRedirect | Redirect:
+    ) -> HTMXTemplate:
         web_context: ScreenAdminWebContext = ScreenAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -433,8 +431,6 @@ class ScreenAdminController(BaseEventAdminController):
             screen_set_id=screen_set_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         admin_screen_types_data: dict[ScreenType, dict[str, Any]] = {
             ScreenType.INPUT: {
@@ -846,7 +842,7 @@ class ScreenAdminController(BaseEventAdminController):
         admin_screens_show_results: bool | None,
         admin_screens_show_ranking: bool | None,
         admin_screens_show_image: bool | None,
-    ) -> HTMXTemplate | ClientRedirect | Redirect:
+    ) -> HTMXTemplate:
         if admin_screens_show_family_screens is not None:
             SessionHandler.set_session_admin_screens_show_family_screens(
                 request, admin_screens_show_family_screens
@@ -892,7 +888,7 @@ class ScreenAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         screen_type: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_screens_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -912,7 +908,7 @@ class ScreenAdminController(BaseEventAdminController):
         action: str,
         event_uniq_id: str,
         screen_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_screens_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -932,7 +928,7 @@ class ScreenAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         assert screen_id is not None or screen_type is not None
         match action:
             case 'update' | 'delete' | 'clone' | 'create':
@@ -946,8 +942,7 @@ class ScreenAdminController(BaseEventAdminController):
                 )
             case _:
                 raise ValueError(f'action=[{action}]')
-        if web_context.error:
-            return web_context.error
+
         event = web_context.get_admin_event()
         stored_screen: StoredScreen = self._admin_validate_screen_update_data(
             action, web_context, data
@@ -1051,7 +1046,7 @@ class ScreenAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         screen_type: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_screen_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -1074,7 +1069,7 @@ class ScreenAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_screen_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -1097,7 +1092,7 @@ class ScreenAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_screen_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -1120,7 +1115,7 @@ class ScreenAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         screen_id: int,
-    ) -> HTMXTemplate | ClientRedirect | Redirect:
+    ) -> HTMXTemplate:
         web_context = ScreenAdminWebContext(request, event_uniq_id, screen_id)
         event = web_context.get_admin_event()
         screen = web_context.get_admin_screen()
@@ -1134,7 +1129,7 @@ class ScreenAdminController(BaseEventAdminController):
             )
         ):
             # No precise error (validated in JS)
-            return self.redirect_error(request, f'Invalid uniq ID [{new_uniq_id}].')
+            raise ClientException(f'Invalid uniq ID [{new_uniq_id}].')
         stored_screen = screen.stored_screen
         assert stored_screen is not None
         stored_screen.uniq_id = new_uniq_id
@@ -1165,7 +1160,7 @@ class ScreenAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_screen_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -1184,7 +1179,7 @@ class ScreenAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         screen_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_screens_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1203,7 +1198,7 @@ class ScreenAdminController(BaseEventAdminController):
         event_uniq_id: str,
         screen_id: int,
         screen_set_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_screens_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1223,7 +1218,7 @@ class ScreenAdminController(BaseEventAdminController):
             dict[str, Any],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> HTMXTemplate | ClientRedirect | Redirect:
+    ) -> HTMXTemplate:
         match action:
             case 'delete' | 'clone' | 'update' | 'add' | 'reorder':
                 web_context: ScreenAdminWebContext = ScreenAdminWebContext(
@@ -1236,15 +1231,13 @@ class ScreenAdminController(BaseEventAdminController):
                 )
             case _:
                 raise ValueError(f'action=[{action}]')
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         screen = web_context.get_admin_screen()
         match action:
             case 'delete':
                 if len(screen.screen_sets_sorted_by_order) <= 1:
-                    return BaseController.redirect_error(
-                        request, _('The last set of a screen can not be deleted.')
+                    raise ClientException(
+                        'The last set of a screen can not be deleted.'
                     )
             case 'update' | 'clone' | 'add' | 'reorder':
                 pass
@@ -1310,7 +1303,7 @@ class ScreenAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_screen_sets_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -1334,7 +1327,7 @@ class ScreenAdminController(BaseEventAdminController):
             dict[str, str | list[int]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_screen_sets_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -1358,7 +1351,7 @@ class ScreenAdminController(BaseEventAdminController):
             dict[str, str | list[int]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_screen_sets_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -1383,7 +1376,7 @@ class ScreenAdminController(BaseEventAdminController):
         event_uniq_id: str,
         screen_id: int,
         screen_set_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_screen_sets_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -1406,7 +1399,7 @@ class ScreenAdminController(BaseEventAdminController):
             dict[str, str | list[int]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_screen_sets_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -1424,7 +1417,7 @@ class ScreenAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_screens_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1439,7 +1432,7 @@ class ScreenAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_screens_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1454,7 +1447,7 @@ class ScreenAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_screens_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1469,7 +1462,7 @@ class ScreenAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_screens_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1484,7 +1477,7 @@ class ScreenAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_screens_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -1499,7 +1492,7 @@ class ScreenAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_screens_render(
             request,
             event_uniq_id=event_uniq_id,

--- a/src/web/controllers/admin/timer_admin_controller.py
+++ b/src/web/controllers/admin/timer_admin_controller.py
@@ -4,7 +4,8 @@ from datetime import datetime
 from typing import Annotated, Any
 
 from litestar import post, get, delete, patch
-from litestar.plugins.htmx import HTMXRequest, ClientRedirect
+from litestar.exceptions import NotFoundException, ClientException
+from litestar.plugins.htmx import HTMXRequest
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
 from litestar.response import Template
@@ -19,7 +20,7 @@ from web.controllers.admin.base_event_admin_controller import (
     BaseEventAdminWebContext,
     BaseEventAdminController,
 )
-from web.controllers.base_controller import Redirect, WebContext
+from web.controllers.base_controller import WebContext
 from web.messages import Message
 
 
@@ -44,14 +45,13 @@ class TimerAdminWebContext(BaseEventAdminWebContext):
         assert self.admin_event is not None
         self.admin_timer: Timer | None = None
         self.admin_timer_hour: TimerHour | None = None
-        if self.error:
-            return
+
         if timer_id:
             try:
                 self.admin_timer = self.admin_event.timers_by_id[timer_id]
             except KeyError:
-                self._redirect_error(f'Timer [{timer_id}] not found.')
-                return
+                raise NotFoundException(f'Timer [{timer_id}] not found.')
+
         if timer_hour_id:
             assert self.admin_timer is not None
             try:
@@ -59,10 +59,9 @@ class TimerAdminWebContext(BaseEventAdminWebContext):
                     timer_hour_id
                 ]
             except KeyError:
-                self._redirect_error(
+                raise NotFoundException(
                     f'Hour [{timer_hour_id}] not found for timer [{self.admin_timer.uniq_id}].'
                 )
-                return
 
     def get_admin_timer(self) -> Timer:
         assert self.admin_timer is not None
@@ -248,7 +247,7 @@ class TimerAdminController(BaseEventAdminController):
         timer_hour_id: int | None = None,
         data: dict[str, str] | None = None,
         errors: dict[str, str] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: TimerAdminWebContext = TimerAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -256,8 +255,6 @@ class TimerAdminController(BaseEventAdminController):
             timer_hour_id=timer_hour_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
         event = web_context.get_admin_event()
         template_context = web_context.template_context | {
             'admin_event_tab': 'admin-event-timers-tab',
@@ -396,7 +393,7 @@ class TimerAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_timers_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -410,7 +407,7 @@ class TimerAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_timers_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -431,7 +428,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: TimerAdminWebContext = TimerAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -490,7 +487,7 @@ class TimerAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_timers_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -509,7 +506,7 @@ class TimerAdminController(BaseEventAdminController):
         event_uniq_id: str,
         action: str,
         timer_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_timers_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -528,7 +525,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         match action:
             case 'update' | 'delete' | 'clone' | 'create':
                 web_context: TimerAdminWebContext = TimerAdminWebContext(
@@ -540,8 +537,7 @@ class TimerAdminController(BaseEventAdminController):
                 )
             case _:
                 raise ValueError(f'action=[{action}]')
-        if web_context.error:
-            return web_context.error
+
         event = web_context.get_admin_event()
         stored_timer: StoredTimer | None = self._admin_validate_timer_update_data(
             action, web_context, data
@@ -637,7 +633,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_timer_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -659,7 +655,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_timer_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -681,7 +677,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_timer_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -704,7 +700,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_timer_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -722,7 +718,7 @@ class TimerAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         timer_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_timers_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -741,7 +737,7 @@ class TimerAdminController(BaseEventAdminController):
         event_uniq_id: str,
         timer_id: int,
         timer_hour_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_event_timers_render(
             request,
             event_uniq_id=event_uniq_id,
@@ -761,7 +757,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, Any],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         match action:
             case 'delete' | 'clone' | 'update' | 'add' | 'reorder':
                 web_context: TimerAdminWebContext = TimerAdminWebContext(
@@ -773,17 +769,14 @@ class TimerAdminController(BaseEventAdminController):
                 )
             case _:
                 raise ValueError(f'action=[{action}]')
-        if web_context.error:
-            return web_context.error
+
         if web_context.admin_event is None:
             raise RuntimeError('admin_event not defined')
         match action:
             case 'delete':
                 assert web_context.admin_timer is not None
                 if len(web_context.admin_timer.timer_hours_by_id) <= 1:
-                    return self.redirect_error(
-                        request, 'The last hour of timer can not be deleted.'
-                    )
+                    raise ClientException('The last hour of timer can not be deleted.')
             case 'update' | 'clone' | 'add' | 'reorder':
                 pass
             case _:
@@ -871,7 +864,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_timer_hours_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -895,7 +888,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, str | list[int]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_timer_hours_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -919,7 +912,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, str | list[int]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_timer_hours_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -944,7 +937,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, str | list[int]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_timer_hours_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -967,7 +960,7 @@ class TimerAdminController(BaseEventAdminController):
             dict[str, str | list[int]],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_timer_hours_update(
             request,
             event_uniq_id=event_uniq_id,

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -5,7 +5,8 @@ from tempfile import NamedTemporaryFile
 from typing import Annotated, Any
 
 from litestar import post, get, patch, delete
-from litestar.plugins.htmx import HTMXRequest, HTMXTemplate, ClientRedirect
+from litestar.exceptions import NotFoundException, ClientException
+from litestar.plugins.htmx import HTMXRequest, HTMXTemplate
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
 from litestar.response import Template, File
@@ -49,7 +50,7 @@ from web.controllers.admin.base_event_admin_controller import (
     BaseEventAdminWebContext,
     BaseEventAdminController,
 )
-from web.controllers.base_controller import Redirect, WebContext
+from web.controllers.base_controller import WebContext
 from web.messages import Message
 from web.session import SessionHandler
 
@@ -77,25 +78,21 @@ class TournamentAdminWebContext(BaseEventAdminWebContext):
         assert self.admin_event is not None
 
         self.admin_tournament: Tournament | None = None
-        self.admin_tournament_criterion: TournamentCriterion | None = None
-        if self.error:
-            return
         if tournament_id:
             try:
                 self.admin_tournament = self.admin_event.tournaments_by_id[
                     tournament_id
                 ]
             except KeyError:
-                self._redirect_error(f'Tournament [{tournament_id}] not found.')
-                return
+                raise NotFoundException(f'Tournament [{tournament_id}] not found.')
 
+        self.admin_tournament_criterion: TournamentCriterion | None = None
         if criterion_id:
             assert self.admin_tournament is not None
             if criterion_id not in self.admin_tournament.criteria_by_id:
-                self._redirect_error(
+                raise NotFoundException(
                     f'Unknown criterion ID [{criterion_id}] for tournament [{self.admin_tournament.name}].'
                 )
-                return
             self.admin_tournament_criterion = self.admin_tournament.criteria_by_id[
                 criterion_id
             ]
@@ -122,10 +119,7 @@ class TournamentAdminController(BaseEventAdminController):
         cls,
         web_context: TournamentAdminWebContext,
         template_context: dict[str, Any] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
-        if web_context.error:
-            return web_context.error
-
+    ) -> Template:
         tournament_form_fields_templates_and_data = (
             plugin_manager.hook.get_tournament_card_block_template_and_data()
         )
@@ -177,7 +171,7 @@ class TournamentAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         admin_tournaments_show_details: bool | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -595,7 +589,7 @@ class TournamentAdminController(BaseEventAdminController):
         self,
         request: HTMXRequest,
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -621,7 +615,7 @@ class TournamentAdminController(BaseEventAdminController):
         action: FormAction,
         event_uniq_id: str,
         tournament_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -645,7 +639,7 @@ class TournamentAdminController(BaseEventAdminController):
         action: FormAction,
         event_uniq_id: str,
         tournament_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -653,8 +647,6 @@ class TournamentAdminController(BaseEventAdminController):
             criterion_id=None,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
         if web_context.admin_event is None:
             raise RuntimeError('admin_event not defined')
         add_other = 'add_other' in data
@@ -805,7 +797,7 @@ class TournamentAdminController(BaseEventAdminController):
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
         event_uniq_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_tournament_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -827,7 +819,7 @@ class TournamentAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._admin_tournament_update(
             request,
             event_uniq_id=event_uniq_id,
@@ -845,7 +837,7 @@ class TournamentAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int | None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request, event_uniq_id, tournament_id, None
         )
@@ -863,12 +855,10 @@ class TournamentAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request, event_uniq_id, tournament_id, None
         )
-        if web_context.error:
-            return web_context.error
         with EventDatabase(event_uniq_id, True) as database:
             database.delete_stored_tournament(tournament_id)
         Message.success(
@@ -948,7 +938,7 @@ class TournamentAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int | None,
         importer_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: TournamentAdminWebContext = TournamentAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -979,14 +969,12 @@ class TournamentAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int | None,
         importer_id: str,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request, event_uniq_id, tournament_id, None
         )
         if web_context.admin_tournament and web_context.admin_tournament.started:
-            return self.redirect_error(
-                request, 'Import only possible before the tournament starts.'
-            )
+            raise ClientException('Import only possible before the tournament starts.')
         errors: dict[str, str] = {}
         event = web_context.get_admin_event()
         normalized_data = await WebContext.normalize_multipart_data(data)
@@ -1111,12 +1099,10 @@ class TournamentAdminController(BaseEventAdminController):
         ],
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request, event_uniq_id, tournament_id, criterion_id=None
         )
-        if web_context.error:
-            return web_context.error
         add_other = 'add_other' in data
         SessionHandler.set_session_admin_tournament_criterion_add_other_active(
             request, add_other
@@ -1166,15 +1152,14 @@ class TournamentAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         tournament_criterion_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request,
             event_uniq_id,
             tournament_id,
             criterion_id=tournament_criterion_id,
         )
-        if web_context.error:
-            return web_context.error
+
         flat_data = WebContext.flatten_list_data(data)
         if errors := self._validate_tournament_criterion_form_data(flat_data):
             self._admin_base_event_render(
@@ -1209,15 +1194,14 @@ class TournamentAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         tournament_criterion_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request,
             event_uniq_id,
             tournament_id,
             criterion_id=tournament_criterion_id,
         )
-        if web_context.error:
-            return web_context.error
+
         web_context.get_admin_tournament().delete_criterion(tournament_criterion_id)
         return self._admin_base_event_render(
             web_context.template_context | {'modal': 'tournament_criteria'}
@@ -1234,7 +1218,7 @@ class TournamentAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request,
             event_uniq_id,
@@ -1256,7 +1240,7 @@ class TournamentAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request, event_uniq_id, tournament_id, criterion_id=None
         )
@@ -1280,15 +1264,14 @@ class TournamentAdminController(BaseEventAdminController):
         event_uniq_id: str,
         tournament_id: int,
         tournament_criterion_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = TournamentAdminWebContext(
             request,
             event_uniq_id,
             tournament_id,
             criterion_id=tournament_criterion_id,
         )
-        if web_context.error:
-            return web_context.error
+
         tournament_criterion = web_context.get_admin_tournament_criterion()
         data = {'type': tournament_criterion.player_filter.id} | {
             option.id: WebContext.value_to_form_data(option.value)
@@ -1317,7 +1300,7 @@ class TournamentAdminController(BaseEventAdminController):
         request: HTMXRequest,
         event_uniq_id: str,
         tournament_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: TournamentAdminWebContext = TournamentAdminWebContext(
             request,
             event_uniq_id=event_uniq_id,
@@ -1325,8 +1308,7 @@ class TournamentAdminController(BaseEventAdminController):
             criterion_id=None,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
+
         assert web_context.admin_event is not None
         admin_event: Event = web_context.admin_event
         admin_tournament: Tournament | None = web_context.admin_tournament

--- a/src/web/controllers/base_controller.py
+++ b/src/web/controllers/base_controller.py
@@ -11,11 +11,11 @@ from typing import Annotated, Any
 
 from httpdate.httpdate import httpdate_to_unixtime, unixtime_to_httpdate
 from litestar.datastructures import UploadFile
-from litestar.plugins.htmx import HTMXRequest, HTMXTemplate, ClientRedirect
+from litestar.plugins.htmx import HTMXRequest, HTMXTemplate
 from litestar.controller import Controller
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
-from litestar.response import Redirect, Template
+from litestar.response import Template
 
 from common import check_rgb_str, DEVEL_ENV
 from common.i18n import (
@@ -33,7 +33,6 @@ from data.access_levels.client_tracker import ClientTracker
 from data.player import Federation, Club
 from web.messages import Message
 from web.session import SessionHandler
-from web.urls import index_url
 
 logger: Logger = get_logger()
 
@@ -55,7 +54,6 @@ class WebContext:
     ):
         self.request: HTMXRequest = request
         self.data: dict[str, str] | None = data
-        self.error: ClientRedirect | Redirect | None = None
         # sets the session locale to the thread
         set_locale(SessionHandler.get_session_locale(request))
         if request.client:
@@ -350,9 +348,6 @@ class WebContext:
             return ''
         return f'{value.year}-{value.month:02d}-{value.day:02d}'
 
-    def _redirect_error(self, errors: str | list[str]):
-        self.error = BaseController.redirect_error(self.request, errors)
-
     @property
     def template_context(self) -> dict[str, Any]:
         """
@@ -390,16 +385,6 @@ class BaseController(Controller):
     The basic controller, inherited by all the controllers of the application.
     Controllers are used to handle web requests and respond to clients.
     """
-
-    @staticmethod
-    def redirect_error(
-        request: HTMXRequest, errors: str | list[str] | Exception
-    ) -> ClientRedirect | Redirect:
-        if request.headers.get('hx-request') == 'true':
-            Message.error(request, errors)
-            return ClientRedirect(redirect_to=index_url(request))
-        else:
-            return Redirect(index_url(request))
 
     @staticmethod
     def render_messages(

--- a/src/web/controllers/index_controller.py
+++ b/src/web/controllers/index_controller.py
@@ -98,6 +98,9 @@ class IndexController(BaseController):
         if request.htmx:
             reload_message = _('Reload the page')
         match status_code:
+            case status_codes.HTTP_400_BAD_REQUEST:
+                title = _('400 - Bad request')
+                error_message = _('Consult the logs for more details.')
             case status_codes.HTTP_401_UNAUTHORIZED:
                 title = _('401 - Authentication failed')
                 error_message = _('Sorry, authorization failed.')

--- a/src/web/controllers/profile_controller.py
+++ b/src/web/controllers/profile_controller.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError, VerificationError, InvalidHash
 from litestar import post, get
-from litestar.plugins.htmx import HTMXRequest, ClientRedirect
+from litestar.plugins.htmx import HTMXRequest
 from litestar.enums import RequestEncodingType
 from litestar.params import Body
 from litestar.response import Template
@@ -15,7 +15,7 @@ from data.event import Event
 from database.sqlite.event.event_database import EventDatabase
 from web.controllers.admin.base_admin_controller import AdminWebContext
 from web.controllers.admin.base_event_admin_controller import BaseEventAdminWebContext
-from web.controllers.base_controller import Redirect, WebContext, BaseController
+from web.controllers.base_controller import WebContext, BaseController
 from web.session import SessionHandler
 
 
@@ -43,7 +43,7 @@ class ProfileController(BaseController):
         ]
         | None = None,
         errors: dict[str, str] | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         active_user_account_options: dict[str, str] = {}
         if isinstance(web_context, ProfileWebContext):
             active_user_account_options = (
@@ -74,14 +74,12 @@ class ProfileController(BaseController):
         request: HTMXRequest,
         event_uniq_id: str | None,
         locale: str | None = None,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context = ProfileWebContext(
             request,
             event_uniq_id=event_uniq_id,
             data=None,
         )
-        if web_context.error:
-            return web_context.error
 
         self.set_locale(request, locale)
 
@@ -99,14 +97,13 @@ class ProfileController(BaseController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: ProfileWebContext = ProfileWebContext(
             request,
             event_uniq_id=event_uniq_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
+
         errors: dict[str, str] = {}
         if data is None:
             data = {}
@@ -195,14 +192,13 @@ class ProfileController(BaseController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: ProfileWebContext = ProfileWebContext(
             request,
             event_uniq_id=event_uniq_id,
             data=data,
         )
-        if web_context.error:
-            return web_context.error
+
         assert web_context.admin_event is not None
         SessionHandler.store_user_account(
             request,

--- a/src/web/controllers/user/base_screen_user_controller.py
+++ b/src/web/controllers/user/base_screen_user_controller.py
@@ -3,7 +3,7 @@ from logging import Logger
 from typing import Any, Iterable
 
 from litestar.exceptions import NotFoundException
-from litestar.plugins.htmx import HTMXRequest, HTMXTemplate, ClientRedirect
+from litestar.plugins.htmx import HTMXRequest, HTMXTemplate
 
 from common.logger import get_logger
 from common.sharly_chess_config import SharlyChessConfig
@@ -14,7 +14,6 @@ from data.screen import Screen
 from utils.enum import ScreenType
 from plugins.manager import plugin_manager
 from plugins.utils import ExtraColumn
-from web.controllers.base_controller import Redirect
 from web.controllers.user.base_user_controller import BaseUserController
 from web.controllers.user.event_user_controller import (
     EventUserWebContext,
@@ -80,11 +79,7 @@ class ScreenUserWebContext(ScreenOrRotatorOrDisplayControllerUserWebContext):
         self,
         request: HTMXRequest,
     ):
-        super().__init__(
-            request,
-        )
-        if self.error:
-            return
+        super().__init__(request)
         self._screen: Screen = RequestUtils.get_screen(request)
         self.user_event_tab = self.screen.type.value
 
@@ -102,8 +97,6 @@ class RotatorUserWebContext(ScreenOrRotatorOrDisplayControllerUserWebContext):
             request,
             user_event_tab='rotators',
         )
-        if self.error:
-            return
         self.rotator, self.rotator_screen_index, self._screen = (
             RequestUtils.get_rotator(request)
         )
@@ -123,8 +116,6 @@ class DisplayControllerUserWebContext(ScreenOrRotatorOrDisplayControllerUserWebC
             request,
             user_event_tab='display_controllers',
         )
-        if self.error:
-            return
         self.display_controller, self.rotator_screen_index, self._screen = (
             RequestUtils.get_display_controller(request)
         )
@@ -145,8 +136,6 @@ class BasicScreenOrFamilyUserWebContext(ScreenUserWebContext):
             request,
         )
         self.family: Family | None = None
-        if self.error:
-            return
         if ':' in self.screen.uniq_id:
             family_uniq_id: str = self.screen.uniq_id.split(':')[0]
             try:
@@ -166,7 +155,7 @@ class BaseScreenUserController(BaseUserController):
     def _user_screen_render(
         cls,
         web_context: ScreenOrRotatorOrDisplayControllerUserWebContext,
-    ) -> HTMXTemplate | ClientRedirect | Redirect:
+    ) -> HTMXTemplate:
         # Allow plugin to provide extra columns
         per_plugin_columns: Iterable[Iterable[ExtraColumn]] = []
         if web_context.screen is not None:

--- a/src/web/controllers/user/base_user_controller.py
+++ b/src/web/controllers/user/base_user_controller.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from litestar.exceptions import NotFoundException
 from litestar.plugins.htmx import HTMXRequest
 
 from common.sharly_chess_config import SharlyChessConfig
@@ -18,8 +19,6 @@ class UserWebContext(WebContext):
     ):
         super().__init__(request, data=None)
         self.user_tab: str | None = user_tab
-        if self.error:
-            return
         self.check_user_tab()
 
     def check_user_tab(self):
@@ -29,7 +28,7 @@ class UserWebContext(WebContext):
             'current_events',
             'coming_events',
         ]:
-            self._redirect_error(
+            raise NotFoundException(
                 f'Invalid value [{self.user_tab}] for parameter [user_tab]'
             )
 

--- a/src/web/controllers/user/event_user_controller.py
+++ b/src/web/controllers/user/event_user_controller.py
@@ -21,8 +21,6 @@ class EventUserWebContext(UserWebContext):
         super().__init__(request, user_tab=None)
         self.user_event: Event = RequestUtils.get_event(request)
         self.user_event_tab: str | None = user_event_tab
-        if self.error:
-            return
         # tracks the visit of the client
         ClientTracker().track_client(
             self.client.host,

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -1,7 +1,7 @@
 from contextlib import suppress
 
 from litestar import head, get
-from litestar.plugins.htmx import HTMXRequest, Reswap, ClientRedirect
+from litestar.plugins.htmx import HTMXRequest, Reswap
 from litestar.response import Template
 from litestar.status_codes import HTTP_304_NOT_MODIFIED
 from litestar_htmx import HTMXTemplate
@@ -9,7 +9,6 @@ from litestar_htmx import HTMXTemplate
 from data.screen_set import ScreenSet
 from data.tournament import Tournament
 from utils.enum import ScreenType
-from web.controllers.base_controller import Redirect
 from web.controllers.user.base_screen_user_controller import (
     BaseScreenUserController,
     BasicScreenOrFamilyUserWebContext,
@@ -121,14 +120,8 @@ class ScreenUserController(BaseScreenUserController):
         request: HTMXRequest,
         event_uniq_id: str,
         screen_uniq_id: str,
-    ) -> HTMXTemplate | Reswap | ClientRedirect | Redirect:
-        web_context: BasicScreenOrFamilyUserWebContext = (
-            BasicScreenOrFamilyUserWebContext(
-                request,
-            )
-        )
-        if web_context.error:
-            return web_context.error
+    ) -> HTMXTemplate | Reswap:
+        web_context = BasicScreenOrFamilyUserWebContext(request)
         date: float | None = self.get_if_modified_since(request)
         if date is None or self._user_screen_refresh_needed(web_context, date):
             return self._user_screen_render(web_context)
@@ -169,12 +162,10 @@ class ScreenUserController(BaseScreenUserController):
         event_uniq_id: str,
         rotator_id: int,
         rotator_screen_index: int = 0,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: RotatorUserWebContext = RotatorUserWebContext(
             request,
         )
-        if web_context.error:
-            return web_context.error
         return self._user_screen_render(web_context)
 
     @head(
@@ -213,12 +204,10 @@ class ScreenUserController(BaseScreenUserController):
         event_uniq_id: str,
         display_controller_id: int,
         rotator_screen_index: int = 0,
-    ) -> Template | ClientRedirect | Redirect | Reswap:
+    ) -> Template | Reswap:
         web_context: DisplayControllerUserWebContext = DisplayControllerUserWebContext(
             request,
         )
-        if web_context.error:
-            return web_context.error
 
         date: float | None = (
             self.get_if_modified_since(request) if not web_context.is_rotator else None

--- a/src/web/controllers/user/tournament_user_controller.py
+++ b/src/web/controllers/user/tournament_user_controller.py
@@ -2,7 +2,7 @@ from contextlib import suppress
 from typing import Any
 
 from litestar import patch, delete, put, get
-from litestar.plugins.htmx import HTMXRequest, HTMXTemplate, ClientRedirect
+from litestar.plugins.htmx import HTMXRequest, HTMXTemplate
 from litestar.response import Template
 from litestar.status_codes import HTTP_200_OK
 from litestar.channels import ChannelsPlugin
@@ -13,7 +13,6 @@ from data.tournament import Tournament
 from utils.enum import Result
 from web.controllers.admin.pairings_admin_controller import PairingsAdminController
 from web.controllers.admin.player_admin_controller import PlayerAdminController
-from web.controllers.base_controller import Redirect
 from web.controllers.user.base_screen_user_controller import (
     ScreenUserWebContext,
     BaseScreenUserController,
@@ -34,8 +33,6 @@ class TournamentUserWebContext(ScreenUserWebContext):
         super().__init__(
             request,
         )
-        if self.error:
-            return
         self.tournament: Tournament = RequestUtils.get_tournament(request)
 
     @property
@@ -46,15 +43,8 @@ class TournamentUserWebContext(ScreenUserWebContext):
 
 
 class BoardUserWebContext(TournamentUserWebContext):
-    def __init__(
-        self,
-        request: HTMXRequest,
-    ):
-        super().__init__(
-            request,
-        )
-        if self.error:
-            return
+    def __init__(self, request: HTMXRequest):
+        super().__init__(request)
         self.board: Board = RequestUtils.get_board(request)
 
     @property
@@ -69,11 +59,7 @@ class ResultUserWebContext(BoardUserWebContext):
         self,
         request: HTMXRequest,
     ):
-        super().__init__(
-            request,
-        )
-        if self.error:
-            return
+        super().__init__(request)
         self.round, self.board, self.result = RequestUtils.get_round_board_result(
             request
         )
@@ -84,11 +70,7 @@ class PlayerUserWebContext(TournamentUserWebContext):
         self,
         request: HTMXRequest,
     ):
-        super().__init__(
-            request,
-        )
-        if self.error:
-            return
+        super().__init__(request)
         self.player: Player = RequestUtils.get_player(request)
         self.board: Board | None = (
             self.tournament.boards[self.player.board_id - 1]
@@ -126,12 +108,10 @@ class CheckInUserController(BaseInputUserController):
         screen_uniq_id: str,
         tournament_id: int,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: PlayerUserWebContext = PlayerUserWebContext(
             request,
         )
-        if web_context.error:
-            return web_context.error
         return HTMXTemplate(
             template_name='user/modals.html',
             context=web_context.template_context | {},
@@ -153,12 +133,10 @@ class CheckInUserController(BaseInputUserController):
         screen_uniq_id: str,
         tournament_id: int,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         player_web_context: PlayerUserWebContext = PlayerUserWebContext(
             request,
         )
-        if player_web_context.error:
-            return player_web_context.error
         assert player_web_context.player.id is not None
         player_web_context.tournament.check_in_player(
             player_web_context.player, not player_web_context.player.check_in
@@ -174,8 +152,6 @@ class CheckInUserController(BaseInputUserController):
                 request,
             )
         )
-        if web_context.error:
-            return web_context.error
         return self._user_screen_render(web_context)
 
 
@@ -190,12 +166,10 @@ class IllegalMoveUserController(BaseInputUserController):
         self,
         request: HTMXRequest,
         add: bool,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         player_web_context: PlayerUserWebContext = PlayerUserWebContext(
             request,
         )
-        if player_web_context.error:
-            return player_web_context.error
         assert player_web_context.player.id is not None
 
         if add:
@@ -222,8 +196,6 @@ class IllegalMoveUserController(BaseInputUserController):
                 request,
             )
         )
-        if web_context.error:
-            return web_context.error
         return self._user_screen_render(web_context)
 
     @put(
@@ -239,7 +211,7 @@ class IllegalMoveUserController(BaseInputUserController):
         screen_uniq_id: str,
         tournament_id: int,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._delete_or_add_illegal_move(
             request,
             add=True,
@@ -258,7 +230,7 @@ class IllegalMoveUserController(BaseInputUserController):
         screen_uniq_id: str,
         tournament_id: int,
         player_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._delete_or_add_illegal_move(
             request,
             add=False,
@@ -283,12 +255,10 @@ class ResultUserController(BaseInputUserController):
         screen_uniq_id: str,
         tournament_id: int,
         board_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         web_context: BoardUserWebContext = BoardUserWebContext(
             request,
         )
-        if web_context.error:
-            return web_context.error
         return HTMXTemplate(
             template_name='user/modals.html',
             context=web_context.template_context | {},
@@ -301,12 +271,10 @@ class ResultUserController(BaseInputUserController):
         self,
         request: HTMXRequest,
         channels: ChannelsPlugin,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         result_web_context: ResultUserWebContext = ResultUserWebContext(
             request,
         )
-        if result_web_context.error:
-            return result_web_context.error
         assert result_web_context.board.id is not None
         if result_web_context.result == Result.NO_RESULT:
             with suppress(ValueError):
@@ -332,8 +300,6 @@ class ResultUserController(BaseInputUserController):
                 request,
             )
         )
-        if web_context.error:
-            return web_context.error
         return self._user_screen_render(web_context)
 
     @put(
@@ -355,7 +321,7 @@ class ResultUserController(BaseInputUserController):
         round: int,
         board_id: int,
         result: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._user_update_result(
             request,
             channels=channels,
@@ -380,7 +346,7 @@ class ResultUserController(BaseInputUserController):
         tournament_id: int,
         round: int,
         board_id: int,
-    ) -> Template | ClientRedirect | Redirect:
+    ) -> Template:
         return self._user_update_result(
             request,
             channels=channels,

--- a/src/web/server_engine.py
+++ b/src/web/server_engine.py
@@ -12,7 +12,11 @@ from webbrowser import open
 import requests
 import uvicorn
 from litestar import Litestar
-from litestar.exceptions import PermissionDeniedException
+from litestar.exceptions import (
+    PermissionDeniedException,
+    NotFoundException,
+    ClientException,
+)
 from litestar.logging import LoggingConfig
 from litestar.plugins.htmx import HTMXRequest
 from litestar.types import Scope, HTTPScope
@@ -39,7 +43,6 @@ from web.settings import (
     exception_handlers,
     listeners,
 )
-from web.utils import NotFoundException
 
 logger = get_logger()
 
@@ -174,11 +177,27 @@ class ServerEngine(Engine):
             console_log_level=sharly_chess_config.console_log_level,
         )
 
-        def log_permission_denied(exc: Exception, scope: Scope) -> None:
-            if isinstance(exc, PermissionDeniedException) and scope['type'] == 'http':
+        def log_http_exception(exc: Exception, scope: Scope):
+            if not scope['type'] == 'http':
+                return
+            if isinstance(exc, PermissionDeniedException):
                 http = cast(HTTPScope, scope)
                 logger.warning(
                     '403 permission denied: %s %s',
+                    http.get('method', '?'),
+                    http.get('path', '?'),
+                )
+            elif isinstance(exc, NotFoundException):
+                http = cast(HTTPScope, scope)
+                logger.error(
+                    '404 not found: %s %s',
+                    http.get('method', '?'),
+                    http.get('path', '?'),
+                )
+            elif isinstance(exc, ClientException):
+                http = cast(HTTPScope, scope)
+                logger.error(
+                    '400 not found: %s %s',
                     http.get('method', '?'),
                     http.get('path', '?'),
                 )
@@ -191,9 +210,16 @@ class ServerEngine(Engine):
             template_config=template_config,
             logging_config=LoggingConfig(
                 **logging_config,
-                disable_stack_trace={403, PermissionDeniedException, NotFoundException},
+                disable_stack_trace={
+                    400,
+                    403,
+                    404,
+                    ClientException,
+                    PermissionDeniedException,
+                    NotFoundException,
+                },
             ),  # type: ignore
-            after_exception=[log_permission_denied],
+            after_exception=[log_http_exception],
             middleware=middlewares,
             stores=stores,
             pdb_on_exception=self.debug,

--- a/src/web/settings.py
+++ b/src/web/settings.py
@@ -15,6 +15,7 @@ from litestar.status_codes import (
     HTTP_404_NOT_FOUND,
     HTTP_500_INTERNAL_SERVER_ERROR,
     HTTP_403_FORBIDDEN,
+    HTTP_400_BAD_REQUEST,
 )
 from litestar.stores.file import FileStore
 from litestar.stores.base import Store
@@ -99,6 +100,7 @@ route_handlers: Sequence[ControllerRouterHandler] = [
 ]
 
 exception_handlers = {
+    HTTP_400_BAD_REQUEST: IndexController.handle_exception,
     HTTP_403_FORBIDDEN: IndexController.handle_exception,
     HTTP_404_NOT_FOUND: IndexController.handle_exception,
     HTTP_500_INTERNAL_SERVER_ERROR: IndexController.handle_exception,


### PR DESCRIPTION
After this, we won't rely on returning web_context.error to stop the propagation of an error, which definitely was not everywhere.