### PR TITLE
Fix duplicated objects renumbering

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@ English version below
 - Correction de la récupération des versions précédentes (3.0.1)
 - Optimisation des requêtes d'écriture dans la base de données (3.0.5)
 - Éviter de télécharger continuellement les bases locales plus valides lorsqu'il n'y a pas de connexion (3.0.8)
+- Correction de la renumérotation des objets dupliqués (3.0.9)
 
 ## Évènements
 
@@ -87,6 +88,7 @@ English version below
 - Fixed previous versions recovering (3.0.1)
 - Optimized the write queries in the database (3.0.5)
 - Prevent downloading outdated local databases continuously when there is no connexion (3.0.8)
+- Fixed the renumbering of duplicated objects (3.0.9)
 
 ## Events
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -179,8 +179,8 @@ class StaticUtils:
         base_uniq_id = cls.name_to_uniq_id(base_uniq_id)
         if matches := re.match(r'^(.*)-(\d+)$', base_uniq_id):
             base_uniq_id = matches.group(1)
-            index = int(matches.group(2)) - 1
-            uniq_id = f'{base_uniq_id}-{index + 1}'
+            index = int(matches.group(2))
+            uniq_id = f'{base_uniq_id}-{index}'
         while uniq_id in used_uniq_ids:
             index += 1
             uniq_id = f'{base_uniq_id}-{index}'
@@ -194,8 +194,8 @@ class StaticUtils:
         name = base_name
         if matches := re.match(r'^(.*) \((\d+)\)$', base_name):
             base_name = matches.group(1)
-            index = int(matches.group(2)) - 1
-            name = f'{base_name} ({index + 1})'
+            index = int(matches.group(2))
+            name = f'{base_name} ({index})'
         while name in used_names:
             index += 1
             name = f'{base_name} ({index})'


### PR DESCRIPTION
To reproduce: 
- create a prize category named `Category (2)`
- duplicate the category  
--> duplicated category is named `Category (2)`