### PR TITLE
Fix the club player sorting with no-league players

### DIFF
--- a/src/plugins/ffe/ffe.py
+++ b/src/plugins/ffe/ffe.py
@@ -507,7 +507,7 @@ class FfePlugin(Plugin):
     def player_club_sort_key(self, player: Player):
         # We sort by league first
         return (
-            FFEUtils.get_player_plugin_data(player).league,
+            FFEUtils.get_player_plugin_data(player).league or '',
             player.club,
             player.last_name,
             player.first_name,


### PR DESCRIPTION
player tab 500s when you sort by club with a player with no league (you have to clear the session for it to work again)