### PR TITLE
Directly update local database options

### DIFF
--- a/src/web/controllers/admin/index_admin_controller.py
+++ b/src/web/controllers/admin/index_admin_controller.py
@@ -1120,6 +1120,7 @@ class IndexAdminController(BaseAdminController):
         stored_database.outdate_action = action.id
         with ConfigDatabase(write=True) as config_database:
             config_database.update_stored_local_source_database(stored_database)
+        database.check()
         return HTMXTemplate(
             template_name='admin/common/database/database_row.html',
             context=self._database_modal_context() | {'database': database},

--- a/src/web/controllers/admin/index_admin_controller.py
+++ b/src/web/controllers/admin/index_admin_controller.py
@@ -39,7 +39,6 @@ from database.sqlite.config.config_database import ConfigDatabase
 from database.sqlite.config.config_store import (
     StoredConfig,
     StoredPlugin,
-    StoredLocalSourceDatabase,
 )
 from database.sqlite.event.event_database import EventDatabase
 from database.sqlite.event.event_store import StoredEvent
@@ -49,8 +48,14 @@ from database.sqlite.local_source_database import (
     OutdatedActionManager,
     OutdatedDelayManager,
 )
-from database.sqlite.local_source_database.actions import NotifOutdatedAction
-from database.sqlite.local_source_database.delays import DisabledOutdatedDelay
+from database.sqlite.local_source_database.actions import (
+    NotifOutdatedAction,
+    OutdatedAction,
+)
+from database.sqlite.local_source_database.delays import (
+    DisabledOutdatedDelay,
+    OutdatedDelay,
+)
 from plugins.manager import plugin_manager
 from utils import StaticUtils
 from utils.enum import FormAction
@@ -1065,30 +1070,16 @@ class IndexAdminController(BaseAdminController):
             },
         )
 
-    def _database_modal_context(
-        self,
-        data: dict[str, str] | None = None,
-        errors: dict[str, str] | None = None,
-    ) -> dict[str, Any]:
-        data = data or {}
-        databases: list[LocalSourceDatabase] = LocalSourceDatabaseManager.objects()
-        for database in databases:
-            data |= {
-                f'{database.id}_outdate_delay': database.outdate_delay.id,
-                f'{database.id}_outdate_action': (database.outdate_action.id),
-            }
-        template_context = {
-            'databases': databases,
+    @staticmethod
+    def _database_modal_context() -> dict[str, Any]:
+        return {
+            'databases': LocalSourceDatabaseManager.objects(),
             'online_data_sources': OnlineDataSourceManager.objects(),
             'network_connected': NetworkMonitor.connected(),
             'outdate_delay_options': OutdatedDelayManager.options(),
             'outdate_action_options': OutdatedActionManager.options(),
             'modal': 'database',
-            'data': data,
-            'errors': errors or {},
         }
-
-        return template_context
 
     @get(
         path='/database-modal',
@@ -1104,7 +1095,7 @@ class IndexAdminController(BaseAdminController):
         )
 
     @patch(
-        path='/database-options-update',
+        path='/database-options-update/{database_id:str}',
         name='admin-database-options-update',
         guards=[ActionGuard(AuthAction.MANAGE_SOURCE_DATABASES)],
     )
@@ -1115,46 +1106,23 @@ class IndexAdminController(BaseAdminController):
             dict[str, str],
             Body(media_type=RequestEncodingType.URL_ENCODED),
         ],
+        database_id: str,
     ) -> Template:
-        source_databases: list[LocalSourceDatabase] = (
-            LocalSourceDatabaseManager.objects()
-        )
+        database = LocalSourceDatabaseManager.get_object(database_id)
+        stored_database = database.stored_source_database
+        delay: OutdatedDelay = DisabledOutdatedDelay()
+        if delay_id := WebContext.form_data_to_str(data, 'outdate_delay'):
+            delay = OutdatedDelayManager.get_object(delay_id)
+        action: OutdatedAction = NotifOutdatedAction()
+        if action_id := WebContext.form_data_to_str(data, 'outdate_action'):
+            action = OutdatedActionManager.get_object(action_id)
+        stored_database.outdate_delay = delay.id
+        stored_database.outdate_action = action.id
         with ConfigDatabase(write=True) as config_database:
-            for source_database in source_databases:
-                outdate_delay = (
-                    WebContext.form_data_to_str(
-                        data,
-                        f'{source_database.id}_outdate_delay',
-                    )
-                    or DisabledOutdatedDelay.static_id()
-                )
-                outdate_action = (
-                    WebContext.form_data_to_str(
-                        data, f'{source_database.id}_outdate_action'
-                    )
-                    or NotifOutdatedAction.static_id()
-                )
-                config_database.update_stored_local_source_database(
-                    StoredLocalSourceDatabase(
-                        name=source_database.id,
-                        outdate_delay=outdate_delay,
-                        outdate_action=outdate_action,
-                        updated_at=source_database.updated_at_timestamp,
-                    )
-                )
-        Message.success(
-            request, _('Local source databases settings have been updated.')
-        )
-
-        # Clear the modal contents, and send an event
+            config_database.update_stored_local_source_database(stored_database)
         return HTMXTemplate(
-            template_name='common/empty_modal_and_messages.html',
-            context={
-                'messages': Message.messages(request),
-            },
-            re_target='#modal-wrapper',
-            trigger_event='close_modal',
-            after='receive',
+            template_name='admin/common/database/database_row.html',
+            context=self._database_modal_context() | {'database': database},
         )
 
     @get(

--- a/src/web/templates/admin/common/database/database_modal.html
+++ b/src/web/templates/admin/common/database/database_modal.html
@@ -69,39 +69,32 @@
                 </table>
             {% endif %}
             <h4>{{ _('Local databases') }}</h4>
-            <form
-                id="modal-form"
-                hx-patch="{{ url_for('admin-database-options-update') }}"
-                hx-target="body"
-                hx-indicator="#please-wait"
+            <table
+                class="table prominent table-sm w-100 bg-light mx-auto justify-content-center"
             >
-                <table
-                    class="table prominent table-sm w-100 bg-light mx-auto justify-content-center"
-                >
-                    <thead>
-                        <tr>
-                            <th>
-                                {{ _('Database') }}
-                            </th>
-                            <th class="text-center">
-                                {{ _('Action delay') }}
-                            </th>
-                            <th class="text-center">
-                                {{ _('Action') }}
-                            </th>
-                            <th class="text-center">
-                                {{ _('Last update') }}
-                            </th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for database in databases %}
-                            {% include 'database_row.html' %}
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </form>
+                <thead>
+                    <tr>
+                        <th>
+                            {{ _('Database') }}
+                        </th>
+                        <th class="text-center">
+                            {{ _('Action delay') }}
+                        </th>
+                        <th class="text-center">
+                            {{ _('Action') }}
+                        </th>
+                        <th class="text-center">
+                            {{ _('Last update') }}
+                        </th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for database in databases %}
+                        {% include 'database_row.html' %}
+                    {% endfor %}
+                </tbody>
+            </table>
         </div>
         <div class="modal-footer">
             <button
@@ -111,14 +104,6 @@
             >
                 <i class="bi-x-circle-fill lh-1"></i>
                 {{ _('Close') }}
-            </button>
-            <button
-                type="submit"
-                form="modal-form"
-                class="text-nowrap white d-inline-flex gap-2 align-items-center btn btn-primary"
-            >
-                <i class="bi-floppy-fill lh-1"></i>
-                {{ _('Save') }}
             </button>
         </div>
     </div>

--- a/src/web/templates/admin/common/database/database_row.html
+++ b/src/web/templates/admin/common/database/database_row.html
@@ -1,30 +1,43 @@
-<tr>
+{% import '/admin/common/macros.j2' as admin_macros with context %}
+
+
+<tr id="database-{{ database.id }}-row">
+    <button
+        id="database-{{ database.id }}-submit"
+        hx-patch="{{ url_for('admin-database-options-update', database_id=database.id) }}"
+        hx-vals='js:{
+            outdate_delay: $("#{{ database.id }}-outdate-delay").val(),
+            outdate_action: $("#{{ database.id }}-outdate-action").val(),
+        }'
+        hx-target="#database-{{ database.id }}-row"
+        hx-swap="outerHTML"
+        hx-indicator="#please-wait"
+        style="display:none"
+    ></button>
     <th >{{ database.name }}</th>
     <td>
-        {{ admin_macros.select_input(
-            name=database.id ~ '_outdate_delay',
-            label=None,
-            help_text=None,
-            select_options=outdate_delay_options,
-            data=data, errors=errors
+        {{ admin_macros.select_content(
+            id=database.id ~ '-outdate-delay',
+            name='outdate_delay',
+            selected=[database.outdate_delay.id],
+            options=outdate_delay_options,
+            onchange="$('#database-" ~ database.id ~ "-submit').click()",
         ) }}
     </td>
     <td>
         <span
-            id="{{ database.id }}-outdate-action-container"
-            {% if data[database.id ~ '_outdate_delay'] == 'disabled' %}
+            {% if database.outdate_delay.id == 'disabled' %}
                 class="invisible"
             {% endif %}
         >
-            {{ admin_macros.select_input(
-                name=database.id ~ '_outdate_action',
-                label=None,
-                help_text=None,
-                select_options=outdate_action_options,
-                data=data, errors=errors
+            {{ admin_macros.select_content(
+                id=database.id ~ '-outdate-action',
+                name='outdate_action',
+                selected=[database.outdate_action.id],
+                options=outdate_action_options,
+                onchange="$('#database-" ~ database.id ~ "-submit').click()",
             ) }}
         </span>
-
     </td>
     <td id="{{ database.id }}-updated-at" class="text-center"></td>
     <td class="text-end">
@@ -37,14 +50,4 @@
             {% include 'database_update_buttons.html' %}
         </div>
     </td>
-    <script>
-        $('#{{ database.id }}-outdate-delay').change(function () {
-            const outdateAction = $('#{{ database.id }}-outdate-action-container');
-            if ($(this).val() === 'disabled') {
-                outdateAction.addClass('invisible');
-            } else {
-                outdateAction.removeClass('invisible');
-            }
-        });
-    </script>
 </tr>

--- a/src/web/templates/admin/common/macros.j2
+++ b/src/web/templates/admin/common/macros.j2
@@ -176,7 +176,7 @@
     {% endif %}
 {% endmacro %}
 
-{% macro _select_content(
+{% macro select_content(
     id,
     name,
     options,
@@ -433,7 +433,7 @@ with_indicator: display a loading indicator, optional
                 "
             >
                 {% if input_type == 'select' %}
-                    {{ _select_content(
+                    {{ select_content(
                         id=id,
                         name=name,
                         options=select_options,
@@ -1170,7 +1170,7 @@ with_indicator: display a loading indicator, optional
         hx-indicator="#please-wait"
         style="flex-wrap: nowrap !important;"
     >
-        {{ _select_content(
+        {{ select_content(
             id=id ~ '-select',
             name=name,
             options=options,

--- a/src/web/templates/admin/players/player_modal.html
+++ b/src/web/templates/admin/players/player_modal.html
@@ -69,9 +69,9 @@
                                     hx-target="#search-results"
                                     hx-get="{{ url_for('admin-search-player', event_uniq_id=admin_event.uniq_id) }}"
                                     hx-vals='js:{
-                                    data_source_id: $("#data-source-select").val(),
-                                    {% if admin_player %}player_id: {{ admin_player.id }}{% endif %}
-                                }'
+                                        data_source_id: $("#data-source-select").val(),
+                                        {% if admin_player %}player_id: {{ admin_player.id }}{% endif %}
+                                    }'
                                     hx-on::before-request="$('#search-results').show();"
                                     hx-on::after-request="$('#search-results').show();"
                                     hx-sync="this:replace"


### PR DESCRIPTION
This avoids having to save the database when exiting the modal, which is counter-intuitive as the modal is both informative and interactable. Applies the same styling as the the history modal