### PR TITLE
Upgrade minimal Python version to 3.13

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -39,7 +39,7 @@ jobs:
           # Version range or exact version of Python or PyPy to use, using SemVer's version range syntax. Reads from .python-version if unset.
           # NOTE(pascalaubry): on Windows self-hosted runners, the first install fails:
           # https://github.com/actions/setup-python/issues/969
-          python-version: 3.12
+          python-version: 3.13
       - name: Install dependencies
         shell: cmd  # pwsh is not found on Windows self-hosted runners (https://github.com/actions/runner/issues/3415)
         run: |

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/setup-python@v5.5.0
         with:
           # Version range or exact version of Python or PyPy to use, using SemVer's version range syntax. Reads from .python-version if unset.
-          python-version: 3.12
+          python-version: 3.13
       - name: Install dependencies
         shell: bash
         run: |

--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                python-version: '3.12'
+                python-version: '3.13'
 
             - name: Install dependencies
               run: |

--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -37,7 +37,7 @@ jobs:
                 python scripts/i18n/i18n_update.py
 
             - name: Ruff check
-              run: ruff check --target-version=py312 --exit-non-zero-on-fix .
+              run: ruff check --target-version=py313 --exit-non-zero-on-fix .
 
             - name: Check format
               run: ruff format --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v4
               with:
-                python-version: '3.12'
+                python-version: '3.13'
 
             - name: Install dependencies
               run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
                 python scripts/i18n/i18n_update.py
 
             - name: Ruff check
-              run: ruff check --target-version=py312 --exit-non-zero-on-fix .
+              run: ruff check --target-version=py313 --exit-non-zero-on-fix .
 
             - name: Check format
               run: ruff format --check .

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /.idea/
-/venv/
 /papi/
 /events/
 /logs/
@@ -34,6 +33,7 @@ __pycache__/
 # Generated database files
 *-shm
 *-wal
+*-journal
 .scc
 
 # MacOS files
@@ -54,8 +54,9 @@ __pycache__/
 .env
 
 # virtual environments
-/.venv-dev
-/.venv-export
+/.venv-*
+/.venv
+/venv/
 
 # PyInstaller spec files
 /*.spec

--- a/docs/contributing/contributing-guide.md
+++ b/docs/contributing/contributing-guide.md
@@ -18,7 +18,7 @@ If a related issue doesn't exist, you can open a new issue using a relevant [iss
 
 ### Contributing code
 
-This project uses [Python 3.12](https://www.python.org/downloads/release/python-3129/), and is reliant on Windows-specific APIs.
+This project uses [Python 3.13](https://www.python.org/downloads/release/python-3138/), and is reliant on Windows-specific APIs.
 As such, this project does not support Linux or MacOS, or any other operating system.
 This will change in the future.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sharly-chess"
 description = "An application to help chess arbiters and organizers manage their tournaments"
-requires-python = ">=3.12.0"
+requires-python = ">=3.13.0"
 version = "3.1.6"
 
 authors = [
@@ -20,7 +20,7 @@ dependencies = [
   "AdvancedHTMLParser ~= 9.0.2",
   "XlsxWriter ~= 3.2.2",
   "apluggy ~= 1.1.0",
-  # Latests compatible version should always be preferred due to security reasons
+  # Latest compatible version should always be preferred due to security reasons
   # This can be pinned later due to security concerns
   "argon2-cffi",
   "babel ~= 2.16.0",

--- a/scripts/export/macos/mac_project_builder.py
+++ b/scripts/export/macos/mac_project_builder.py
@@ -37,7 +37,7 @@ class MacProjectBuilder(ProjectBuilder):
     def hook_get_venv_lib_path(
         self,
     ) -> Path:
-        return self._python_dir / '..' / 'lib' / 'python3.12' / 'site-packages'
+        return self._python_dir / '..' / 'lib' / 'python3.13' / 'site-packages'
 
     def hook_post_build_project(self) -> bool:
         # The SharlyChess.app bundle is now created by the build_and_notarize.sh script

--- a/src/common/network.py
+++ b/src/common/network.py
@@ -428,7 +428,7 @@ class NetworkMonitor:
         """Starts a thread to test for internet connectivity every few seconds"""
         # NOTE(Amaras): The entire Python program exits when only daemon threads
         # are left, and those threads will be stopped abruptly on program shutdown
-        # See https://docs.python.org/3.12/library/threading.html#thread-objects
+        # See https://docs.python.org/3.13/library/threading.html#thread-objects
         # for more documentation
         #
         # By passing cls as an arg, we can share it with the main thread.


### PR DESCRIPTION
Since Python 3.14 came out a few days ago, and Python 3.12 has been without a bugfix since April this year, I have upgraded the minimal Python version to 3.13.0.

Here is the full "What's new in Python 3.13?" on the Python documentation: https://docs.python.org/3.13/whatsnew/3.13.html

In short, not much, most of the new features are not easily available, or it's the new REPL, or improved error messages.

