### PR TITLE
Fixed the display of long player names on boards/input/players screens (aka the BBDLL bug)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,7 +36,7 @@ English version below
 - Réorganisation des écrans composant les écrans rotatifs (3.1.0)
 - Correction de la mise à jour de l'identifiant unique des écrans (3.1.2)
 - Correction de l'affichage des numéros des échiquiers fixes (3.1.7)
-- Correction de l'affichage des noms longs sur les écrans (3.1.7)
+- Amélioration de l'affichage des noms longs sur les écrans (3.1.7)
 
 ## Appariements
 
@@ -98,7 +98,7 @@ English version below
 - Rotator screens reordering (3.1.0)
 - Fixed screen uniq ID update (3.1.2)
 - Fixed the display of fixed board numbers (3.1.7)
-- Fixed the display of player long names on screens (3.1.7)
+- Improved the display of player long names on screens (3.1.7)
 
 ## Pairings
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,7 @@ English version below
 - Réorganisation des écrans composant les écrans rotatifs (3.1.0)
 - Correction de la mise à jour de l'identifiant unique des écrans (3.1.2)
 - Correction de l'affichage des numéros des échiquiers fixes (3.1.7)
+- Correction de l'affichage des noms longs sur les écrans de saisie et d'affichage par échiquier (3.1.7)
 
 ## Appariements
 
@@ -97,6 +98,7 @@ English version below
 - Rotator screens reordering (3.1.0)
 - Fixed screen uniq ID update (3.1.2)
 - Fixed the display of fixed board numbers (3.1.7)
+- Fixed the display of player long names on boards/input screens (3.1.7)
 
 ## Pairings
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,7 +36,7 @@ English version below
 - Réorganisation des écrans composant les écrans rotatifs (3.1.0)
 - Correction de la mise à jour de l'identifiant unique des écrans (3.1.2)
 - Correction de l'affichage des numéros des échiquiers fixes (3.1.7)
-- Correction de l'affichage des noms longs sur les écrans de saisie et d'affichage par échiquier (3.1.7)
+- Correction de l'affichage des noms longs sur les écrans (3.1.7)
 
 ## Appariements
 
@@ -98,7 +98,7 @@ English version below
 - Rotator screens reordering (3.1.0)
 - Fixed screen uniq ID update (3.1.2)
 - Fixed the display of fixed board numbers (3.1.7)
-- Fixed the display of player long names on boards/input screens (3.1.7)
+- Fixed the display of player long names on screens (3.1.7)
 
 ## Pairings
 

--- a/src/data/screen_set.py
+++ b/src/data/screen_set.py
@@ -432,14 +432,6 @@ class ScreenSet:
         return format_timestamp_date_time(self.last_update)
 
     @property
-    def has_fixed_boards(self) -> bool:
-        """Returns True if at least one fixed board, False otherwise."""
-        return any(
-            any(board.number != board.id for board in boards)
-            for boards in self.boards_lists
-        )
-
-    @property
     def numbers_str(self) -> str:
         if self.fixed_board_numbers:
             return _('boards {board_numbers}').format(

--- a/src/data/screen_set.py
+++ b/src/data/screen_set.py
@@ -432,6 +432,14 @@ class ScreenSet:
         return format_timestamp_date_time(self.last_update)
 
     @property
+    def has_fixed_boards(self) -> bool:
+        """Returns True if at least one fixed board, False otherwise."""
+        return any(
+            any(board.number != board.id for board in boards)
+            for boards in self.boards_lists
+        )
+
+    @property
     def numbers_str(self) -> str:
         if self.fixed_board_numbers:
             return _('boards {board_numbers}').format(

--- a/src/web/static/css/user.css
+++ b/src/web/static/css/user.css
@@ -69,12 +69,12 @@
     color: white;
     font-weight: bold;
 }
-.board-row,
-.player-row {
+.grid-striped .board-row,
+.grid-striped .player-row {
     display: contents;
 }
-.board-row > div,
-.player-row > div {
+.grid-striped .board-row > div,
+.grid-striped .player-row > div {
     padding: 0.25rem 0.25rem;
     border-bottom: 1px solid var(--bs-border-color);
 }

--- a/src/web/static/css/user.css
+++ b/src/web/static/css/user.css
@@ -69,10 +69,12 @@
     color: white;
     font-weight: bold;
 }
-.board-row {
+.board-row,
+.player-row {
     display: contents;
 }
-.board-row > div {
+.board-row > div,
+.player-row > div {
     padding: 0.25rem 0.25rem;
     border-bottom: 1px solid var(--bs-border-color);
 }

--- a/src/web/static/css/user.css
+++ b/src/web/static/css/user.css
@@ -59,19 +59,40 @@
 # BOARDS/INPUT SCREENS - BOARD/PLAYER ROWS
 ###########################################################
 */
+.grid-striped {
+    display: grid;
+    background-color: white;
+}
+.grid-header {
+    padding: 0.25rem 0.5rem;
+    background-color: #212529;
+    color: white;
+    font-weight: bold;
+}
+.board-row {
+    display: contents;
+}
+.board-row > div {
+    padding: 0.25rem 0.25rem;
+    border-bottom: 1px solid var(--bs-border-color);
+}
+.grid-striped > .board-row:nth-of-type(odd) > * {
+    color: var(--bs-table-striped-color);
+    background-color: rgba(0, 0, 0, 0.05);
+}
 .input-screen .board-row.editable {
     cursor: pointer;
 }
-.input-screen .board-row.result-not-set:hover {
+.input-screen .board-row.result-not-set:hover, .input-screen .grid-striped>.board-row.result-not-set:hover > div {
     background-color: yellow;
 }
-.input-screen .board-row.result-set:hover {
+.input-screen .board-row.result-set:hover, .input-screen .grid-striped>.board-row.result-set:hover > div {
     background-color: #ffffcc;
 }
-.input-screen .board-row.special-results-allowed.result-not-set:hover {
+.input-screen .board-row.special-results-allowed.result-not-set:hover, .input-screen .grid-striped>.board-row.special-results-allowed.result-not-set:hover > div {
     background-color: #ffc500;
 }
-.input-screen .board-row.special-results-allowed.result-set:hover {
+.input-screen .board-row.special-results-allowed.result-set:hover .input-screen .grid-striped>.board-row.special-results-allowed.result-set:hover > div {
     background-color: #fff2cd;
 }
 .time-control-modified .minutes,

--- a/src/web/templates/user/screen/boards/board_row_illegal_moves_cell.html
+++ b/src/web/templates/user/screen/boards/board_row_illegal_moves_cell.html
@@ -4,10 +4,11 @@
     tournament.record_illegal_moves
 %}
     <td class="
-        illegal-moves-cell bg-transparent text-nowrap compact-col
+        bg-transparent
         {% if screen.type == 'input' and last_illegal_move_updated and last_illegal_move_updated.expiration > now and last_illegal_move_updated.tournament_id == tournament.id and last_illegal_move_updated.player_id == player.id %}
             last_illegal_move_updated
         {% endif %}"
+        style="width: {{ illegal_moves_width }}%; {{ common_style }}"
     >
         {% if player %}
             {% for _ in range([illegal_moves, tournament.record_illegal_moves]|min) %}

--- a/src/web/templates/user/screen/boards/board_row_illegal_moves_cell.html
+++ b/src/web/templates/user/screen/boards/board_row_illegal_moves_cell.html
@@ -3,12 +3,10 @@
     and
     tournament.record_illegal_moves
 %}
-    <td class="
-        bg-transparent
+    <div class="
         {% if screen.type == 'input' and last_illegal_move_updated and last_illegal_move_updated.expiration > now and last_illegal_move_updated.tournament_id == tournament.id and last_illegal_move_updated.player_id == player.id %}
             last_illegal_move_updated
         {% endif %}"
-        style="width: {{ illegal_moves_width }}%; {{ common_style }}"
     >
         {% if player %}
             {% for _ in range([illegal_moves, tournament.record_illegal_moves]|min) %}
@@ -41,5 +39,5 @@
                 {% endif %}
             {% endif %}
         {%endif %}
-    </td>
+    </div>
 {% endif %}

--- a/src/web/templates/user/screen/boards/board_row_player_cell.html
+++ b/src/web/templates/user/screen/boards/board_row_player_cell.html
@@ -1,10 +1,10 @@
-<td
+<div
     class="
-        player-cell bg-transparent
+        player-cell
         {% if screen.type == 'input' and last_illegal_move_updated and last_illegal_move_updated.expiration > now and last_illegal_move_updated.tournament_id == tournament.id and last_illegal_move_updated.player_id == player.id %}
             last_illegal_move_updated
         {% endif %}"
-    style="width: {{ player_width }}%; {{ common_style }} text-overflow: ellipsis;"
+    style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"
     {% if editable %}
         hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
         hx-target="body"
@@ -18,4 +18,4 @@
     {% else %}{% if player.title.short_name %}{{ player.title.short_name }}&nbsp;{% endif %}{{ player.full_name }} {{ player.rating_str }}
     {% if tournament.handicap and opponent.id != 1 %}(<span class="{%if player.time_control_modified %}time-control-modified{% else %}time-control-unchanged{% endif %}">{%if player.time_control_initial_time_minutes %}<span class="minutes">{{ player.time_control_initial_time_minutes }}'</span>{% endif %}{%if player.time_control_initial_time_seconds %}<span class="seconds">{{ player.time_control_initial_time_seconds }}"</span>{% endif -%}
     {% if tournament.time_control_increment %} + {{ tournament.time_control_increment }}"{{ _('/move') }}{% endif %}</span>){% endif %}{% endif %}
-</td>
+</div>

--- a/src/web/templates/user/screen/boards/board_row_player_cell.html
+++ b/src/web/templates/user/screen/boards/board_row_player_cell.html
@@ -4,6 +4,7 @@
         {% if screen.type == 'input' and last_illegal_move_updated and last_illegal_move_updated.expiration > now and last_illegal_move_updated.tournament_id == tournament.id and last_illegal_move_updated.player_id == player.id %}
             last_illegal_move_updated
         {% endif %}"
+    style="width: {{ player_width }}%; {{ common_style }} text-overflow: ellipsis;"
     {% if editable %}
         hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
         hx-target="body"

--- a/src/web/templates/user/screen/boards/player_row_player_cell.html
+++ b/src/web/templates/user/screen/boards/player_row_player_cell.html
@@ -1,12 +1,14 @@
-<td
-    class="
-        player-cell bg-transparent
-        {% if screen.type == 'input' and last_check_in_updated and last_check_in_updated.expiration > now and last_check_in_updated.tournament_id == tournament.id and last_check_in_updated.player_id == player.id %}
-            last_check_in_updated
-        {% endif %}
-        {% if screen.type == 'input' and tournament.check_in_open %}
-            cursor-pointer
-        {% endif %}"
+<div
+        class="
+            player-cell
+            {% if screen.type == 'input' and last_check_in_updated and last_check_in_updated.expiration > now and last_check_in_updated.tournament_id == tournament.id and last_check_in_updated.player_id == player.id %}
+                last_check_in_updated
+            {% endif %}
+            {% if screen.type == 'input' and tournament.check_in_open %}
+                cursor-pointer
+            {% endif %}
+            overflow-hidden text-nowrap"
+        style="text-overflow: ellipsis;"
     {% if
         screen.type == 'input'
         and client.can_check_in_players(tournament.id)
@@ -25,4 +27,4 @@
         ></i>
     {% endif %}
     {% if player.title.short_name %}{{ player.title.short_name }}&nbsp;{% endif %}{{ player.full_name }} {{ player.rating_str }}
-</td>
+</div>

--- a/src/web/templates/user/screen/boards/set.html
+++ b/src/web/templates/user/screen/boards/set.html
@@ -23,89 +23,61 @@
                 <div class="row gy-2 gx-3 screen-set-row mx-0">
                     {% for boards in screen_set.boards_lists %}
                         <div class="col screen-set-col {% if loop.first %}ps-0{% endif %} {% if loop.last %}pe-0{% endif %}">
-                            {% set board_number_width=9 if screen_set.has_fixed_boards else 5 %}
-                            {% set real_points_width=9 if tournament.print_real_points(current_round) else 0 %}
-                            {% set points_width=7 %}
-                            {% set score_width=7 %}
-                            {% set illegal_moves_width=2 * tournament.record_illegal_moves if screen.type == 'input' else 0 %}
-                            {% set player_width=((100 - board_number_width - score_width - 2 * (real_points_width + points_width + illegal_moves_width)) / 2) | int %}
-                            {% set common_style='white-space: nowrap; overflow: hidden; text-overflow: hidden;' %}
-                            <table class="table table-striped table-sm bg-light" style="table-layout: fixed">
-                                <thead class="table-dark">
-                                    <tr>
-                                        <th
-                                                scope="col"
-                                                class="board-number"
-                                                style="width: {{ board_number_width }}%; {{ common_style }}"
-                                        >
-                                            Ech
-                                        </th>
-                                        <th
-                                                scope="col"
-                                                class="points"
-                                                style="width: {{ points_width }}%; {{ common_style }}"
-                                        >
-                                            Pts
-                                        </th>
+                            <div
+                                class="d-grid grid-striped"
+                                style="
+                                    grid-template-columns:
+                                        auto           /* board number */
+                                        auto           /* points */
                                         {% if tournament.print_real_points(current_round) %}
-                                            <th
-                                                    scope="col"
-                                                    class="points"
-                                                    style="width: {{ real_points_width }}%; {{ common_style }}"
-                                            ></th>
+                                            auto       /* real points */
                                         {% endif %}
                                         {% if screen.type == 'input' and tournament.record_illegal_moves %}
-                                            <th
-                                                    scope="col"
-                                                    class="player"
-                                                    style="width: {{ illegal_moves_width }}%; {{ common_style }}"
-                                            ></th>
+                                            auto         /* illegal moves */
                                         {% endif %}
-                                        <th
-                                                scope="col"
-                                                class="player"
-                                                style="width: {{ player_width }}%; {{ common_style }}"
-                                        >
-                                            {{ _('White') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}
-                                        </th>
-                                        <th
-                                                scope="col"
-                                                class="score text-center"
-                                                style="width: {{ score_width }}%; {{ common_style }}"
-                                        >
-                                            Score
-                                        </th>
+                                        1fr            /* white player */
+                                        auto           /* score */
                                         {% if screen.type == 'input' and tournament.record_illegal_moves %}
-                                            <th
-                                                    scope="col"
-                                                    class="player"
-                                                    style="width: {{ illegal_moves_width }}%; {{ common_style }}"
-                                            ></th>
+                                            auto         /* illegal moves */
                                         {% endif %}
-                                        <th
-                                                scope="col"
-                                                class="player"
-                                                style="width: {{ player_width }}%; {{ common_style }}"
-                                        >
-                                            {{ _('Black') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}
-                                        </th>
+                                        1fr            /* black player */
                                         {% if tournament.print_real_points(current_round) %}
-                                            <th
-                                                    scope="col"
-                                                    class="points"
-                                                    style="width: {{ real_points_width }}%; {{ common_style }}"
-                                            ></th>
+                                            auto       /* real points */
                                         {% endif %}
-                                        <th
-                                                scope="col"
-                                                class="points"
-                                                style="width: {{ points_width }}%; {{ common_style }}"
-                                        >
-                                            Pts
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody>
+                                        auto;          /* points */
+                                "
+                            >
+                                <div class="grid-header">
+                                    {{ _('Bd. *** BOARD NUMBER FOR TABLE HEADER')}}
+                                </div>
+                                <div class="grid-header">
+                                    {{ _('Pts *** POINTS FOR TABLE HEADER')}}
+                                </div>
+                                {% if tournament.print_real_points(current_round) %}
+                                    <div class="grid-header"></div>
+                                {% endif %}
+                                {% if screen.type == 'input' and tournament.record_illegal_moves %}
+                                    <div class="grid-header"></div>
+                                {% endif %}
+                                <div class="grid-header">
+                                    {{ _('White') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}
+                                </div>
+                                <div class="grid-header">
+                                    {{ _('Res. ** RESULT FOR TABLE HEADER') }}
+                                </div>
+                                {% if screen.type == 'input' and tournament.record_illegal_moves %}
+                                    <div class="grid-header"></div>
+                                {% endif %}
+                                <div class="grid-header">
+                                    {{ _('Black') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}
+                                </div>
+                                {% if tournament.print_real_points(current_round) %}
+                                    <div class="grid-header"></div>
+                                {% endif %}
+                                <div class="grid-header">
+                                    {{ _('Pts *** POINTS FOR TABLE HEADER')}}
+                                </div>
+
                                 {% for board in boards %}
                                     {% with wp=board.white_player, bp=board.black_player %}
                                     {% set editable =
@@ -116,7 +88,7 @@
                                             (not board.result_str and client.can_enter_results(tournament.id))
                                         )
                                     %}
-                                    <tr
+                                    <div
                                         id="tournament-{{ tournament.id }}-board-{{ board.id }}-row"
                                         class="
                                             board-row
@@ -125,10 +97,7 @@
                                             {% if board.result_str %}result-set{% else %}result-not-set fw-bold{% endif %}
                                             {% if last_result_updated and last_result_updated.expiration > now and last_result_updated.tournament_id == tournament.id and last_result_updated.round == tournament.current_round and last_result_updated.board_id == board.id %}last_result_updated{% endif %}"
                                         >
-                                        <th
-                                            scope="row gy-2 gx-3"
-                                            class="board-number bg-transparent text-end text-nowrap"
-                                            style="width: {{ board_number_width }}%; {{ common_style }}"
+                                        <div class="board-number text-end text-nowrap"
                                             {% if editable %}
                                                 hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
                                                 hx-target="body"
@@ -136,10 +105,11 @@
                                                 data-bs-toggle="modal"
                                                 data-bs-target="#modal-wrapper"
                                             {% endif %}
-                                        >{% if board.number != board.id %}({{ board.id }}.) {% endif %}{{ board.number }}.</th>
-                                        <td
-                                            class="points bg-transparent text-center text-nowrap"
-                                            style="width: {{ points_width }}%; {{ common_style }}"
+                                        >
+                                            {% if board.number != board.id %}({{ board.id }}.) {% endif %}{{ board.number }}.
+                                        </div>
+                                        <div
+                                            class="points text-center text-nowrap"
                                             {% if editable %}
                                                 hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
                                                 hx-target="body"
@@ -149,11 +119,10 @@
                                             {% endif %}
                                         >
                                             {{ wp.vpoints_str }}
-                                        </td>
+                                        </div>
                                         {% if tournament.print_real_points(current_round) %}
-                                            <td
-                                                class="points bg-transparent text-center text-nowrap"
-                                                style="width: {{ real_points_width }}%; {{ common_style }}"
+                                            <div
+                                                class="points text-center text-nowrap"
                                                 {% if editable %}
                                                     hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
                                                     hx-target="body"
@@ -163,7 +132,7 @@
                                                 {% endif %}
                                             >
                                                 [{{ wp.points_str }}]
-                                            </td>
+                                            </div>
                                         {% endif %}
                                         {% if screen.type == 'input' and tournament.record_illegal_moves %}
                                             {% with player=wp, illegal_moves=board.white_pairing.illegal_moves %}
@@ -173,9 +142,8 @@
                                         {% with player=wp, opponent=bp %}
                                             {% include 'board_row_player_cell.html' %}
                                         {% endwith %}
-                                        <td
-                                            class="score bg-transparent text-center text-nowrap"
-                                            style="width: {{ score_width }}%; {{ common_style }}"
+                                        <div
+                                            class="score text-center text-nowrap"
                                             data-testid="board-score"
                                             {% if editable %}
                                                 hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
@@ -186,7 +154,7 @@
                                             {% endif %}
                                         >
                                             {% if board.result_str %}{{ board.result_str }}{% else %}{{ _('#%(board_number)d', board_number=board.number) }}{% endif %}
-                                        </td>
+                                        </div>
                                         {% if screen.type == 'input' and tournament.record_illegal_moves %}
                                             {% with player=bp, illegal_moves=board.black_pairing.illegal_moves %}
                                                 {% include 'board_row_illegal_moves_cell.html' %}
@@ -196,9 +164,8 @@
                                             {% include 'board_row_player_cell.html' %}
                                         {% endwith %}
                                         {% if tournament.print_real_points(current_round) %}
-                                            <td
-                                                class="points bg-transparent text-center"
-                                                style="width: {{ real_points_width }}%; {{ common_style }}"
+                                            <div
+                                                class="points text-center"
                                                 {% if editable %}
                                                     hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
                                                     hx-target="body"
@@ -210,11 +177,10 @@
                                                 {% if bp %}
                                                     [{{ bp.points_str }}]
                                                 {% endif %}
-                                            </td>
+                                            </div>
                                         {% endif %}
-                                        <td
-                                            class="points bg-transparent text-center"
-                                            style="width: {{ points_width }}%; {{ common_style }}"
+                                        <div
+                                            class="points text-center"
                                             {% if editable %}
                                                 hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
                                                 hx-target="body"
@@ -226,12 +192,11 @@
                                             {% if bp %}
                                                 {{ bp.vpoints_str }}
                                             {% endif %}
-                                        </td>
-                                    </tr>
+                                        </div>
+                                    </div>
                                     {% endwith %}
                                 {% endfor %}
-                                </tbody>
-                            </table>
+                            </div>
                         </div>
                     {% endfor %}
                 </div>

--- a/src/web/templates/user/screen/boards/set.html
+++ b/src/web/templates/user/screen/boards/set.html
@@ -23,17 +23,86 @@
                 <div class="row gy-2 gx-3 screen-set-row mx-0">
                     {% for boards in screen_set.boards_lists %}
                         <div class="col screen-set-col {% if loop.first %}ps-0{% endif %} {% if loop.last %}pe-0{% endif %}">
-                            <table class="table table-striped table-sm bg-light">
+                            {% set board_number_width=9 if screen_set.has_fixed_boards else 5 %}
+                            {% set real_points_width=9 if tournament.print_real_points(current_round) else 0 %}
+                            {% set points_width=7 %}
+                            {% set score_width=7 %}
+                            {% set illegal_moves_width=2 * tournament.record_illegal_moves if screen.type == 'input' else 0 %}
+                            {% set player_width=((100 - board_number_width - score_width - 2 * (real_points_width + points_width + illegal_moves_width)) / 2) | int %}
+                            {% set common_style='white-space: nowrap; overflow: hidden; text-overflow: hidden;' %}
+                            <table class="table table-striped table-sm bg-light" style="table-layout: fixed">
                                 <thead class="table-dark">
                                     <tr>
-                                        <th scope="col" class="board-number">Ech</th>
-                                        <th scope="col" class="points">Pts</th>
-                                        {% if tournament.print_real_points(current_round) %}<th scope="col" class="points">&nbsp;</th>{% endif %}
-                                        <th scope="col" class="player w-50" {% if screen.type == 'input' and tournament.record_illegal_moves %}colspan="2"{% endif %}>{{ _('White') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}</th>
-                                        <th scope="col" class="score">Score</th>
-                                        <th scope="col" class="player w-50" {% if screen.type == 'input' and tournament.record_illegal_moves %}colspan="2"{% endif %}>{{ _('Black') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}</th>
-                                        {% if tournament.print_real_points(current_round) %}<th scope="col" class="points">&nbsp;</th>{% endif %}
-                                        <th scope="col" class="points">Pts</th>
+                                        <th
+                                                scope="col"
+                                                class="board-number"
+                                                style="width: {{ board_number_width }}%; {{ common_style }}"
+                                        >
+                                            Ech
+                                        </th>
+                                        <th
+                                                scope="col"
+                                                class="points"
+                                                style="width: {{ points_width }}%; {{ common_style }}"
+                                        >
+                                            Pts
+                                        </th>
+                                        {% if tournament.print_real_points(current_round) %}
+                                            <th
+                                                    scope="col"
+                                                    class="points"
+                                                    style="width: {{ real_points_width }}%; {{ common_style }}"
+                                            ></th>
+                                        {% endif %}
+                                        {% if screen.type == 'input' and tournament.record_illegal_moves %}
+                                            <th
+                                                    scope="col"
+                                                    class="player"
+                                                    style="width: {{ illegal_moves_width }}%; {{ common_style }}"
+                                            ></th>
+                                        {% endif %}
+                                        <th
+                                                scope="col"
+                                                class="player"
+                                                style="width: {{ player_width }}%; {{ common_style }}"
+                                        >
+                                            {{ _('White') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}
+                                        </th>
+                                        <th
+                                                scope="col"
+                                                class="score text-center"
+                                                style="width: {{ score_width }}%; {{ common_style }}"
+                                        >
+                                            Score
+                                        </th>
+                                        {% if screen.type == 'input' and tournament.record_illegal_moves %}
+                                            <th
+                                                    scope="col"
+                                                    class="player"
+                                                    style="width: {{ illegal_moves_width }}%; {{ common_style }}"
+                                            ></th>
+                                        {% endif %}
+                                        <th
+                                                scope="col"
+                                                class="player"
+                                                style="width: {{ player_width }}%; {{ common_style }}"
+                                        >
+                                            {{ _('Black') }}{% if tournament.handicap %} ({{ _('time control') }}){% endif %}
+                                        </th>
+                                        {% if tournament.print_real_points(current_round) %}
+                                            <th
+                                                    scope="col"
+                                                    class="points"
+                                                    style="width: {{ real_points_width }}%; {{ common_style }}"
+                                            ></th>
+                                        {% endif %}
+                                        <th
+                                                scope="col"
+                                                class="points"
+                                                style="width: {{ points_width }}%; {{ common_style }}"
+                                        >
+                                            Pts
+                                        </th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -59,6 +128,7 @@
                                         <th
                                             scope="row gy-2 gx-3"
                                             class="board-number bg-transparent text-end text-nowrap"
+                                            style="width: {{ board_number_width }}%; {{ common_style }}"
                                             {% if editable %}
                                                 hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
                                                 hx-target="body"
@@ -68,7 +138,8 @@
                                             {% endif %}
                                         >{% if board.number != board.id %}({{ board.id }}.) {% endif %}{{ board.number }}.</th>
                                         <td
-                                            class="points bg-transparent text-center"
+                                            class="points bg-transparent text-center text-nowrap"
+                                            style="width: {{ points_width }}%; {{ common_style }}"
                                             {% if editable %}
                                                 hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
                                                 hx-target="body"
@@ -81,7 +152,8 @@
                                         </td>
                                         {% if tournament.print_real_points(current_round) %}
                                             <td
-                                                class="points bg-transparent text-center"
+                                                class="points bg-transparent text-center text-nowrap"
+                                                style="width: {{ real_points_width }}%; {{ common_style }}"
                                                 {% if editable %}
                                                     hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
                                                     hx-target="body"
@@ -93,12 +165,17 @@
                                                 [{{ wp.points_str }}]
                                             </td>
                                         {% endif %}
-                                        {% with player=wp, opponent=bp, illegal_moves=board.white_pairing.illegal_moves %}
-                                            {% include 'board_row_illegal_moves_cell.html' %}
+                                        {% if screen.type == 'input' and tournament.record_illegal_moves %}
+                                            {% with player=wp, illegal_moves=board.white_pairing.illegal_moves %}
+                                                {% include 'board_row_illegal_moves_cell.html' %}
+                                            {% endwith %}
+                                        {% endif %}
+                                        {% with player=wp, opponent=bp %}
                                             {% include 'board_row_player_cell.html' %}
                                         {% endwith %}
                                         <td
                                             class="score bg-transparent text-center text-nowrap"
+                                            style="width: {{ score_width }}%; {{ common_style }}"
                                             data-testid="board-score"
                                             {% if editable %}
                                                 hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
@@ -110,13 +187,18 @@
                                         >
                                             {% if board.result_str %}{{ board.result_str }}{% else %}{{ _('#%(board_number)d', board_number=board.number) }}{% endif %}
                                         </td>
-                                        {% with player=bp, opponent=wp, illegal_moves=board.black_pairing.illegal_moves if bp else 0 %}
-                                            {% include 'board_row_illegal_moves_cell.html' %}
+                                        {% if screen.type == 'input' and tournament.record_illegal_moves %}
+                                            {% with player=bp, illegal_moves=board.black_pairing.illegal_moves %}
+                                                {% include 'board_row_illegal_moves_cell.html' %}
+                                            {% endwith %}
+                                        {% endif %}
+                                        {% with player=bp, opponent=wp %}
                                             {% include 'board_row_player_cell.html' %}
                                         {% endwith %}
                                         {% if tournament.print_real_points(current_round) %}
                                             <td
                                                 class="points bg-transparent text-center"
+                                                style="width: {{ real_points_width }}%; {{ common_style }}"
                                                 {% if editable %}
                                                     hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
                                                     hx-target="body"
@@ -132,6 +214,7 @@
                                         {% endif %}
                                         <td
                                             class="points bg-transparent text-center"
+                                            style="width: {{ points_width }}%; {{ common_style }}"
                                             {% if editable %}
                                                 hx-get="{{ url_for('user-result-modal', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, board_id=board.id) }}"
                                                 hx-target="body"

--- a/src/web/templates/user/screen/boards/set.html
+++ b/src/web/templates/user/screen/boards/set.html
@@ -216,20 +216,22 @@
                             <div class="row gy-2 gx-3 screen-set-tuple-row px-0">
                                 {% for players_by_name in players_by_name_tuple %}
                                     <div class="col screen-set-tuple-col px-1">
-                                        <table class="table table-striped table-sm bg-light">
-                                            <thead class="table-dark">
-                                                <tr>
-                                                    <th scope="col" class="player">{{ _('Player / Elo') }}</th>
-                                                </tr>
-                                            </thead>
-                                            <tbody>
+                                        <div
+                                            class="d-grid grid-striped"
+                                            style="
+                                                grid-template-columns:
+                                                    1fr            /* player */
+                                            "
+                                        >
+                                            <div class="grid-header">
+                                                {{ _('Player / Elo') }}
+                                            </div>
                                             {% for player in players_by_name %}
-                                                <tr class="player-row">
+                                                <div class="player-row">
                                                     {% include 'player_row_player_cell.html' %}
-                                                </tr>
+                                                </div>
                                             {% endfor %}
-                                            </tbody>
-                                        </table>
+                                        </div>
                                     </div>
                                 {% endfor %}
                             </div>

--- a/src/web/templates/user/screen/players/set.html
+++ b/src/web/templates/user/screen/players/set.html
@@ -24,7 +24,7 @@
                         "
                     >
                         <div
-                                class="grid-header overflow-hidden text-nowrap"
+                                class="grid-header text-nowrap"
                         >
                             {% if tournament.current_round %}{{ _('Player Elo [Pts]') }}{% else %}{{ _('Player Elo') }}{% endif %}
                         </div>
@@ -33,7 +33,7 @@
                         </div>
                         {% if screen_set.players_show_opponent %}
                             <div
-                                    class="grid-header overflow-hidden text-nowrap"
+                                    class="grid-header text-nowrap"
                                     style="text-overflow: ellipsis;"
                             >
                                 {% if tournament.current_round %}{{ _('Opponent Elo [Pts]') }}{% else %}{{ _('Opponent Elo') }}{% endif %}

--- a/src/web/templates/user/screen/players/set.html
+++ b/src/web/templates/user/screen/players/set.html
@@ -50,7 +50,7 @@
                                         >
                                             {% if player.title.short_name %}{{ player.title.short_name }}&nbsp;{% endif %}{{ player.full_name }} {{ player.rating_str }} [{{ player.vpoints_str }}]
                                         </div>
-                                        <div class="pairing overflow-hidden text-nowrap">
+                                        <div class="pairing text-nowrap">
                                             {% if pairing.exempt %}
                                                 {{ player.exempt_str }}
                                             {% elif not opponent_id %}

--- a/src/web/templates/user/screen/players/set.html
+++ b/src/web/templates/user/screen/players/set.html
@@ -12,43 +12,78 @@
         <div class="row gy-2 gx-3 screen-set-row mx-0 w-100">
             {% for players in screen_set.players_by_name_lists %}
                 <div class="col screen-set-col {% if loop.first %}ps-0{% endif %} {% if loop.last %}pe-0{% endif %}">
-                    <table class="table table-striped table-sm bg-light">
-                        <thead class="table-dark">
-                            <tr>
-                                <th scope="col" class="player w-50 text-nowrap text-start">{% if tournament.current_round %}{{ _('Player Elo [Pts]') }}{% else %}{{ _('Player Elo') }}{% endif %}</th>
-                                <th scope="col" class="pairing text-nowrap text-start">{{ _('Board & color') }}</th>
+                    <div
+                        class="d-grid grid-striped"
+                        style="
+                            grid-template-columns:
+                                1fr            /* player */
+                                auto           /* pairing */
                                 {% if screen_set.players_show_opponent %}
-                                    <th scope="col" class="opponent w-50 text-nowrap text-start">{% if tournament.current_round %}{{ _('Opponent Elo [Pts]') }}{% else %}{{ _('Opponent Elo') }}{% endif %}</th>
+                                    1fr            /* opponent */
                                 {% endif %}
-                            </tr>
-                        </thead>
-                        <tbody>
+                        "
+                    >
+                        <div
+                                class="grid-header overflow-hidden text-nowrap"
+                        >
+                            {% if tournament.current_round %}{{ _('Player Elo [Pts]') }}{% else %}{{ _('Player Elo') }}{% endif %}
+                        </div>
+                        <div class="grid-header">
+                            {{ _('Board & color') }}
+                        </div>
+                        {% if screen_set.players_show_opponent %}
+                            <div
+                                    class="grid-header overflow-hidden text-nowrap"
+                                    style="text-overflow: ellipsis;"
+                            >
+                                {% if tournament.current_round %}{{ _('Opponent Elo [Pts]') }}{% else %}{{ _('Opponent Elo') }}{% endif %}
+                            </div>
+                        {% endif %}
                         {% for player in players %}
                             {% if tournament.current_round %}
                                 {% with pairing=player.pairings[tournament.current_round] %}
                                 {% with opponent_id=pairing.opponent_id %}
-                                    <tr class="player-row {% if not opponent_id %}not-paired fs-italic{% else %}paired fw-bold{% endif %}">
-                                        <td  class="player bg-transparent text-nowrap {% if opponent_id and not pairing.exempt %}{% if player.color == 'W' %}white{%else %}black{%endif %}{%endif %}">
+                                    <div class="player-row {% if not opponent_id %}not-paired fs-italic{% else %}paired fw-bold{% endif %}">
+                                        <div
+                                                class="player overflow-hidden text-nowrap"
+                                                style="text-overflow: ellipsis;"
+                                        >
                                             {% if player.title.short_name %}{{ player.title.short_name }}&nbsp;{% endif %}{{ player.full_name }} {{ player.rating_str }} [{{ player.vpoints_str }}]
-                                        </td>
-                                        {% if pairing.exempt %}
-                                            <td colspan="2" class="bg-transparent text-nowrap">{{ player.exempt_str }}</td>
-                                        {% elif not opponent_id %}
-                                            <td colspan="2" class="bg-transparent text-nowrap">{{ player.not_paired_str }}</td>
-                                        {% else %}
-                                            {% with opponent=tournament.players_by_id[opponent_id] %}
-                                                <td class="pairing bg-transparent text-nowrap {% if player.color == 'W' %}white{%else %}black{%endif %}">{{ _('Board #%(board_number)d with %(color)s', board_number=player.board_number, color=player.color_str) }}</td>
-                                                {% if screen_set.players_show_opponent %}
-                                                    <td class="opponent bg-transparent text-nowrap {% if player.color == 'W' %}white{%else %}black{%endif %}">{{ _('vs') }} {% if opponent.title.short_name %}{{ opponent.title.short_name }}&nbsp;{% endif %}{{ opponent.full_name }} {{ opponent.rating_str }} [{{ opponent.vpoints_str }}]</td>
+                                        </div>
+                                        <div class="pairing overflow-hidden text-nowrap">
+                                            {% if pairing.exempt %}
+                                                {{ player.exempt_str }}
+                                            {% elif not opponent_id %}
+                                                {{ player.not_paired_str }}
+                                            {% else %}
+                                                {% with opponent=tournament.players_by_id[opponent_id] %}
+                                                    {{ _('Board #%(board_number)d with %(color)s', board_number=player.board_number, color=player.color_str) }}
+                                                {% endwith %}
+                                            {% endif %}
+                                        </div>
+                                        {% if screen_set.players_show_opponent %}
+                                            <div
+                                                    class="opponent overflow-hidden text-nowrap"
+                                                    style="text-overflow: ellipsis;"
+                                            ></div>
+                                                {% if pairing.exempt %}
+                                                {% elif not opponent_id %}
+                                                {% else %}
+                                                    {% with opponent=tournament.players_by_id[opponent_id] %}
+                                                        {{ _('vs') }} {% if opponent.title.short_name %}{{ opponent.title.short_name }}&nbsp;{% endif %}{{ opponent.full_name }} {{ opponent.rating_str }} [{{ opponent.vpoints_str }}]
+                                                    {% endwith %}
                                                 {% endif %}
-                                            {% endwith %}
+                                            </div>
                                         {% endif %}
-                                    </tr>
+                                    </div>
                                 {% endwith %}
                                 {% endwith %}
                             {% else %}
-                                <tr class="player-row not-paired fs-italic">
-                                    <td class="player bg-transparent">
+                                <div class="player-row not-paired fs-italic">
+                                    <div
+                                            class="player overflow-hidden text-nowrap"
+                                            style="text-overflow: ellipsis;"
+                                    >
                                         <i class="
                                             {% if player.check_in %}
                                                 bi-check-square-fill player-check-out
@@ -57,13 +92,18 @@
                                             {% endif %}
                                             player-{{ tournament.id }}-{{ player.id }}"></i>
                                         {% if player.title.short_name %}{{ player.title.short_name }}&nbsp;{% endif %}{{ player.full_name }} {{ player.rating_str }}
-                                    </td>
-                                    <td colspan="2" class="bg-transparent"><span class="fst-italic">{{ player.not_paired_str }}</span></td>
-                                </tr>
+                                    </div>
+                                    <div class="pairing text-nowrap">
+                                        {{ player.not_paired_str }}
+                                    </div>
+                                    {% if screen_set.players_show_opponent %}
+                                        <div class="opponent text-nowrap">
+                                        </div>
+                                    {% endif %}
+                                </div>
                             {% endif %}
                         {% endfor %}
-                        </tbody>
-                    </table>
+                    </div>
                 </div>
             {% endfor %}
         </div>

--- a/tests/e2e/access_levels/base_access_level_test.py
+++ b/tests/e2e/access_levels/base_access_level_test.py
@@ -311,7 +311,6 @@ class BaseAccessLevelTest:
         self.auth_page.goto(
             f'/view/screen/{PUBLIC_EVENT_ID}/{self.unpaired_screen.uniq_id}'
         )
-        TestUtils.take_screenshot(self.auth_page, 'unpaired_screen')
         rows = self.auth_page.locator('div.player-row')
 
         expect(rows).to_have_count(16)

--- a/tests/e2e/access_levels/base_access_level_test.py
+++ b/tests/e2e/access_levels/base_access_level_test.py
@@ -291,7 +291,7 @@ class BaseAccessLevelTest:
         if can_access:
             # Test access to the input screen
             page.goto(f'/view/screen/{PUBLIC_EVENT_ID}/{screen.uniq_id}')
-            rows = page.locator('table tbody tr')
+            rows = page.locator('div.board-row')
             expect(rows).to_have_count(8)
         else:
             # Test no access to the input screen, should redirect to the 403 page
@@ -311,14 +311,15 @@ class BaseAccessLevelTest:
         self.auth_page.goto(
             f'/view/screen/{PUBLIC_EVENT_ID}/{self.unpaired_screen.uniq_id}'
         )
-        rows = self.auth_page.locator('table tbody tr')
+        TestUtils.take_screenshot(self.auth_page, 'unpaired_screen')
+        rows = self.auth_page.locator('div.player-row')
 
         expect(rows).to_have_count(16)
         row = rows.filter(has_text='AMOS')
 
         if can_access:
             # Try to open the modal
-            expect(row.locator('td:nth-child(1)')).to_have_attribute(
+            expect(row.locator('div:nth-child(1)')).to_have_attribute(
                 'hx-get', re.compile(r'.*checkin-modal.*')
             )
             row.click()
@@ -332,7 +333,7 @@ class BaseAccessLevelTest:
             # Test that the page is updated
             expect(row.locator('i.bi-check-square-fill')).to_be_visible()
         else:
-            expect(row.locator('td:nth-child(1)')).not_to_have_attribute(
+            expect(row.locator('div:nth-child(1)')).not_to_have_attribute(
                 'hx-get', re.compile(r'.*checkin-modal.*')
             )
 
@@ -345,7 +346,7 @@ class BaseAccessLevelTest:
         self.auth_page.goto(
             f'/view/screen/{PUBLIC_EVENT_ID}/{self.paired_screen.uniq_id}'
         )
-        rows = self.auth_page.locator('table tbody tr')
+        rows = self.auth_page.locator('div.board-row')
 
         expect(rows).to_have_count(8)
         row = rows.filter(has_text='ALYX')
@@ -406,7 +407,7 @@ class BaseAccessLevelTest:
         self.auth_page.goto(
             f'/view/screen/{PUBLIC_EVENT_ID}/{self.paired_screen.uniq_id}'
         )
-        rows = self.auth_page.locator('table tbody tr')
+        rows = self.auth_page.locator('div.board-row')
 
         row = rows.filter(has_text='ALYX')
         illegal_move_button = row.get_by_test_id('add-illegal-move-button-W')

--- a/tests/e2e/screens/test_family_screens.py
+++ b/tests/e2e/screens/test_family_screens.py
@@ -67,7 +67,7 @@ class TestFamilyScreensFunctionality:
             {'parts': 2},
         )
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:001')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.board-row')
         expect(rows).to_have_count(4)
 
         first_row = rows.first
@@ -76,7 +76,7 @@ class TestFamilyScreensFunctionality:
         expect(last_row).to_contain_text('DAVID')
 
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:002')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.board-row')
         expect(rows).to_have_count(4)
 
         first_row = rows.first
@@ -90,7 +90,7 @@ class TestFamilyScreensFunctionality:
         modal.locator('button:has-text("IRINA")').click()
 
         # Test that the page is updated
-        expect(last_row.locator('td.score')).to_contain_text(str(Result.LOSS))
+        expect(last_row.locator('div.score')).to_contain_text(str(Result.LOSS))
 
         TestUtils.delete_family(api_request_context, EVENT_ID, stored_family.id)
 
@@ -109,7 +109,7 @@ class TestFamilyScreensFunctionality:
             {'number': 2},
         )
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:001')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.board-row')
         expect(rows).to_have_count(2)
 
         first_row = rows.first
@@ -118,7 +118,7 @@ class TestFamilyScreensFunctionality:
         expect(last_row).to_contain_text('BRUNO')
 
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:004')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.board-row')
         expect(rows).to_have_count(2)
 
         first_row = rows.first
@@ -143,7 +143,7 @@ class TestFamilyScreensFunctionality:
             {'parts': 2},
         )
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:001')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.board-row')
         expect(rows).to_have_count(4)
 
         first_row = rows.first
@@ -152,7 +152,7 @@ class TestFamilyScreensFunctionality:
         expect(last_row).to_contain_text('DAVID')
 
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:002')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.board-row')
         expect(rows).to_have_count(4)
 
         first_row = rows.first
@@ -177,7 +177,7 @@ class TestFamilyScreensFunctionality:
             {'number': 2},
         )
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:001')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.board-row')
         expect(rows).to_have_count(2)
 
         first_row = rows.first
@@ -186,7 +186,7 @@ class TestFamilyScreensFunctionality:
         expect(last_row).to_contain_text('BRUNO')
 
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:004')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.board-row')
         expect(rows).to_have_count(2)
 
         first_row = rows.first
@@ -211,7 +211,7 @@ class TestFamilyScreensFunctionality:
             {'parts': 2},
         )
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:001')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.player-row')
         expect(rows).to_have_count(8)
 
         first_row = rows.first
@@ -220,7 +220,7 @@ class TestFamilyScreensFunctionality:
         expect(last_row).to_contain_text('IRINA')
 
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:002')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.player-row')
         expect(rows).to_have_count(8)
 
         first_row = rows.first
@@ -245,7 +245,7 @@ class TestFamilyScreensFunctionality:
             {'number': 2},
         )
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:001')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.player-row')
         expect(rows).to_have_count(2)
 
         first_row = rows.first
@@ -254,7 +254,7 @@ class TestFamilyScreensFunctionality:
         expect(last_row).to_contain_text('BRUNO')
 
         lan_page.goto(f'/view/screen/{EVENT_ID}/{FAMILY_ID}:008')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.player-row')
         expect(rows).to_have_count(2)
 
         first_row = rows.first

--- a/tests/e2e/screens/test_single_screens.py
+++ b/tests/e2e/screens/test_single_screens.py
@@ -83,7 +83,7 @@ class TestSingleScreensFunctionality:
             {'init_set_tournament_id': unpaired_tournament.id},
         )
         lan_page.goto(f'/view/screen/{EVENT_ID}/{SCREEN_ID}')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.player-row')
         expect(rows).to_have_count(16)
 
         # Should not be checked in
@@ -103,10 +103,10 @@ class TestSingleScreensFunctionality:
         lan_page.goto(f'/view/screen/{EVENT_ID}/{SCREEN_ID}')
 
         # Try to open the modal again
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.player-row')
         expect(rows).to_have_count(16)
         row = rows.filter(has_text='AMOS')
-        expect(row.locator('td:nth-child(1)')).to_have_attribute(
+        expect(row.locator('div:nth-child(1)')).to_have_attribute(
             'hx-get', re.compile(r'.*checkin-modal.*')
         )
         row.click()
@@ -161,12 +161,12 @@ class TestSingleScreensFunctionality:
             {'init_set_tournament_id': paired_tournament.id},
         )
         lan_page.goto(f'/view/screen/{EVENT_ID}/{SCREEN_ID}')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.board-row')
         expect(rows).to_have_count(8)
 
         another_lan_page = lan_context.new_page()
         another_lan_page.goto(f'/view/screen/{EVENT_ID}/{SCREEN_ID}')
-        other_page_rows = another_lan_page.locator('table tbody tr')
+        other_page_rows = another_lan_page.locator('div.board-row')
 
         # Test the primary result button
 
@@ -178,7 +178,7 @@ class TestSingleScreensFunctionality:
 
         for i, player in enumerate(players):
             row = rows.filter(has_text=player['name'])
-            expect(row.locator('td.score')).to_contain_text(f'#{i + 1}')
+            expect(row.locator('div.score')).to_contain_text(f'#{i + 1}')
 
             row.click()
             modal = lan_page.locator('.modal-dialog')
@@ -187,11 +187,13 @@ class TestSingleScreensFunctionality:
             expect(modal).not_to_be_visible()
 
             # Test that the page is updated
-            expect(row.locator('td.score')).to_contain_text(str(player['result']))
+            expect(row.locator('div.score')).to_contain_text(str(player['result']))
 
             # That the other page is refreshed
             other_row = other_page_rows.filter(has_text=player['name'])
-            expect(other_row.locator('td.score')).to_contain_text(str(player['result']))
+            expect(other_row.locator('div.score')).to_contain_text(
+                str(player['result'])
+            )
 
         TestUtils.delete_screen(api_request_context, EVENT_ID, stored_screen.id)
 
@@ -209,11 +211,11 @@ class TestSingleScreensFunctionality:
             {'init_set_tournament_id': paired_tournament.id},
         )
         lan_page.goto(f'/view/screen/{EVENT_ID}/{SCREEN_ID}')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.board-row')
         expect(rows).to_have_count(8)
 
         row = rows.filter(has_text='ALYX')
-        expect(row.locator('td.score')).to_contain_text('#1')
+        expect(row.locator('div.score')).to_contain_text('#1')
 
         # Update the first row for some possible results, and check that the result is updated on the screen
         for r in [Result.LOSS, Result.DRAW, Result.WIN]:
@@ -221,7 +223,7 @@ class TestSingleScreensFunctionality:
                 f'/pairing/set-result/{EVENT_ID}/{paired_tournament.id}/1/1/{r.value}'
             )
             assert set_result.ok
-            expect(row.locator('td.score')).to_contain_text(str(r))
+            expect(row.locator('div.score')).to_contain_text(str(r))
 
     def test_players_screen(
         self,
@@ -237,7 +239,7 @@ class TestSingleScreensFunctionality:
             {'init_set_tournament_id': paired_tournament.id},
         )
         lan_page.goto(f'/view/screen/{EVENT_ID}/{SCREEN_ID}')
-        rows = lan_page.locator('table tbody tr')
+        rows = lan_page.locator('div.player-row')
         expect(rows).to_have_count(16)
 
         first_row = rows.first


### PR DESCRIPTION
The goal of this PR is to prevent from any line break on boards/input screens to get nice display even with players having long names.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4656853d-e828-498b-b656-571f54869153" />
