### PR TITLE
Add pairings checking utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Sharly Chess - © Sharly Chess project 2013-2025_
 - [Description of the databases](docs/technical-appendices/databases.md)
 - [Internationalization](docs/technical-appendices/i18n.md)
 - [Network](docs/technical-appendices/network.md)
-- [Checking the pairings](docs/technical-appendices/pairings-checker.md)
+- [FIDE endorsement](docs/technical-appendices/fide-endorsement.md)
 
 ### Sandbox
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ _Sharly Chess - © Sharly Chess project 2013-2025_
 - [Description of the databases](docs/technical-appendices/databases.md)
 - [Internationalization](docs/technical-appendices/i18n.md)
 - [Network](docs/technical-appendices/network.md)
+- [Checking the pairings](docs/technical-appendices/pairings-checker.md)
 
 ### Sandbox
 

--- a/docs/technical-appendices/fide-endorsement.md
+++ b/docs/technical-appendices/fide-endorsement.md
@@ -1,8 +1,31 @@
-# _Sharly Chess_ - Checking the pairings
+# _Sharly Chess_ - _FIDE_ endorsement
 
-Checking the pairings is needed for the FIDE certification.
+## Useful links
 
-Pairings and checks entirely rely on the BbpPairings pairing engine.
+### GitHub issue
+
+- ["_FIDE_ endorsement"](https://github.com/Sharly-Chess/sharly-chess/issues/937)
+
+### FIDE Handbook
+
+- [Handbook C.04.A Appendix: Endorsement of a software program](https://handbook.fide.com/chapter/C04A)
+  - Application for Swiss Pairing Program _FIDE_ Endorsement
+  - Tournament Report File Format (version 2006)
+  - Tournament Report File Format (version 2016)
+  - List of _FIDE_ Endorsed Programs
+  - Verification check-list
+  - [Application for Swiss Pairing Program FIDE Endorsement (form)](https://www.fide.com/FIDE/handbook/C04Annex1_FE1.pdf)
+
+### Pairing engines
+
+- [_BbpPairings_](https://github.com/BieremaBoyzProgramming/bbpPairings)
+- [_JaVaFo_](https://www.rrweb.org/javafo/aum/JaVaFo2_AUM.htm)
+
+## Checking the _Sharly Chess_ pairings
+
+Checking the pairings is needed for the _FIDE_ endorsement.
+
+Pairings and checks entirely rely on the _BbpPairings_ pairing engine.
 
 ## Generate tournament pairings
 

--- a/docs/technical-appendices/pairings-checker.md
+++ b/docs/technical-appendices/pairings-checker.md
@@ -1,0 +1,45 @@
+# _Sharly Chess_ - Checking the pairings
+
+Checking the pairings is needed for the FIDE certification.
+
+Pairings and checks entirely rely on the BbpPairings pairing engine.
+
+## Generate tournament pairings
+
+Generate a random TRF file ``test.trf``:
+
+``sharly-chess-<version>.exe --generate-tournament --output-file=test.trf``<br/>
+or<br/>
+``sharly-chess-<version>.exe -g -o test.trf``
+
+Generate a random TRF file ``test.trf`` using a random seed (to easily reproduce the tests):
+
+``sharly-chess-<version>.exe --generate-tournament --output-file=test.trf --random-seed=12345678``<br/>
+or<br/>
+``sharly-chess-<version>.exe -g -o test.trf -s=12345678``
+
+## Check tournament pairings
+
+Check the pairings of a TRF file ``test.trf`` (automatically writes file ``test.list``):
+
+``sharly-chess-<version>.exe --check-tournament test.trf``<br/>
+or<br/>
+``sharly-chess-<version>.exe -c test.trf``
+
+Check the pairings of a TRF file ``test.trf`` (write to file ``test2.list``):
+
+``sharly-chess-<version>.exe --check-tournament --check-list-file=test2.list test.trf``<br/>
+or<br/>
+``sharly-chess-<version>.exe -c -l test2.list test.trf``
+
+## Generate and check tournament pairings
+
+Generate a random TRF file ``test.trf`` and check it:
+
+``sharly-chess-<version>.exe --generate-tournament --output-file=test.trf --check-tournament``<br/>
+or<br/>
+``sharly-chess-<version>.exe -g -o test.trf -c``
+
+## Generate and check 5000 tournament pairings at once
+
+Use script ``/scripts/fide/generate_and_check_tournaments.py``.

--- a/docs/technical-appendices/pairings-checker.md
+++ b/docs/technical-appendices/pairings-checker.md
@@ -16,7 +16,7 @@ Generate a random TRF file ``test.trf`` using a random seed (to easily reproduce
 
 ``sharly-chess-<version>.exe --generate-tournament --output-file=test.trf --random-seed=12345678``<br/>
 or<br/>
-``sharly-chess-<version>.exe -g -o test.trf -s=12345678``
+``sharly-chess-<version>.exe -g -o test.trf -s 12345678``
 
 ## Check tournament pairings
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
   "Jinja2 ~= 3.1.5",
   "litestar ~= 2.16.0",
   "packaging ~= 25.0",
-  # downgrading pefile from 2024.8.26 to 2023.2.7, cf https://github.com/pyinstaller/pyinstaller/issues/8762
+  "pathvalidate ~= 3.3.1",
+    # downgrading pefile from 2024.8.26 to 2023.2.7, cf https://github.com/pyinstaller/pyinstaller/issues/8762
   "pefile == 2023.2.7",
   "pluggy ~= 1.5.0",
   "psutil ~= 7.0.0",

--- a/scripts/fide/generate_and_check_tournaments.py
+++ b/scripts/fide/generate_and_check_tournaments.py
@@ -9,22 +9,17 @@ def main(
 ):
     """Generate *n* tournaments and check them."""
     bbp_pairings: BbpPairings = BbpPairings()
-    base_dir: Path = TMP_DIR / 'tournament_checker'
-    tournaments_dir: Path = base_dir / 'tournaments'
-    tournaments_dir.mkdir(exist_ok=True, parents=True)
-    check_lists_dir: Path = base_dir / 'check_lists'
-    check_lists_dir.mkdir(exist_ok=True, parents=True)
+    pairings_checker_dir: Path = TMP_DIR / 'pairings_checker'
+    pairings_checker_dir.mkdir(exist_ok=True, parents=True)
     for i in range(1, max(n, 1) + 1):
-        tournament_file: Path = tournaments_dir / f'{i:05d}.trf'
+        tournament_file: Path = pairings_checker_dir / f'{i:05d}.trf'
         bbp_pairings.generate_tournament(
             tournament_file,
             i,
             overwrite=False,
         )
-        check_list_file: Path = check_lists_dir / f'{i:05d}.list'
         bbp_pairings.check_tournament(
             tournament_file,
-            check_list_file,
             overwrite=False,
         )
 

--- a/scripts/fide/generate_and_check_tournaments.py
+++ b/scripts/fide/generate_and_check_tournaments.py
@@ -18,7 +18,6 @@ def main(
         tournament_file: Path = pairings_checker_dir / f'{i:05d}.trfx'
         if BbpPairingsGenerator().generate_tournament(
             tournament_file,
-            i,
             cache=True,
         ):
             tournament_checks.append(
@@ -42,4 +41,4 @@ def main(
 
 
 if __name__ == '__main__':
-    main(300)
+    main(10)

--- a/scripts/fide/generate_and_check_tournaments.py
+++ b/scripts/fide/generate_and_check_tournaments.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from common import TMP_DIR
+from data.pairings.engines import BbpPairings
+
+
+def main(
+    n: int,
+):
+    """Generate *n* tournaments and check them."""
+    bbp_pairings: BbpPairings = BbpPairings()
+    base_dir: Path = TMP_DIR / 'tournament_checker'
+    tournaments_dir: Path = base_dir / 'tournaments'
+    tournaments_dir.mkdir(exist_ok=True, parents=True)
+    check_lists_dir: Path = base_dir / 'check_lists'
+    check_lists_dir.mkdir(exist_ok=True, parents=True)
+    for i in range(1, max(n, 1) + 1):
+        tournament_file: Path = tournaments_dir / f'{i:05d}.trf'
+        bbp_pairings.generate_tournament(
+            tournament_file,
+            i,
+            overwrite=False,
+        )
+        check_list_file: Path = check_lists_dir / f'{i:05d}.list'
+        bbp_pairings.check_tournament(
+            tournament_file,
+            check_list_file,
+            overwrite=False,
+        )
+
+
+if __name__ == '__main__':
+    main(5000)

--- a/scripts/fide/generate_and_check_tournaments.py
+++ b/scripts/fide/generate_and_check_tournaments.py
@@ -41,4 +41,4 @@ def main(
 
 
 if __name__ == '__main__':
-    main(10)
+    main(2)

--- a/scripts/fide/generate_and_check_tournaments.py
+++ b/scripts/fide/generate_and_check_tournaments.py
@@ -1,28 +1,45 @@
 from pathlib import Path
 
 from common import TMP_DIR
-from data.pairings.engines import BbpPairings
+from common.logger import print_interactive_info
+from common.tool_installer import BbpPairingsInstaller
+from data.pairings.checkers import BbpPairingsChecker, TournamentCheck
+from data.pairings.generators import BbpPairingsGenerator
 
 
 def main(
     n: int,
 ):
     """Generate *n* tournaments and check them."""
-    bbp_pairings: BbpPairings = BbpPairings()
     pairings_checker_dir: Path = TMP_DIR / 'pairings_checker'
     pairings_checker_dir.mkdir(exist_ok=True, parents=True)
+    tournament_checks: list[TournamentCheck] = []
     for i in range(1, max(n, 1) + 1):
-        tournament_file: Path = pairings_checker_dir / f'{i:05d}.trf'
-        bbp_pairings.generate_tournament(
+        tournament_file: Path = pairings_checker_dir / f'{i:05d}.trfx'
+        if BbpPairingsGenerator().generate_tournament(
             tournament_file,
             i,
-            overwrite=False,
-        )
-        bbp_pairings.check_tournament(
-            tournament_file,
-            overwrite=False,
-        )
+            cache=True,
+        ):
+            tournament_checks.append(
+                BbpPairingsChecker.check_tournament(
+                    tournament_file,
+                    cache=True,
+                )
+            )
+    print_interactive_info('Internal FPC (Free Pairing Checker)')
+    bbp_pairings_installer = BbpPairingsInstaller()
+    print_interactive_info(
+        f'- Reference RTG: {bbp_pairings_installer.name} v{bbp_pairings_installer.version}'
+    )
+    print_interactive_info(f'- Number of test tournaments: {len(tournament_checks)}')
+    print_interactive_info(
+        f'- Rounds per test tournament (min/max/avg): {min(tournament_check.rounds for tournament_check in tournament_checks)}/{max(tournament_check.rounds for tournament_check in tournament_checks)}/{sum(tournament_check.rounds for tournament_check in tournament_checks) / len(tournament_checks):.2f}'
+    )
+    print_interactive_info(
+        f'- Number of rounds with pairing differences detected by internal checker: {len([tournament_check for tournament_check in tournament_checks if tournament_check.diff])}'
+    )
 
 
 if __name__ == '__main__':
-    main(5000)
+    main(300)

--- a/src/data/input_output/tournament_importers.py
+++ b/src/data/input_output/tournament_importers.py
@@ -104,9 +104,10 @@ class TournamentImporter(OptionHandler[TournamentImporterOption], ABC):
         self,
         event: Event,
         tournament: Tournament | None = None,
-    ) -> Tournament:
+    ) -> int:
         """Load a tournament into an event.
         If tournament is provided, update this tournament, otherwise create a new one.
+        Returns the ID of the tournament.
         Raises if the tournament already has players."""
         stored_tournament, stored_players = self.load_stored_tournament(
             event, tournament.stored_tournament if tournament else None
@@ -127,7 +128,7 @@ class TournamentImporter(OptionHandler[TournamentImporterOption], ABC):
         tournament.set_players_pairing_numbers()
         for task in self.post_import_task:
             task(tournament)
-        return tournament
+        return tournament.id
 
     @staticmethod
     def _write_stored_tournament(

--- a/src/data/input_output/trf_mappers.py
+++ b/src/data/input_output/trf_mappers.py
@@ -7,6 +7,7 @@ class TrfPlayerGender(CoreMapper[str, PlayerGender]):
     def _core_object_by_outer_value() -> dict[str, PlayerGender]:
         return {
             '': PlayerGender.NONE,
+            ' ': PlayerGender.NONE,
             'm': PlayerGender.MALE,
             'w': PlayerGender.FEMALE,
         }

--- a/src/data/pairings/checkers.py
+++ b/src/data/pairings/checkers.py
@@ -1,0 +1,326 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Self
+
+from common.logger import (
+    get_logger,
+    print_interactive_info,
+    print_interactive_success,
+    print_interactive_error,
+    print_interactive_warning,
+)
+from data.board import Board
+from data.pairings.engines import BbpPairings
+from data.player import Player
+from data.tournament import Tournament
+from database.sqlite.event.event_database import EventDatabase
+
+logger = get_logger()
+
+
+@dataclass
+class CheckerPlayer:
+    id: int
+    last_name: str
+    first_name: str
+    rating: int
+    points: float
+
+    @classmethod
+    def from_object(
+        cls,
+        player: Player,
+    ) -> Self:
+        return CheckerPlayer(
+            player.id,
+            player.last_name,
+            player.first_name,
+            player.rating,
+            player.points,
+        )
+
+    @classmethod
+    def from_dict(
+        cls,
+        d: dict,
+    ) -> Self:
+        return CheckerPlayer(
+            d['id'],
+            d['last_name'],
+            d['first_name'],
+            d['rating'],
+            d['points'],
+        )
+
+    @property
+    def to_dict(self) -> dict:
+        return {
+            'id': self.id,
+            'last_name': self.last_name,
+            'first_name': self.first_name,
+            'rating': self.rating,
+            'points': self.points,
+        }
+
+    def __str__(self):
+        return f'({self.id}) {self.last_name} {self.first_name} {self.rating} [{self.points:.1f}]'
+
+
+@dataclass
+class CheckerBoard:
+    id: int | None
+    white: CheckerPlayer | None
+    black: CheckerPlayer | None
+
+    @classmethod
+    def from_object(
+        cls,
+        board: Board,
+    ) -> Self:
+        return CheckerBoard(
+            board.id,
+            CheckerPlayer.from_object(board.white_player),
+            CheckerPlayer.from_object(board.black_player),
+        )
+
+    @classmethod
+    def from_dict(
+        cls,
+        d: dict,
+    ) -> Self:
+        return CheckerBoard(
+            d['id'],
+            CheckerPlayer.from_dict(d['white']),
+            CheckerPlayer.from_dict(d['black']),
+        )
+
+    @property
+    def to_dict(self) -> dict:
+        return {
+            'id': self.id,
+            'white': self.white.to_dict,
+            'black': self.black.to_dict,
+        }
+
+    def __str__(self):
+        return f'{self.id:03d}. {self.white} vs {self.black}'
+
+
+@dataclass
+class BoardDiff:
+    read_board: CheckerBoard
+    expected_board: CheckerBoard
+
+    @classmethod
+    def from_objects(
+        cls,
+        read_board: Board,
+        expected_board: Board,
+    ) -> Self:
+        return BoardDiff(
+            CheckerBoard.from_object(read_board),
+            CheckerBoard.from_object(expected_board),
+        )
+
+    @classmethod
+    def from_dict(
+        cls,
+        d: dict,
+    ) -> Self:
+        return BoardDiff(
+            CheckerBoard.from_dict(d['read_board']),
+            CheckerBoard.from_dict(d['expected_board']),
+        )
+
+    @property
+    def to_dict(self) -> dict:
+        return {
+            'read_board': self.read_board.to_dict,
+            'expected_board': self.expected_board.to_dict,
+        }
+
+
+class TournamentDiff(dict[int, list[BoardDiff]]):
+    @classmethod
+    def from_dict(
+        cls,
+        d: dict,
+    ) -> Self:
+        return {
+            round_: [BoardDiff.from_dict(board) for board in round_board_diffs]
+            for round_, round_board_diffs in d.items()
+        }
+
+    @property
+    def to_dict(self) -> dict:
+        return {
+            round_: [round_board_diff.to_dict for round_board_diff in round_board_diffs]
+            for round_, round_board_diffs in self.items()
+        }
+
+
+@dataclass
+class TournamentCheck:
+    name: str
+    player_count: int
+    rounds: int
+    diff: TournamentDiff
+
+    @classmethod
+    def from_object(
+        cls,
+        tournament: Tournament,
+    ) -> Self:
+        return TournamentCheck(
+            tournament.name,
+            tournament.player_count,
+            tournament.rounds,
+            TournamentDiff(),
+        )
+
+    @classmethod
+    def from_dict(
+        cls,
+        d: dict,
+    ) -> Self:
+        return TournamentCheck(
+            d['name'],
+            d['player_count'],
+            d['rounds'],
+            TournamentDiff.from_dict(d['diff']),
+        )
+
+    @classmethod
+    def load_from_file(
+        cls,
+        input_file: Path,
+    ) -> Self:
+        with open(input_file, 'r', encoding='utf-8') as file:
+            return TournamentCheck.from_dict(json.load(file))
+
+    @property
+    def to_dict(self) -> dict:
+        return {
+            'name': self.name,
+            'player_count': self.player_count,
+            'rounds': self.rounds,
+            'diff': self.diff.to_dict,
+        }
+
+    def dump_to_file(
+        self,
+        output_file: Path,
+    ):
+        with open(output_file, 'w', encoding='utf-8') as file:
+            json.dump(self.to_dict, file, ensure_ascii=False, indent=2)
+
+    @property
+    def round_error_count(self) -> int:
+        """Returns the number of rounds with errors."""
+        return len(self.diff)
+
+    @property
+    def board_error_count(self) -> int:
+        """Returns the number of boards with errors."""
+        return sum(len(round_board_diffs) for round_board_diffs in self.diff.values())
+
+
+class BbpPairingsChecker(BbpPairings):
+    @staticmethod
+    def check_tournament(
+        trf_input_file_path: Path,
+        cache: bool = False,
+    ) -> TournamentCheck:
+        """Checks a tournament by looking at the differences
+        between the pairings of the input file and those
+        made by the engine."""
+        check_file_path = trf_input_file_path.with_suffix('.json')
+        try:
+            tournament_check: TournamentCheck
+            if cache and check_file_path.exists():
+                tournament_check = TournamentCheck.load_from_file(check_file_path)
+                print_interactive_info(
+                    f'Loaded pairing analysis of tournament [{trf_input_file_path.name}] from cache.'
+                )
+            else:
+                check_file_path.unlink(missing_ok=True)
+                print_interactive_info(
+                    f'Loading TRFX file [{trf_input_file_path.name}]...'
+                )
+
+                from data.input_output.tournament_importer_options import FileOption
+                from data.input_output.tournament_importers import TrfTournamentImporter
+                from data.loader import EventLoader
+
+                event_loader = EventLoader()
+                event_uniq_id: str = event_loader.get_unused_event_uniq_id('checker')
+                EventDatabase(event_uniq_id).create()
+                event = EventLoader().load_event(event_uniq_id)
+                tournament_id = TrfTournamentImporter(
+                    [
+                        FileOption(trf_input_file_path),
+                    ]
+                ).load_tournament(event)
+                event = EventLoader().load_event(event_uniq_id)
+                tournament = event.tournaments_by_id[tournament_id]
+                tournament_check = TournamentCheck.from_object(tournament)
+                print_interactive_info(
+                    f'Analysing pairings for tournament [{tournament_check.name}]...'
+                )
+                for round_ in range(1, tournament.rounds + 1):
+                    if (
+                        round_pairings_diff
+                        := tournament.pairing_variation.engine.pairings_diff(
+                            tournament,
+                            round_,
+                            ignore_order=True,
+                        )
+                    ):
+                        tournament_check.diff[round_] = [
+                            BoardDiff.from_objects(
+                                read_board,
+                                expected_board,
+                            )
+                            for read_board, expected_board in round_pairings_diff
+                        ]
+                EventDatabase(event_uniq_id).file.unlink()
+                if cache:
+                    tournament_check.dump_to_file(check_file_path)
+            if tournament_check.diff:
+                print_interactive_error(
+                    f'Tournament [{tournament_check.name}]: {tournament_check.board_error_count} error(s) found on {tournament_check.round_error_count} round(s) (players: {tournament_check.player_count}).'
+                )
+                for round_, round_diff in tournament_check.diff.items():
+                    read_board_strings: list[str] = []
+                    expected_board_strings: list[str] = []
+                    for board_diff in round_diff:
+                        read_board_strings.append(
+                            str(board_diff.read_board) if board_diff.read_board else '-'
+                        )
+                        expected_board_strings.append(
+                            str(board_diff.expected_board)
+                            if board_diff.expected_board
+                            else '-'
+                        )
+                    read_boards_len = max(len(s) for s in read_board_strings)
+                    expected_boards_len = max(len(s) for s in expected_board_strings)
+                    print_interactive_warning(
+                        f'Round | {"Read".ljust(read_boards_len)} | Expected'
+                    )
+                    for read_board_string, expected_board_string in zip(
+                        read_board_strings, expected_board_strings
+                    ):
+                        print_interactive_warning(
+                            f'{str(round_).rjust(2, "0").rjust(5)} | {read_board_string.ljust(read_boards_len)} | {expected_board_string.ljust(expected_boards_len)}'
+                        )
+            else:
+                print_interactive_success(
+                    f'Tournament [{tournament_check.name}]: no errors (rounds: {tournament_check.rounds}, players: {tournament_check.player_count}).'
+                )
+
+            return tournament_check
+        except BaseException as be:
+            print_interactive_error(f'Exception: {be}')
+            check_file_path.unlink(missing_ok=True)
+            raise

--- a/src/data/pairings/checkers.py
+++ b/src/data/pairings/checkers.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Self
+from typing import Optional
 
 from common.logger import (
     get_logger,
@@ -31,26 +31,34 @@ class CheckerPlayer:
     def from_object(
         cls,
         player: Player,
-    ) -> Self:
-        return CheckerPlayer(
-            player.id,
-            player.last_name,
-            player.first_name,
-            player.rating,
-            player.points,
+    ) -> Optional['CheckerPlayer']:
+        return (
+            CheckerPlayer(
+                player.id,
+                player.last_name,
+                player.first_name,
+                player.rating,
+                player.points or 0.0,
+            )
+            if player
+            else None
         )
 
     @classmethod
     def from_dict(
         cls,
         d: dict,
-    ) -> Self:
-        return CheckerPlayer(
-            d['id'],
-            d['last_name'],
-            d['first_name'],
-            d['rating'],
-            d['points'],
+    ) -> Optional['CheckerPlayer']:
+        return (
+            CheckerPlayer(
+                d['id'],
+                d['last_name'],
+                d['first_name'],
+                d['rating'],
+                d['points'],
+            )
+            if d
+            else None
         )
 
     @property
@@ -69,65 +77,77 @@ class CheckerPlayer:
 
 @dataclass
 class CheckerBoard:
-    id: int | None
+    id: int
     white: CheckerPlayer | None
     black: CheckerPlayer | None
 
     @classmethod
     def from_object(
         cls,
-        board: Board,
-    ) -> Self:
-        return CheckerBoard(
-            board.id,
-            CheckerPlayer.from_object(board.white_player),
-            CheckerPlayer.from_object(board.black_player),
+        board: Board | None,
+    ) -> Optional['CheckerBoard']:
+        return (
+            CheckerBoard(
+                board.id,
+                CheckerPlayer.from_object(board.white_player)
+                if board.white_player
+                else None,
+                CheckerPlayer.from_object(board.black_player)
+                if board.black_player
+                else None,
+            )
+            if board
+            else None
         )
 
     @classmethod
     def from_dict(
         cls,
         d: dict,
-    ) -> Self:
-        return CheckerBoard(
-            d['id'],
-            CheckerPlayer.from_dict(d['white']),
-            CheckerPlayer.from_dict(d['black']),
+    ) -> Optional['CheckerBoard']:
+        return (
+            CheckerBoard(
+                d['id'],
+                CheckerPlayer.from_dict(d['white']),
+                CheckerPlayer.from_dict(d['black']),
+            )
+            if d
+            else None
         )
 
     @property
     def to_dict(self) -> dict:
         return {
             'id': self.id,
-            'white': self.white.to_dict,
-            'black': self.black.to_dict,
+            'white': self.white.to_dict if self.white else None,
+            'black': self.black.to_dict if self.black else None,
         }
 
     def __str__(self):
-        return f'{self.id:03d}. {self.white} vs {self.black}'
+        return f'{self.id:03d}. {self.white if self.white else "-"} vs {self.black if self.black else "-"}'
 
 
 @dataclass
 class BoardDiff:
-    read_board: CheckerBoard
-    expected_board: CheckerBoard
+    read_board: CheckerBoard | None
+    expected_board: CheckerBoard | None
 
     @classmethod
     def from_objects(
         cls,
-        read_board: Board,
-        expected_board: Board,
-    ) -> Self:
+        read_board: Board | None,
+        expected_board: Board | None,
+    ) -> 'BoardDiff':
         return BoardDiff(
-            CheckerBoard.from_object(read_board),
-            CheckerBoard.from_object(expected_board),
+            CheckerBoard.from_object(read_board) if read_board else None,
+            CheckerBoard.from_object(expected_board) if expected_board else None,
         )
 
     @classmethod
     def from_dict(
         cls,
         d: dict,
-    ) -> Self:
+    ) -> 'BoardDiff':
         return BoardDiff(
             CheckerBoard.from_dict(d['read_board']),
             CheckerBoard.from_dict(d['expected_board']),
@@ -136,27 +156,10 @@ class BoardDiff:
     @property
     def to_dict(self) -> dict:
         return {
-            'read_board': self.read_board.to_dict,
-            'expected_board': self.expected_board.to_dict,
-        }
-
-
-class TournamentDiff(dict[int, list[BoardDiff]]):
-    @classmethod
-    def from_dict(
-        cls,
-        d: dict,
-    ) -> Self:
-        return {
-            round_: [BoardDiff.from_dict(board) for board in round_board_diffs]
-            for round_, round_board_diffs in d.items()
-        }
-
-    @property
-    def to_dict(self) -> dict:
-        return {
-            round_: [round_board_diff.to_dict for round_board_diff in round_board_diffs]
-            for round_, round_board_diffs in self.items()
+            'read_board': self.read_board.to_dict if self.read_board else None,
+            'expected_board': self.expected_board.to_dict
+            if self.expected_board
+            else None,
         }
 
 
@@ -165,37 +168,42 @@ class TournamentCheck:
     name: str
     player_count: int
     rounds: int
-    diff: TournamentDiff
+    diff: dict[int, list[BoardDiff]]
 
     @classmethod
     def from_object(
         cls,
         tournament: Tournament,
-    ) -> Self:
+    ) -> 'TournamentCheck':
         return TournamentCheck(
             tournament.name,
             tournament.player_count,
             tournament.rounds,
-            TournamentDiff(),
+            {},
         )
 
     @classmethod
     def from_dict(
         cls,
         d: dict,
-    ) -> Self:
+    ) -> 'TournamentCheck':
         return TournamentCheck(
             d['name'],
             d['player_count'],
             d['rounds'],
-            TournamentDiff.from_dict(d['diff']),
+            {
+                round_: [
+                    BoardDiff.from_dict(board_diff) for board_diff in round_board_diffs
+                ]
+                for round_, round_board_diffs in d['diff'].items()
+            },
         )
 
     @classmethod
     def load_from_file(
         cls,
         input_file: Path,
-    ) -> Self:
+    ) -> 'TournamentCheck':
         with open(input_file, 'r', encoding='utf-8') as file:
             return TournamentCheck.from_dict(json.load(file))
 
@@ -205,7 +213,12 @@ class TournamentCheck:
             'name': self.name,
             'player_count': self.player_count,
             'rounds': self.rounds,
-            'diff': self.diff.to_dict,
+            'diff': {
+                round_: [
+                    round_board_diff.to_dict for round_board_diff in round_board_diffs
+                ]
+                for round_, round_board_diffs in self.diff.items()
+            },
         }
 
     def dump_to_file(

--- a/src/data/pairings/engines.py
+++ b/src/data/pairings/engines.py
@@ -13,14 +13,10 @@ from common.exception import SharlyChessException
 from common.i18n import _
 from common.logger import (
     get_logger,
-    print_interactive_info,
-    print_interactive_error,
-    print_interactive_success,
 )
 from common.tool_installer import BbpPairingsInstaller
 from data.board import Board
 from data.pairings.settings import BergerNumbersSetting
-from database.sqlite.event.event_database import EventDatabase
 from database.sqlite.event.event_store import StoredBoard
 from utils import StaticUtils
 from utils.enum import TrfType, Result
@@ -290,120 +286,6 @@ class BbpPairings(PairingEngine):
             boards = self._boards_from_file(pairing_file, tournament, round_, False)
 
         return history_data, boards
-
-    def generate_tournament(
-        self,
-        trf_file_path: Path,
-        random_seed: int | None = None,
-        overwrite: bool = True,
-    ) -> bool:
-        """Generates a random tournament."""
-        if not overwrite and trf_file_path.exists():
-            print_interactive_info(f'TRF file {trf_file_path} previously generated.')
-            return True
-        trf_file_path.parent.mkdir(parents=True, exist_ok=True)
-        cmd: list[str] = [
-            str(self.executable_path),
-            # dutch pairing
-            '--dutch',
-            # generate
-            '-g',
-            # output file
-            '-o',
-            str(trf_file_path),
-        ]
-        if random_seed:
-            cmd += [
-                # random seed
-                '-s',
-                str(random_seed),
-            ]
-        result = StaticUtils.run_process(
-            cmd,
-            capture_output=True,
-            encoding='utf-8',
-        )
-        if result.returncode:
-            print_interactive_error(
-                f'BbpPairings random tournament generator failed with status {result.returncode}.'
-            )
-            print_interactive_error(f'stdout: {result.stdout}')
-            print_interactive_error(f'stderr: {result.stderr}')
-            return False
-        print_interactive_success(
-            f'BbpPairings random tournament generator created TRF file {trf_file_path}.'
-        )
-        return True
-
-    @classmethod
-    def _diff_display(
-        cls, pairing_diff: list[tuple[Board | None, Board | None]]
-    ) -> str:
-        message = f'Real boards{"":<19}Expected boards\n'
-        for real_board, expected_board in pairing_diff:
-            message += f'{cls._board_display(real_board)}   {cls._board_display(expected_board)}\n'
-        return message
-
-    @staticmethod
-    def _board_display(board: Board | None) -> str:
-        if not board:
-            return f'{"":<14} - {"":<10}'
-        return (
-            f'{board.index:>2}. {board.white_player.full_name:<10}'
-            f' - {getattr(board.black_player, "full_name", ""):<10}'
-        )
-
-    def check_tournament(
-        self,
-        trf_input_file_path: Path,
-        overwrite: bool = True,
-    ) -> bool:
-        """Checks a tournament."""
-        result_file_path = trf_input_file_path.with_suffix('.txt')
-        if result_file_path.exists():
-            if not overwrite:
-                print_interactive_info(
-                    f'Result file {result_file_path} previously generated.'
-                )
-                with open(result_file_path, 'r') as f:
-                    result = f.read()
-                if result:
-                    print_interactive_error(result)
-                    return False
-                else:
-                    return True
-            result_file_path.unlink()
-
-        from data.input_output.tournament_importer_options import FileOption
-        from data.input_output.tournament_importers import TrfTournamentImporter
-        from data.loader import EventLoader
-
-        event_uniq_id: str = 'dummy'
-        EventDatabase(event_uniq_id).create()
-        event = EventLoader().load_event(event_uniq_id)
-        tournament_id = TrfTournamentImporter(
-            [
-                FileOption(trf_input_file_path),
-            ]
-        ).load_tournament(event)
-        event = EventLoader().load_event(event_uniq_id)
-        tournament = event.tournaments_by_id[tournament_id]
-        for round_ in range(1, tournament.rounds + 1):
-            if diff := tournament.pairing_variation.engine.pairings_diff(
-                tournament,
-                round_,
-                ignore_order=True,
-            ):
-                result = f'Round {round_}: {len(diff)} differences\n\n{self._diff_display(diff)}'
-                print_interactive_error(result)
-                with open(result_file_path, 'w') as f:
-                    f.write(result)
-                return False
-        print_interactive_error(
-            f'Pairings are correct for the {tournament.rounds} rounds.'
-        )
-        result_file_path.touch()
-        return True
 
 
 class RoundRobinPairingEngine(PairingEngine, ABC):

--- a/src/data/pairings/engines.py
+++ b/src/data/pairings/engines.py
@@ -11,7 +11,12 @@ from typing_extensions import override
 from common import TMP_DIR
 from common.exception import SharlyChessException
 from common.i18n import _
-from common.logger import get_logger
+from common.logger import (
+    get_logger,
+    print_interactive_info,
+    print_interactive_error,
+    print_interactive_success,
+)
 from common.tool_installer import BbpPairingsInstaller
 from data.board import Board
 from data.pairings.settings import BergerNumbersSetting
@@ -283,7 +288,90 @@ class BbpPairings(PairingEngine):
         with open(pairings_file_path, encoding='utf-8') as pairing_file:
             boards = self._boards_from_file(pairing_file, tournament, round_, False)
 
-        return (history_data, boards)
+        return history_data, boards
+
+    def generate_tournament(
+        self,
+        trf_file_path: Path,
+        random_seed: int | None = None,
+        overwrite: bool = True,
+    ) -> bool:
+        """Generates a random tournament."""
+        if not overwrite and trf_file_path.exists():
+            print_interactive_info(f'TRF file {trf_file_path} previously generated.')
+            return True
+        trf_file_path.parent.mkdir(parents=True, exist_ok=True)
+        cmd: list[str] = [
+            self.executable_path,
+            # dutch pairing
+            '--dutch',
+            # generate
+            '-g',
+            # output file
+            '-o',
+            trf_file_path,
+        ]
+        if random_seed:
+            cmd += [
+                # random seed
+                '-s',
+                str(random_seed),
+            ]
+        result = StaticUtils.run_process(
+            cmd,
+            capture_output=True,
+            encoding='utf-8',
+        )
+        if result.returncode:
+            print_interactive_error(
+                f'BbpPairings random tournament generator failed with status {result.returncode}.'
+            )
+            print_interactive_error(f'stdout: {result.stdout}')
+            print_interactive_error(f'stderr: {result.stderr}')
+            return False
+        print_interactive_success(
+            f'BbpPairings random tournament generator created TRF file {trf_file_path}.'
+        )
+        return True
+
+    def check_tournament(
+        self,
+        input_file_path: Path,
+        check_list_file_path: Path,
+        overwrite: bool = True,
+    ) -> bool:
+        """Checks a tournament."""
+        if not overwrite and check_list_file_path.exists():
+            print_interactive_info(f'File {check_list_file_path} previously generated.')
+            return True
+        check_list_file_path.parent.mkdir(parents=True, exist_ok=True)
+        result = StaticUtils.run_process(
+            [
+                self.executable_path,
+                # dutch pairing
+                '--dutch',
+                # input file
+                input_file_path,
+                # check
+                '-c',
+                # check-list file
+                '-l',
+                check_list_file_path,
+            ],
+            capture_output=True,
+            encoding='utf-8',
+        )
+        if result.returncode:
+            print_interactive_error(
+                f'BbpPairings checker failed with status {result.returncode}.'
+            )
+            print_interactive_error(f'stdout: {result.stdout}')
+            print_interactive_error(f'stderr: {result.stderr}')
+            return False
+        print_interactive_success(
+            f'BbpPairings checker created check-list file {check_list_file_path}.'
+        )
+        return True
 
 
 class RoundRobinPairingEngine(PairingEngine, ABC):

--- a/src/data/pairings/engines.py
+++ b/src/data/pairings/engines.py
@@ -381,11 +381,13 @@ class BbpPairings(PairingEngine):
         event_uniq_id: str = 'dummy'
         EventDatabase(event_uniq_id).create()
         event = EventLoader().load_event(event_uniq_id)
-        tournament = TrfTournamentImporter(
+        tournament_id = TrfTournamentImporter(
             [
                 FileOption(trf_input_file_path),
             ]
         ).load_tournament(event)
+        event = EventLoader().load_event(event_uniq_id)
+        tournament = event.tournaments_by_id[tournament_id]
         for round_ in range(1, tournament.rounds + 1):
             if diff := tournament.pairing_variation.engine.pairings_diff(
                 tournament,

--- a/src/data/pairings/engines.py
+++ b/src/data/pairings/engines.py
@@ -20,6 +20,7 @@ from common.logger import (
 from common.tool_installer import BbpPairingsInstaller
 from data.board import Board
 from data.pairings.settings import BergerNumbersSetting
+from database.sqlite.event.event_database import EventDatabase
 from database.sqlite.event.event_store import StoredBoard
 from utils import StaticUtils
 from utils.enum import TrfType, Result
@@ -334,43 +335,72 @@ class BbpPairings(PairingEngine):
         )
         return True
 
+    @classmethod
+    def _diff_display(
+        cls, pairing_diff: list[tuple[Board | None, Board | None]]
+    ) -> str:
+        message = f'Real boards{"":<19}Expected boards\n'
+        for real_board, expected_board in pairing_diff:
+            message += f'{cls._board_display(real_board)}   {cls._board_display(expected_board)}\n'
+        return message
+
+    @staticmethod
+    def _board_display(board: Board | None) -> str:
+        if not board:
+            return f'{"":<14} - {"":<10}'
+        return (
+            f'{board.index:>2}. {board.white_player.full_name:<10}'
+            f' - {getattr(board.black_player, "full_name", ""):<10}'
+        )
+
     def check_tournament(
         self,
-        input_file_path: Path,
-        check_list_file_path: Path,
+        trf_input_file_path: Path,
         overwrite: bool = True,
     ) -> bool:
         """Checks a tournament."""
-        if not overwrite and check_list_file_path.exists():
-            print_interactive_info(f'File {check_list_file_path} previously generated.')
-            return True
-        check_list_file_path.parent.mkdir(parents=True, exist_ok=True)
-        result = StaticUtils.run_process(
+        result_file_path = trf_input_file_path.with_suffix('.txt')
+        if result_file_path.exists():
+            if not overwrite:
+                print_interactive_info(
+                    f'Result file {result_file_path} previously generated.'
+                )
+                with open(result_file_path, 'r') as f:
+                    result = f.read()
+                if result:
+                    print_interactive_error(result)
+                    return False
+                else:
+                    return True
+            result_file_path.unlink()
+
+        from data.input_output.tournament_importer_options import FileOption
+        from data.input_output.tournament_importers import TrfTournamentImporter
+        from data.loader import EventLoader
+
+        event_uniq_id: str = 'dummy'
+        EventDatabase(event_uniq_id).create()
+        event = EventLoader().load_event(event_uniq_id)
+        tournament = TrfTournamentImporter(
             [
-                self.executable_path,
-                # dutch pairing
-                '--dutch',
-                # input file
-                str(input_file_path),
-                # check
-                '-c',
-                # check-list file
-                '-l',
-                str(check_list_file_path),
-            ],
-            capture_output=True,
-            encoding='utf-8',
+                FileOption(trf_input_file_path),
+            ]
+        ).load_tournament(event)
+        for round_ in range(1, tournament.rounds + 1):
+            if diff := tournament.pairing_variation.engine.pairings_diff(
+                tournament,
+                round_,
+                ignore_order=True,
+            ):
+                result = f'Round {round_}: {len(diff)} differences\n\n{self._diff_display(diff)}'
+                print_interactive_error(result)
+                with open(result_file_path, 'w') as f:
+                    f.write(result)
+                return False
+        print_interactive_error(
+            f'Pairings are correct for the {tournament.rounds} rounds.'
         )
-        if result.returncode:
-            print_interactive_error(
-                f'BbpPairings checker failed with status {result.returncode}.'
-            )
-            print_interactive_error(f'stdout: {result.stdout}')
-            print_interactive_error(f'stderr: {result.stderr}')
-            return False
-        print_interactive_success(
-            f'BbpPairings checker created check-list file {check_list_file_path}.'
-        )
+        result_file_path.touch()
         return True
 
 

--- a/src/data/pairings/engines.py
+++ b/src/data/pairings/engines.py
@@ -302,7 +302,7 @@ class BbpPairings(PairingEngine):
             return True
         trf_file_path.parent.mkdir(parents=True, exist_ok=True)
         cmd: list[str] = [
-            self.executable_path,
+            str(self.executable_path),
             # dutch pairing
             '--dutch',
             # generate

--- a/src/data/pairings/engines.py
+++ b/src/data/pairings/engines.py
@@ -309,7 +309,7 @@ class BbpPairings(PairingEngine):
             '-g',
             # output file
             '-o',
-            trf_file_path,
+            str(trf_file_path),
         ]
         if random_seed:
             cmd += [
@@ -351,12 +351,12 @@ class BbpPairings(PairingEngine):
                 # dutch pairing
                 '--dutch',
                 # input file
-                input_file_path,
+                str(input_file_path),
                 # check
                 '-c',
                 # check-list file
                 '-l',
-                check_list_file_path,
+                str(check_list_file_path),
             ],
             capture_output=True,
             encoding='utf-8',

--- a/src/data/pairings/generators.py
+++ b/src/data/pairings/generators.py
@@ -16,7 +16,6 @@ class BbpPairingsGenerator(BbpPairings):
     def generate_tournament(
         self,
         trf_file_path: Path,
-        random_seed: int | None = None,
         cache: bool = False,
     ) -> bool:
         """Generates a random tournament and dumps to file
@@ -31,24 +30,17 @@ class BbpPairingsGenerator(BbpPairings):
             else:
                 trf_file_path.unlink(missing_ok=True)
             trf_file_path.parent.mkdir(parents=True, exist_ok=True)
-            cmd: list[str] = [
-                str(self.executable_path),
-                # dutch pairing
-                '--dutch',
-                # generate
-                '-g',
-                # output file
-                '-o',
-                str(trf_file_path),
-            ]
-            if random_seed:
-                cmd += [
-                    # random seed
-                    '-s',
-                    str(random_seed),
-                ]
             result = StaticUtils.run_process(
-                cmd,
+                [
+                    str(self.executable_path),
+                    # dutch pairing
+                    '--dutch',
+                    # generate
+                    '-g',
+                    # output file
+                    '-o',
+                    str(trf_file_path),
+                ],
                 capture_output=True,
                 encoding='utf-8',
             )

--- a/src/data/pairings/generators.py
+++ b/src/data/pairings/generators.py
@@ -29,6 +29,9 @@ class BbpPairingsGenerator(BbpPairings):
                     return True
             else:
                 trf_file_path.unlink(missing_ok=True)
+            print_interactive_info(
+                f'Generating random tournament to TRF file {trf_file_path.name}...'
+            )
             trf_file_path.parent.mkdir(parents=True, exist_ok=True)
             result = StaticUtils.run_process(
                 [

--- a/src/data/pairings/generators.py
+++ b/src/data/pairings/generators.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+from common.logger import (
+    get_logger,
+    print_interactive_info,
+    print_interactive_error,
+    print_interactive_success,
+)
+from data.pairings.engines import BbpPairings
+from utils import StaticUtils
+
+logger = get_logger()
+
+
+class BbpPairingsGenerator(BbpPairings):
+    def generate_tournament(
+        self,
+        trf_file_path: Path,
+        random_seed: int | None = None,
+        cache: bool = False,
+    ) -> bool:
+        """Generates a random tournament and dumps to file
+        in TRFX format, returns True on success, False otherwise."""
+        try:
+            if cache:
+                if trf_file_path.exists():
+                    print_interactive_info(
+                        f'TRF file {trf_file_path.name} read from cache.'
+                    )
+                    return True
+            else:
+                trf_file_path.unlink(missing_ok=True)
+            trf_file_path.parent.mkdir(parents=True, exist_ok=True)
+            cmd: list[str] = [
+                str(self.executable_path),
+                # dutch pairing
+                '--dutch',
+                # generate
+                '-g',
+                # output file
+                '-o',
+                str(trf_file_path),
+            ]
+            if random_seed:
+                cmd += [
+                    # random seed
+                    '-s',
+                    str(random_seed),
+                ]
+            result = StaticUtils.run_process(
+                cmd,
+                capture_output=True,
+                encoding='utf-8',
+            )
+            if result.returncode:
+                print_interactive_error(
+                    f'BbpPairings random tournament generator failed with status {result.returncode}.'
+                )
+                print_interactive_error(f'stdout: {result.stdout}')
+                print_interactive_error(f'stderr: {result.stderr}')
+                return False
+            print_interactive_success(
+                f'BbpPairings random tournament generator created TRF file {trf_file_path.name}.'
+            )
+            return True
+        except BaseException as be:
+            print_interactive_error(f'Exception: {be}')
+            trf_file_path.unlink(missing_ok=True)
+            raise

--- a/src/plugins/chessevent/tournament_importer/importer.py
+++ b/src/plugins/chessevent/tournament_importer/importer.py
@@ -156,7 +156,7 @@ class ChessEventTournamentImporter(TournamentImporter):
         self,
         event: Event,
         tournament: Tournament | None = None,
-    ) -> Tournament:
+    ) -> int:
         try:
             return super().load_tournament(event, tournament)
         except ChessEventStatusError as error:

--- a/src/sharly_chess.py
+++ b/src/sharly_chess.py
@@ -178,11 +178,12 @@ try:
                 )
                 sys.exit(1)
             trf_input_file_path = Path(args.input_file)
-        from data.pairings.engines import BbpPairings
 
-        bbp_pairings: BbpPairings = BbpPairings()
+        from data.pairings.checkers import BbpPairingsChecker
+        from data.pairings.generators import BbpPairingsGenerator
+
         if args.generate_tournament:
-            bbp_pairings.generate_tournament(
+            BbpPairingsGenerator().generate_tournament(
                 trf_input_file_path,
                 args.random_seed,
             )
@@ -192,9 +193,8 @@ try:
                     f'TRF input file [{trf_input_file_path}] not found, exiting.'
                 )
                 sys.exit(1)
-            bbp_pairings.check_tournament(
-                trf_input_file_path,
-            )
+            BbpPairingsChecker().check_tournament(trf_input_file_path)
+
         sys.exit(0)
 
     port = args.port or None

--- a/src/sharly_chess.py
+++ b/src/sharly_chess.py
@@ -1,7 +1,10 @@
 import os
 import warnings
+from pathvalidate import validate_filepath, ValidationError
 import platform
 import sys
+
+from data.pairings.engines import BbpPairings
 
 # Nuclear option: Override warnings.warn to block specific messages
 # warnings.filterwarnings simply would not work
@@ -78,10 +81,10 @@ try:
     arguments = init_script()
 
     from common import DEVEL_ENV, TEST_ENV
-    from common.i18n import _
     from common.logger import (
         get_logger,
         print_interactive_warning,
+        print_interactive_error,
     )
     from gui.server_gui_toga import SharlyChessServerToga
     from web.server_engine import ServerEngine
@@ -110,10 +113,111 @@ try:
             action='store_true',
             help='Force console/CLI mode (default is GUI for bundled apps)',
         )
+    parser.add_argument(
+        '-g',
+        '--generate-tournament',
+        action='store_true',
+        help='generate a random tournament',
+    )
+    parser.add_argument(
+        '-s',
+        '--random-seed',
+        type=int,
+        help='the random seed to use (to reproduce tournament generation)',
+    )
+    parser.add_argument(
+        '-c',
+        '--check-tournament',
+        action='store_true',
+        help='generate a random tournament',
+    )
+    parser.add_argument(
+        'input_file',
+        type=str,
+        help='the input file',
+        nargs='?',
+    )
+    parser.add_argument(
+        '--check-list-file',
+        type=str,
+        help='the check-list file',
+    )
+    parser.add_argument(
+        '-o',
+        '--output-file',
+        type=str,
+        help='the output file',
+    )
+
     args = parser.parse_args(arguments)
 
     if args.server:
-        print_interactive_warning(_('Argument --server is deprecated, ignored.'))
+        print_interactive_warning('Argument --server is deprecated, ignored.')
+
+    if args.generate_tournament or args.check_tournament:
+        trf_input_file_path: Path
+        if args.generate_tournament:
+            if not args.output_file:
+                print_interactive_error('Argument --output-file is needed, exiting.')
+                sys.exit(1)
+            try:
+                validate_filepath(args.output_file)
+            except ValidationError:
+                print_interactive_error(
+                    f'Invalid output file [{args.output_file}], exiting.'
+                )
+                sys.exit(1)
+            trf_input_file_path = Path(args.output_file)
+            if args.check_tournament:
+                if args.input_file:
+                    print_interactive_error(
+                        'Input file not needed with argument --generate-tournament, ignored.'
+                    )
+        else:
+            if not args.input_file:
+                print_interactive_error('Input file is required, exiting.')
+                sys.exit(1)
+            try:
+                validate_filepath(args.input_file)
+            except ValidationError:
+                print_interactive_error(
+                    f'Invalid input file [{args.input_file}], exiting.'
+                )
+                sys.exit(1)
+            trf_input_file_path = Path(args.input_file)
+        bbp_pairings: BbpPairings = BbpPairings()
+        if args.generate_tournament:
+            bbp_pairings.generate_tournament(
+                trf_input_file_path,
+                args.random_seed,
+            )
+        if args.check_tournament:
+            if not trf_input_file_path.exists():
+                print_interactive_error(
+                    f'TRF input file [{trf_input_file_path}] not found, exiting.'
+                )
+                sys.exit(1)
+            check_list_file_path: Path
+            if args.check_list_file:
+                check_list_file_path = Path(args.check_list_file)
+                try:
+                    validate_filepath(args.check_list_file)
+                except ValidationError:
+                    print_interactive_error(
+                        f'Invalid check-list file [{args.check_list_file}], exiting.'
+                    )
+                    sys.exit(1)
+            else:
+                check_list_file_path = trf_input_file_path.with_suffix('.list')
+                print_interactive_warning(
+                    f'Check-list file not set, using default [{check_list_file_path}].'
+                )
+            bbp_pairings: BbpPairings = BbpPairings()
+            bbp_pairings.check_tournament(
+                trf_input_file_path,
+                check_list_file_path,
+            )
+        sys.exit(0)
 
     port = args.port or None
     debug = args.debug if DEVEL_ENV else False

--- a/src/sharly_chess.py
+++ b/src/sharly_chess.py
@@ -136,11 +136,6 @@ try:
         nargs='?',
     )
     parser.add_argument(
-        '--check-list-file',
-        type=str,
-        help='the check-list file',
-    )
-    parser.add_argument(
         '-o',
         '--output-file',
         type=str,
@@ -197,25 +192,8 @@ try:
                     f'TRF input file [{trf_input_file_path}] not found, exiting.'
                 )
                 sys.exit(1)
-            check_list_file_path: Path
-            if args.check_list_file:
-                check_list_file_path = Path(args.check_list_file)
-                try:
-                    validate_filepath(args.check_list_file)
-                except ValidationError:
-                    print_interactive_error(
-                        f'Invalid check-list file [{args.check_list_file}], exiting.'
-                    )
-                    sys.exit(1)
-            else:
-                check_list_file_path = trf_input_file_path.with_suffix('.list')
-                print_interactive_warning(
-                    f'Check-list file not set, using default [{check_list_file_path}].'
-                )
-            bbp_pairings: BbpPairings = BbpPairings()
             bbp_pairings.check_tournament(
                 trf_input_file_path,
-                check_list_file_path,
             )
         sys.exit(0)
 

--- a/src/sharly_chess.py
+++ b/src/sharly_chess.py
@@ -4,8 +4,6 @@ from pathvalidate import validate_filepath, ValidationError
 import platform
 import sys
 
-from data.pairings.engines import BbpPairings
-
 # Nuclear option: Override warnings.warn to block specific messages
 # warnings.filterwarnings simply would not work
 _original_warn = warnings.warn
@@ -185,6 +183,8 @@ try:
                 )
                 sys.exit(1)
             trf_input_file_path = Path(args.input_file)
+        from data.pairings.engines import BbpPairings
+
         bbp_pairings: BbpPairings = BbpPairings()
         if args.generate_tournament:
             bbp_pairings.generate_tournament(

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -990,15 +990,17 @@ class TournamentAdminController(BaseEventAdminController):
         importer = importer_type(importer_options)
         try:
             importer.validate_options(event)
-            tournament = importer.load_tournament(event, web_context.admin_tournament)
-            Message.success(
-                request,
-                _('Tournament [{tournament}] successfully imported.').format(
-                    tournament=tournament.uniq_id
-                ),
+            tournament_id = importer.load_tournament(
+                event, web_context.admin_tournament
             )
             web_context = TournamentAdminWebContext(
                 request, tournament_id, reload_event=True
+            )
+            Message.success(
+                request,
+                _('Tournament [{tournament}] successfully imported.').format(
+                    tournament=web_context.get_admin_tournament().name
+                ),
             )
             return self._admin_event_tournaments_render(web_context)
         except OptionError as error:


### PR DESCRIPTION
## Generate tournament pairings

Generate a random TRF file ``test.trf``:

`sharly-chess-<version>.exe --generate-tournament --output-file=test.trf`
or
`sharly-chess-<version>.exe -g -o test.trf`

Generate a random TRF file ``test.trf`` using a random seed (to easily reproduce the tests):

`sharly-chess-<version>.exe --generate-tournament --output-file=test.trf --random-seed=12345678`
or
`sharly-chess-<version>.exe -g -o test.trf -s 12345678`

## Check tournament pairings

Check the pairings of a TRF file ``test.trf`` (automatically writes file ``test.list``):

`sharly-chess-<version>.exe --check-tournament test.trf`
or
`sharly-chess-<version>.exe -c test.trf`

Check the pairings of a TRF file ``test.trf`` (write to file ``test2.list``):

`sharly-chess-<version>.exe --check-tournament --check-list-file=test2.list test.trf`
or
`sharly-chess-<version>.exe -c -l test2.list test.trf`

## Generate and check tournament pairings

Generate a random TRF file ``test.trf`` and check it:

`sharly-chess-<version>.exe --generate-tournament --output-file=test.trf --check-tournament`
or
`sharly-chess-<version>.exe -g -o test.trf -c`

## Generate and check 5000 tournament pairings at once

Use script ``/scripts/fide/generate_and_check_tournaments.py``.