### PR TITLE
Rename NormReportPrintDocument.static_id

### DIFF
--- a/src/data/print_documents/documents.py
+++ b/src/data/print_documents/documents.py
@@ -997,7 +997,7 @@ class StatisticsPrintDocument(PrintDocument):
 class NormReportPrintDocument(PrintDocument):
     @staticmethod
     def static_id() -> str:
-        return 'norm_report'
+        return 'norm-report'
 
     @staticmethod
     def static_name() -> str:


### PR DESCRIPTION
Use the same naming convention as the other print documents