### PR TITLE
Extend Playwright's `expect` timeouts

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,7 +17,7 @@ from database.sqlite.event.event_store import (
     StoredEvent,
     StoredTournament,
 )
-from playwright.sync_api import Page, Locator, APIRequestContext, APIResponse
+from playwright.sync_api import Page, Locator, APIRequestContext, APIResponse, expect
 
 from plugins.ffe.ffe_tournament_importers import PapiJsonTournamentImporter
 from utils.enum import ScreenType
@@ -30,6 +30,11 @@ class TestConfig:
     TEST_HOST = '127.0.0.1'  # Use IP instead of localhost
     TEST_PORT = 9000
     TEST_TIMEOUT = 30  # seconds to wait for server startup
+
+    # Global timeout for all global expect calls.
+    # NOTE(Amaras): I set to 10s = 10_000 ms because we often had false-positive failures.
+    # Hopefully 10s is long enough to ensure all failures are real failure cases.
+    expect.set_options(timeout=10_000)
 
     # Test data configuration
     TEST_DATA_DIR = Path(__file__).parent / 'tmp'


### PR DESCRIPTION
Due to the number of false-positive test failures, sometimes requiring 2 or 3 runs to validate a run.

This gives all expect a 10-second timeout, instead of the default 5-second timeout