### PR TITLE
Fix the pairings unsafe safety mode showing unexpectedly

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,7 @@ English version below
 - Utilisation des classement _FIDE_ pour les évènements _FFE_ (3.2.3)
 - Lors de l'ajout de rondes supplémentaires, ajout de forfaits aux joueur·euses ayant quitté le tournoi pour ces nouvelles rondes (3.2.3)
 - Correction de problèmes divers sur les tournois Toutes-Rondes (3.2.4)
+- Correction de l'affichage du mode non-sécurisé (3.2.4)
 
 ## Écrans
 
@@ -89,6 +90,7 @@ English version below
 - Force _FIDE_ rating for _FFE_ events (3.2.3)
 - When adding rounds, Add ZPBs to withdraw players for these new rounds (3.2.3)
 - Fixed various issues regarding the Round-Robin tournaments (3.2.4)
+- Fixed the display of the unsafe mode (3.2.4)
 
 ## Screens
 

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -760,7 +760,7 @@ msgid "Black pairings are supposed to have an opponent"
 msgstr "Les appariements avec les Noirs sont censés avoir un·e adversaire."
 
 msgid "Black wins"
-msgstr "Victoires avec les Noirs"
+msgstr "Victoire Noirs"
 
 msgid "Blitz"
 msgstr "Blitz"

--- a/src/web/controllers/admin/pairings_admin_controller.py
+++ b/src/web/controllers/admin/pairings_admin_controller.py
@@ -189,7 +189,10 @@ class PairingsAdminWebContext(BaseEventAdminWebContext):
             )
 
         self.safety_mode = SafetyMode.SAFE
-        if tournament_id:
+        if not tournament_id:
+            # Reset the session safety mode if coming from another page
+            SessionHandler.set_session_admin_pairings_page_identifier(request, None)
+        else:
             page_identifier = PageIdentifier(
                 event.uniq_id, tournament_id, self.admin_round
             )

--- a/src/web/session.py
+++ b/src/web/session.py
@@ -1,7 +1,7 @@
 import time
 from contextlib import suppress
 from logging import Logger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from litestar.plugins.htmx import HTMXRequest
 
@@ -507,16 +507,16 @@ class SessionHandler:
 
     @classmethod
     def set_session_admin_pairings_page_identifier(
-        cls, request: HTMXRequest, page_identifier: 'PageIdentifier'
+        cls, request: HTMXRequest, page_identifier: Optional['PageIdentifier']
     ):
         request.session[cls.ADMIN_PAIRINGS_PAGE_IDENTIFIER_KEY] = (
-            page_identifier.to_json()
+            page_identifier.to_json() if page_identifier else None
         )
 
     @classmethod
     def get_session_admin_pairings_page_identifier(
         cls, request: HTMXRequest
-    ) -> 'PageIdentifier | None':
+    ) -> Optional['PageIdentifier']:
         from web.controllers.admin.pairings_admin_controller import PageIdentifier
 
         if page_identifier := request.session.get(


### PR DESCRIPTION
To reproduce before the fix:
- Enable an unsafe mode on the current round of the first tournament
- go to another tab (ex: Tournaments)
- come back (mode appears safe, but session value is unsafe, just not read)
- do any operation (session value is now read, becoming unsafe)

Now: coming back to the Pairings tab resets the safety mode

also:
<img width="320" height="185" alt="image" src="https://github.com/user-attachments/assets/7b3b2906-43b8-4c85-9305-8552f68f2170" />

