### PR TITLE
Fix FFE league player filter of no-league players

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,6 +47,7 @@ English version below
 
 - Support des départages non-compatibles avec _Papi_ lors de l'export _Papi_ et du téléversement _FFE_ (3.2.0)
 - Restauration de la suppression des données de contact des joueur·euses lors du téléversement _FFE_ (3.2.5)
+- Correction du filtre de ligue des joueur·euses (3.2.5)
 
 ## _ChessEvent_
 
@@ -108,6 +109,7 @@ English version below
 
 - Support for _Papi_ incompatible tie-breaks in the _Papi_ export and the _FFE_ upload (3.2.0)
 - Restore player contact data deletion on the _FFE_ upload (3.2.5)
+- Fixed the league player filter (3.2.5)
 
 ## _ChessEvent_
 

--- a/src/plugins/ffe/ffe.py
+++ b/src/plugins/ffe/ffe.py
@@ -245,14 +245,14 @@ class FfePlugin(Plugin):
     def get_player_admin_template_context(
         self, web_context: PlayerAdminWebContext
     ) -> dict[str, Any]:
-        assert web_context.admin_event is not None
-        admin_event: 'Event' = web_context.admin_event
+        event = web_context.get_admin_event()
+        request = web_context.request
 
         # The leagues that will be shown on the league select list
         players_leagues: list[str] = sorted(
             {
                 FFEUtils.get_player_plugin_data(player).league or ''
-                for player in web_context.admin_event.players_by_id.values()
+                for player in event.players_by_id.values()
             }
         )
 
@@ -260,7 +260,7 @@ class FfePlugin(Plugin):
         filter_leagues: list[str] = [
             league
             for league in FFESessionHandler.get_session_admin_players_filter_leagues(
-                web_context.request
+                request
             )
             if league in players_leagues
         ]
@@ -269,7 +269,7 @@ class FfePlugin(Plugin):
         players_licences: list[PlayerFFELicence] = sorted(
             {
                 FFEUtils.get_player_plugin_data(player).ffe_licence
-                for player in admin_event.players_by_id.values()
+                for player in event.players_by_id.values()
             }
         )
         # The licences that will be selected on the licence select list and used to filter the players
@@ -279,14 +279,13 @@ class FfePlugin(Plugin):
             )
         )
 
-        league_counts: Counter[str | None] = Counter[str | None]()
-        for player in web_context.admin_event.players_by_id.values():
-            league_counts[FFEUtils.get_player_plugin_data(player).league] += 1
+        league_counts: Counter[str] = Counter[str]()
+        for player in event.players_by_id.values():
+            league_counts[FFEUtils.get_player_plugin_data(player).league or ''] += 1
 
         licence_counts: Counter[PlayerFFELicence] = Counter[PlayerFFELicence]()
-        for player in web_context.admin_event.players_by_id.values():
+        for player in event.players_by_id.values():
             licence_counts[FFEUtils.get_player_plugin_data(player).ffe_licence] += 1
-
         return {
             'admin_players_leagues': players_leagues,
             'admin_filter_leagues': filter_leagues,
@@ -295,10 +294,10 @@ class FfePlugin(Plugin):
             'ffe_league_counts': league_counts,
             'ffe_licence_counts': licence_counts,
             'admin_players_filter_leagues': FFESessionHandler.get_session_admin_players_filter_leagues(
-                web_context.request
+                request
             ),
             'admin_players_filter_licences': FFESessionHandler.get_session_admin_players_filter_licences(
-                web_context.request
+                request
             ),
         }
 
@@ -551,7 +550,7 @@ class FfePlugin(Plugin):
         filters: list[Callable[[Player], bool]] = []
         if len(filter_leagues) not in (0, len(admin_players_leagues)):
             filters.append(
-                lambda player: FFEUtils.get_player_plugin_data(player).league
+                lambda player: (FFEUtils.get_player_plugin_data(player).league or '')
                 in filter_leagues
             )
         if len(filter_licences) not in (0, len(admin_players_licences)):

--- a/src/plugins/ffe/ffe_event_controller.py
+++ b/src/plugins/ffe/ffe_event_controller.py
@@ -45,11 +45,7 @@ class FfeAdminEventController(BaseEventAdminController):
         if admin_players_filter_leagues is not None:
             FFESessionHandler.set_session_admin_players_filter_leagues(
                 request,
-                [
-                    league
-                    for league in admin_players_filter_leagues
-                    if league  # '' must be ignored
-                ],
+                [league for league in admin_players_filter_leagues if league != '*'],
             )
         elif admin_players_filter_licences is not None:
             FFESessionHandler.set_session_admin_players_filter_licences(

--- a/src/plugins/ffe/ffe_session_handler.py
+++ b/src/plugins/ffe/ffe_session_handler.py
@@ -16,9 +16,7 @@ class FFESessionHandler:
     def get_session_admin_players_filter_leagues(
         cls, request: HTMXRequest
     ) -> list[str]:
-        return [
-            d for d in request.session.get(cls.ADMIN_PLAYERS_FILTER_LEAGUES_KEY, [])
-        ]
+        return request.session.get(cls.ADMIN_PLAYERS_FILTER_LEAGUES_KEY, [])
 
     ADMIN_PLAYERS_FILTER_LICENCES_KEY: str = 'admin_players_filter_licences'
 

--- a/src/plugins/ffe/templates/ffe_player_league_header.html
+++ b/src/plugins/ffe/templates/ffe_player_league_header.html
@@ -18,8 +18,8 @@
                     </button>
                     <ul class="dropdown-menu table-dropdown-menu p-0">
                         {% with name='admin_players_filter_leagues' %}
-                            {# this input is always checked with an empty value (ignored) to be sure to get a list parameter. #}
-                            <input type="hidden" name="{{ name }}" value="" />
+                            {# this input is always checked with a special value (ignored) to be sure to get a list parameter. #}
+                            <input type="hidden" name="{{ name }}" value="*" />
                             <li class="dropdown-item title text-nowrap">
                                 <input
                                     type="checkbox"


### PR DESCRIPTION
empty ffe_league player filter always shows 0, no matter how many players do not have a league. 
filtering by this `(0)` league acts as if no filter was selected