### PR TITLE
Fix `Modified since last upload` message on never uploaded tournaments

### DIFF
--- a/src/plugins/chess_results/chess_results_background_uploader.py
+++ b/src/plugins/chess_results/chess_results_background_uploader.py
@@ -79,9 +79,11 @@ class ChessResultsBackgroundUploader:
                 )
             cls.upload_status_messages[result_id] = result
 
-        if not ChessResultsUtils.resolve_auto_upload(
-            tournament
-        ) and cls.chess_results_upload_needed(tournament):
+        if (
+            not ChessResultsUtils.resolve_auto_upload(tournament)
+            and cls.chess_results_upload_needed(tournament)
+            and result.status != ChessResultsUploadStatus.NEVER
+        ):
             # For manual updates tell the user that the tournament has been modified
             # For auto uploads, schedule_upload should have already an appropriate message
             result = ChessResultsUploadResult(
@@ -170,7 +172,11 @@ class ChessResultsBackgroundUploader:
             return current_result
 
         result_id = cls.result_id(tournament.event.uniq_id, tournament.id)
-        if not force and not ChessResultsUtils.resolve_auto_upload(tournament):
+        if (
+            not force
+            and not ChessResultsUtils.resolve_auto_upload(tournament)
+            and current_result.status != ChessResultsUploadStatus.NEVER
+        ):
             # Auto upload has been disabled since it was scheduled
             cls.upload_status_messages[result_id] = ChessResultsUploadResult(
                 ChessResultsUploadStatus.CHANGED,

--- a/src/plugins/ffe/ffe_background_uploader.py
+++ b/src/plugins/ffe/ffe_background_uploader.py
@@ -83,8 +83,10 @@ class FfeBackgroundUploader:
                 FfeUploadStatus.SETTINGS_ERROR, unavailable_message
             )
             cls.upload_status_messages[result_id] = result
-        elif not FFEUtils.resolve_auto_upload(tournament) and cls.ffe_upload_needed(
-            tournament
+        elif (
+            not FFEUtils.resolve_auto_upload(tournament)
+            and result.status != FfeUploadStatus.NEVER
+            and cls.ffe_upload_needed(tournament)
         ):
             # For manual updates tell the user that the tournament has been modified
             # For auto uploads, schedule_upload should have already an appropriate message
@@ -176,7 +178,11 @@ class FfeBackgroundUploader:
             return current_result
 
         result_id = cls.result_id(tournament.event.uniq_id, tournament.id)
-        if not force and not FFEUtils.resolve_auto_upload(tournament):
+        if (
+            not force
+            and not FFEUtils.resolve_auto_upload(tournament)
+            and current_result.status != FfeUploadStatus.NEVER
+        ):
             # Auto upload has been disabled since it was scheduled
             cls.upload_status_messages[result_id] = FfeUploadResult(
                 FfeUploadStatus.CHANGED,


### PR DESCRIPTION
On new tournaments, you had the message `Modified since last upload`, even when the tournament had never been uploaded. Now: `Tournament not yet uploaded.`