### PR TITLE
Fix blocked state on form validation with select2 open

### DIFF
--- a/src/web/templates/common/js/modals.js
+++ b/src/web/templates/common/js/modals.js
@@ -1,5 +1,7 @@
+let ignoreNextModalClose = false;
 
 function closeModal() {
+    ignoreNextModalClose = false;
     var myModalEl = document.getElementById('modal-wrapper');
     var modal = bootstrap.Modal.getInstance(myModalEl);
     if (modal) {
@@ -64,7 +66,6 @@ window.addEventListener("close_modal", function(event) {
     closeModal()
 });
 
-let ignoreNextModalClose = false;
 var refreshRequested = false;
 
 function requestRefresh() {


### PR DESCRIPTION
To reproduce: on a event form, open the categories select, then click save