### PR TITLE
Fix acceleration groups never editable

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,10 @@
 - Fixed late entries ZPBs (3.4.0)
 - Fixed U0 category displayed in default category set (3.4.2)
 
+## Pairings
+
+- Allow pairing groups to be edited for acceleration systems other than Baku (3.4.3)
+
 ## Printing
 
 - Prize receipts (3.4.0)

--- a/src/plugins/pairing_acceleration/locale/en/LC_MESSAGES/pairing_acceleration.po
+++ b/src/plugins/pairing_acceleration/locale/en/LC_MESSAGES/pairing_acceleration.po
@@ -37,7 +37,7 @@ msgstr ""
 msgid "No acceleration."
 msgstr ""
 
-msgid "Pairing number range of players the group."
+msgid "Pairing number range of players in the group."
 msgstr ""
 
 #, python-format

--- a/src/plugins/pairing_acceleration/locale/fr/LC_MESSAGES/pairing_acceleration.po
+++ b/src/plugins/pairing_acceleration/locale/fr/LC_MESSAGES/pairing_acceleration.po
@@ -37,7 +37,7 @@ msgstr "La valeur maximale doit être supérieure à la valeur minimale."
 msgid "No acceleration."
 msgstr "Pas d'accélération."
 
-msgid "Pairing number range of players the group."
+msgid "Pairing number range of players in the group."
 msgstr "Plage de numéros d'appariement des joueur·euses du groupe."
 
 #, python-format

--- a/src/plugins/pairing_acceleration/templates/pairing_acceleration/group_a.html
+++ b/src/plugins/pairing_acceleration/templates/pairing_acceleration/group_a.html
@@ -1,3 +1,4 @@
+{% set are_groups_editable = admin_tournament.pairing_variation.are_groups_editable %}
 <h4>
     {{ _('Acceleration groups') }}
     <i
@@ -22,12 +23,12 @@
                     'Pairing number range of the group (recommended: %(min)d-%(max)d).',
                     min=recommended[0],
                     max=recommended[1],
-                ) if setting.are_groups_editable else
-                _('Pairing number range of players the group.')
+                ) if are_groups_editable else
+                _('Pairing number range of players in the group.')
             ),
             tooltip_text=admin_tournament.pairing_variation.get_group_a_tooltip(admin_tournament),
             input_tooltip=(
-                '' if setting.are_groups_editable else
+                '' if are_groups_editable else
                 _('Groups can\'t be edited for this pairing system.')
             ),
             min_disabled=true,

--- a/src/plugins/pairing_acceleration/templates/pairing_acceleration/group_b.html
+++ b/src/plugins/pairing_acceleration/templates/pairing_acceleration/group_b.html
@@ -1,3 +1,4 @@
+{% set are_groups_editable = admin_tournament.pairing_variation.are_groups_editable %}
 <div class="row mb-3">
     <div class="col-12">
         {% set recommended = setting.default_value(admin_tournament) %}
@@ -9,12 +10,12 @@
                     'Pairing number range of the group (recommended: %(min)d-%(max)d).',
                     min=recommended[0],
                     max=recommended[1],
-                ) if setting.are_groups_editable else
-                _('Pairing number range of players the group.')
+                ) if are_groups_editable else
+                _('Pairing number range of players in the group.')
             ),
             tooltip_text=admin_tournament.pairing_variation.get_group_b_tooltip(admin_tournament),
             input_tooltip=(
-                '' if setting.are_groups_editable else
+                '' if are_groups_editable else
                 _('Groups can\'t be edited for this pairing system.')
             ),
             max_disabled=setting.group_count() == 2,

--- a/src/plugins/pairing_acceleration/templates/pairing_acceleration/group_c.html
+++ b/src/plugins/pairing_acceleration/templates/pairing_acceleration/group_c.html
@@ -1,3 +1,4 @@
+{% set are_groups_editable = admin_tournament.pairing_variation.are_groups_editable %}
 <div class="row mb-3">
     <div class="col-12">
         {% set recommended = setting.default_value(admin_tournament) %}
@@ -9,12 +10,12 @@
                     'Pairing number range of the group (recommended: %(min)d-%(max)d).',
                     min=recommended[0],
                     max=recommended[1],
-                ) if setting.are_groups_editable else
-                _('Pairing number range of players the group.')
+                ) if are_groups_editable else
+                _('Pairing number range of players in the group.')
             ),
             tooltip_text=admin_tournament.pairing_variation.get_group_c_tooltip(admin_tournament),
             input_tooltip=(
-                '' if setting.are_groups_editable else
+                '' if are_groups_editable else
                 _('Groups can\'t be edited for this pairing system.')
             ),
             max_disabled=setting.group_count() == 3,

--- a/src/web/templates/admin/common/macros.j2
+++ b/src/web/templates/admin/common/macros.j2
@@ -818,7 +818,7 @@ with_indicator: display a loading indicator, optional
                 ></i>
             {% endif %}
             {% if help_text %}
-                <div id="{{ id }}-help" class="form-text">
+                <div id="{{ id }}-help" class="form-text w-100">
                     {{ help_text }}
                 </div>
             {% endif %}


### PR DESCRIPTION
Before: 
<img width="655" height="596" alt="image" src="https://github.com/user-attachments/assets/8af29040-0b85-43f6-9caf-e4d295ca0194" />    

- Help text display bug (english only)
- groups never enabled (only supposed to be disabled for Baku)