### PR TITLE
Improve i18n docs

### DIFF
--- a/src/common/i18n/__init__.py
+++ b/src/common/i18n/__init__.py
@@ -13,6 +13,7 @@ from common import BASE_DIR, DEVEL_ENV, TEST_ENV
 from common.exception import SharlyChessException
 from common.i18n.babel_updaters import BabelUpdater
 from common.i18n.domains import Domain
+from common.i18n.translators import Translator
 from common.logger import get_logger
 
 logger: Logger = get_logger()
@@ -48,7 +49,7 @@ _auto_update_file: Path = BASE_DIR / 'src' / 'common' / 'i18n' / '.auto-update'
 if DEVEL_ENV:
     babel_updater: BabelUpdater = BabelUpdater(
         Domain.get_domains(),
-        locales,
+        Translator.get_translators(locales),
         DEFAULT_LOCALE,
     )
     # if i18n_update is running then update_i18n_files() will be called later,
@@ -69,7 +70,7 @@ elif TEST_ENV:
     # When testing, make sure that the MO files will be available (including on GitHub)
     BabelUpdater(
         Domain.get_domains(),
-        locales,
+        Translator.get_translators(locales),
         DEFAULT_LOCALE,
     ).create_absent_mo_files()
 
@@ -81,7 +82,7 @@ def update_i18n_files(
     """Update all the i18n files if needed, returns False if the translations should be updated, True otherwise."""
     return BabelUpdater(
         Domain.get_domains(),
-        locales,
+        Translator.get_translators(locales),
         DEFAULT_LOCALE,
     ).update(
         clean=clean,

--- a/src/common/i18n/babel_updaters.py
+++ b/src/common/i18n/babel_updaters.py
@@ -153,39 +153,54 @@ class BabelDomainUpdater(BabelDomainWrapper):
                 self.store_po_for_mo_fingerprint(locale)
                 self.update_mo_file(locale)
                 logger.info('Domain [%s]: wrote MO file.', self.name)
-        ok: bool = True
         for locale_info in self.domain_locale_infos.values():
             if locale_info.error_messages:
                 logger.error(
                     'Domain [%s]: translations are not valid for some locales.',
                     self.name,
                 )
-                ok = False
-                break
+                return False
+        perfect_locales: list[str] = [
+            'fr',
+        ]
+        other_locales: list[str] = [
+            locale
+            for locale in self.locales
+            if locale not in [self.default_locale] + perfect_locales
+        ]
         for locale_info in self.domain_locale_infos.values():
             if locale_info.empty_mandatory_messages:
                 logger.error(
                     'Domain [%s]: mandatory translations are missing for some locales.',
                     self.name,
                 )
-                ok = False
-                break
-        for locale_info in self.domain_locale_infos.values():
-            if not locale_info.default and locale_info.empty_optional_messages:
-                logger.warning(
-                    'Domain [%s]: translations are missing for some locales.', self.name
+                return False
+        for locale in perfect_locales:
+            if self.domain_locale_infos[locale].empty_optional_messages:
+                logger.error(
+                    'Domain [%s]: optional translations are missing for some locales.',
+                    self.name,
                 )
-                ok = False
-                break
-        for locale_info in self.domain_locale_infos.values():
-            if locale_info.flagged_messages:
+                return False
+        for locale in other_locales:
+            if self.domain_locale_infos[locale].empty_optional_messages:
+                logger.warning(
+                    'Domain [%s]: optional translations are missing for some locales.',
+                    self.name,
+                )
+        for locale in perfect_locales:
+            if self.domain_locale_infos[locale].flagged_messages:
+                logger.error(
+                    'Domain [%s]: translations are flagged for some locales.', self.name
+                )
+                return False
+        for locale in other_locales:
+            if self.domain_locale_infos[locale].flagged_messages:
                 logger.warning(
                     'Domain [%s]: translations are flagged for some locales.', self.name
                 )
-                break
-        if ok:
-            logger.info('Domain [%s]: translations OK.', self.name)
-        return ok
+        logger.info('Domain [%s]: translations OK.', self.name)
+        return True
 
     def sources_for_pot_fingerprint_file(self) -> Path:
         """Returns the path of the file used to store the fingerprint of the source files."""

--- a/src/common/i18n/babel_updaters.py
+++ b/src/common/i18n/babel_updaters.py
@@ -34,9 +34,6 @@ class BabelDomainUpdater(BabelDomainWrapper):
             locale: DomainLocaleInfo(self.id, locale, default_locale)
             for locale in self.locales
         }
-        self.translators: dict[str, list[Translator]] = Translator.get_translators(
-            locales
-        )
         self.default_locale: str = default_locale
 
     def update(
@@ -306,98 +303,6 @@ class BabelDomainUpdater(BabelDomainWrapper):
         with open(self.po_for_mo_fingerprint_file(locale), 'wb') as f:
             return f.write(text_file_fingerprint(self.locale_po_file(locale)))
 
-    def markdown(
-        self,
-        flags: list[str],
-    ) -> str:
-        """Returns the markdown associated to the plugin (or core)."""
-        return self.domain_or_total_markdown(
-            self,
-            flags,
-            {
-                locale: len(locale_info.messages)
-                for locale, locale_info in self.domain_locale_infos.items()
-            },
-            {
-                locale: len(locale_info.empty_optional_messages)
-                for locale, locale_info in self.domain_locale_infos.items()
-            },
-            {
-                locale: len(locale_info.empty_mandatory_messages)
-                for locale, locale_info in self.domain_locale_infos.items()
-            },
-            {
-                locale: {
-                    flag: len(locale_info.flagged_messages.get(flag, []))
-                    for flag in flags
-                }
-                for locale, locale_info in self.domain_locale_infos.items()
-            },
-        )
-
-    @staticmethod
-    def domain_or_total_markdown(
-        domain: Domain | None,
-        flags: list[str],
-        messages_len_by_locale: dict[str, int],
-        empty_optional_messages_len_by_locale: dict[str, int],
-        empty_mandatory_messages_len_by_locale: dict[str, int],
-        flagged_messages_len_by_locale: dict[str, dict[str, int]],
-    ) -> str:
-        """Returns the markdown associated to a domain (or all the domains if po_file is None)."""
-        lines: list[str] = []
-        headers: list[str] = [
-            'Locale',
-            'Messages',
-            'Empty',
-            'Empty mandatory',
-        ]
-        headers += [f'[{flag}]' for flag in flags]
-        if domain:
-            headers += [
-                'PO file',
-            ]
-        lines.append('| ' + ' | '.join(headers) + ' |\n')
-        lines.append('|--' + ('|:--:' * (len(headers) - 1)) + '|\n')
-        for locale in messages_len_by_locale:
-            line: str = f'|<img src="../../src/web{locale_flag_url(locale)}" style="height: 1em;"/>&nbsp;``{locale}``&nbsp;{locale_localized_name(locale)} '
-            line += f'| {messages_len_by_locale[locale]} '
-            line += f'| {empty_optional_messages_len_by_locale[locale]} '
-            line += f'| {empty_mandatory_messages_len_by_locale[locale]} '
-            for flag in flags:
-                line += f'| {flagged_messages_len_by_locale[locale][flag]} '
-            if domain:
-                po_file: Path = domain.locale_po_file(locale)
-                line += f'| [{po_file.name}](../../{"/".join(d.name for d in reversed(po_file.relative_to(BASE_DIR).parents))}) '
-            line += '|\n'
-            lines.append(line)
-        lines.append('\n')
-        return ''.join(lines)
-
-    def translators_markdown(self) -> str:
-        """Returns the markdown associated to the plugin (or core)."""
-        lines: list[str] = []
-        headers: list[str] = [
-            'Locale',
-            'Translators',
-        ]
-        lines.append('| ' + ' | '.join(headers) + ' |\n')
-        lines.append('|--' + ('|:--:' * (len(headers) - 1)) + '|\n')
-        for locale, locale_info in self.domain_locale_infos.items():
-            line: str = f'|<img src="../../src/web{locale_flag_url(locale)}" style="height: 1em;"/>&nbsp;``{locale}``&nbsp;{locale_localized_name(locale)} '
-            translator_strings: list[str] = []
-            for translator in self.translators[locale]:
-                if translator.github_user:
-                    translator_strings.append(
-                        f'[{translator.name}](https://github.com/{translator.github_user})'
-                    )
-                else:
-                    translator_strings.append(translator.name)
-            line += f'| {"<br/>".join(translator_strings)} |\n'
-            lines.append(line)
-        lines.append('\n')
-        return ''.join(lines)
-
     def create_absent_mo_files(self):
         """Creates the MO files when not found (used when first pulling the repository and for testing on GitHub)."""
         for locale, locale_info in self.domain_locale_infos.items():
@@ -453,15 +358,19 @@ class BabelUpdater:
 
     def __init__(
         self,
-        domains: list['Domain'],
-        locales: list[str],
+        domains: list[Domain],
+        translators: dict[str, list[Translator]],
         default_locale: str,
     ):
-        self.locales: list[str] = locales
-        self.babel_domain_updaters: dict['Domain', BabelDomainUpdater] = {
-            domain: BabelDomainUpdater(domain.id, self.locales, default_locale)
+        self.translators: dict[str, list[Translator]] = translators
+        self.babel_domain_updaters: list[BabelDomainUpdater] = [
+            BabelDomainUpdater(domain.id, self.locales, default_locale)
             for domain in domains
-        }
+        ]
+
+    @property
+    def locales(self) -> list[str]:
+        return list(self.translators.keys())
 
     def update(
         self,
@@ -472,12 +381,25 @@ class BabelUpdater:
         ok: bool = all(
             [
                 babel_domain_updater.update(clean=clean)
-                for babel_domain_updater in self.babel_domain_updaters.values()
+                for babel_domain_updater in self.babel_domain_updaters
             ]
         )
         if ok and generate_doc:
             self.write_markdown()
         return ok
+
+    def create_absent_mo_files(self):
+        """For all the domains, creates the MO files when not found
+        (used when first pulling the repository and for testing on GitHub)."""
+        for babel_plugin_updater in self.babel_domain_updaters:
+            babel_plugin_updater.create_absent_mo_files()
+
+    def update_mo_files(
+        self,
+    ):
+        """ ""For all the domains, only update the MO files if the PO files have changed."""
+        for babel_domain_updater in self.babel_domain_updaters:
+            babel_domain_updater.update_mo_files()
 
     def write_markdown(self):
         """For (the core and) all the plugins, update all the files that need to updated (POT, PO, MO), and check the translations."""
@@ -512,78 +434,10 @@ class BabelUpdater:
         flags: list[str] = list(
             {
                 flag
-                for babel_domain_updater in self.babel_domain_updaters.values()
+                for babel_domain_updater in self.babel_domain_updaters
                 for locale, locale_info in babel_domain_updater.domain_locale_infos.items()
                 for flag in locale_info.flagged_messages
             }
-        )
-        new_content: str = ''.join(
-            [
-                '## Translators\n\n',
-                list(self.babel_domain_updaters.values())[0].translators_markdown(),
-            ]
-            + [
-                '## Locales implemented and translation status\n\n',
-            ]
-            + [
-                '### Core and plugins\n\n',
-                BabelDomainUpdater.domain_or_total_markdown(
-                    None,
-                    flags,
-                    {
-                        locale: sum(
-                            len(
-                                babel_domain_updater.domain_locale_infos[
-                                    locale
-                                ].messages
-                            )
-                            for babel_domain_updater in self.babel_domain_updaters.values()
-                        )
-                        for locale in self.locales
-                    },
-                    {
-                        locale: sum(
-                            len(
-                                babel_domain_updater.domain_locale_infos[
-                                    locale
-                                ].empty_optional_messages
-                            )
-                            for babel_domain_updater in self.babel_domain_updaters.values()
-                        )
-                        for locale in self.locales
-                    },
-                    {
-                        locale: sum(
-                            len(
-                                babel_domain_updater.domain_locale_infos[
-                                    locale
-                                ].empty_mandatory_messages
-                            )
-                            for babel_domain_updater in self.babel_domain_updaters.values()
-                        )
-                        for locale in self.locales
-                    },
-                    {
-                        locale: {
-                            flag: sum(
-                                len(
-                                    babel_domain_updater.domain_locale_infos[
-                                        locale
-                                    ].flagged_messages.get(flag, [])
-                                )
-                                for babel_domain_updater in self.babel_domain_updaters.values()
-                            )
-                            for flag in flags
-                        }
-                        for locale in self.locales
-                    },
-                ),
-            ]
-            + [
-                f'### {"Core" if babel_domain_updater.is_core else f"Plugin `{babel_domain_updater.name}`"}\n\n'
-                f'{babel_domain_updater.markdown(flags)}'
-                for babel_domain_updater in self.babel_domain_updaters.values()
-            ]
         )
         with open(doc_file, 'w', encoding='utf-8') as f:
             for line in (
@@ -594,7 +448,11 @@ class BabelUpdater:
                 + [
                     f'Last update: {datetime.strftime(datetime.fromtimestamp(time.time()), "%Y-%m-%d %H:%M")}\n\n'
                 ]
-                + [new_content]
+                + [
+                    self.translators_markdown_text(),
+                    self.by_locale_markdown_text(flags),
+                    self.by_domain_markdown_text(flags),
+                ]
                 + [
                     f'{end_comment}\n',
                 ]
@@ -603,15 +461,279 @@ class BabelUpdater:
                 f.write(line)
         logger.info('Wrote [%s].', doc_file)
 
-    def create_absent_mo_files(self):
-        """For all the domains, creates the MO files when not found
-        (used when first pulling the repository and for testing on GitHub)."""
-        for babel_plugin_updater in self.babel_domain_updaters.values():
-            babel_plugin_updater.create_absent_mo_files()
-
-    def update_mo_files(
+    def translators_markdown_text(
         self,
-    ):
-        """ ""For all the domains, only update the MO files if the PO files have changed."""
-        for babel_domain_updater in self.babel_domain_updaters.values():
-            babel_domain_updater.update_mo_files()
+    ) -> str:
+        headers: list[str] = [
+            'Locale',
+            'Translators',
+        ]
+        lines: list[str] = [
+            '## Translators\n\n| ' + ' | '.join(headers) + ' |',
+            '|--' + ('|--' * (len(headers) - 1)) + '|',
+        ]
+        for locale in self.locales:
+            lines.append(
+                f'| <img src="../../src/web{
+                    locale_flag_url(locale)
+                }" style="height: 1em;"/>&nbsp;``{locale}``&nbsp;{
+                    locale_localized_name(locale)
+                } | {
+                    ", ".join(
+                        translator.markdown for translator in self.translators[locale]
+                    )
+                } |'
+            )
+        return '\n'.join(lines) + '\n\n'
+
+    def by_locale_markdown_text(
+        self,
+        flags: list[str],
+    ) -> str:
+        lines: list[str] = ['## Translations by locale\n']
+        for locale in self.locales:
+            lines.append(
+                f'### <img src="../../src/web{locale_flag_url(locale)}" style="height: 1em;"/>&nbsp;``{locale}``&nbsp;{locale_localized_name(locale)}\n'
+            )
+            lines += self.markdown_header_lines(
+                column1_locale=False,
+                domain=None,
+                flags=flags,
+            )
+            for babel_domain_updater in self.babel_domain_updaters:
+                domain_locale_info: DomainLocaleInfo = (
+                    babel_domain_updater.domain_locale_infos[locale]
+                )
+                lines.append(
+                    self.markdown_line(
+                        column1_locale=False,
+                        locale=locale,
+                        domain=babel_domain_updater,
+                        flags=flags,
+                        messages_count=len(domain_locale_info.messages),
+                        empty_optional_messages_count=len(
+                            domain_locale_info.empty_optional_messages
+                        ),
+                        empty_mandatory_messages_count=len(
+                            domain_locale_info.empty_mandatory_messages
+                        ),
+                        flagged_messages_count={
+                            flag: len(domain_locale_info.flagged_messages.get(flag, []))
+                            for flag in flags
+                        },
+                    )
+                )
+            lines.append(
+                self.markdown_line(
+                    column1_locale=False,
+                    locale=locale,
+                    domain=None,
+                    flags=flags,
+                    messages_count=sum(
+                        len(babel_domain_updater.domain_locale_infos[locale].messages)
+                        for babel_domain_updater in self.babel_domain_updaters
+                    ),
+                    empty_optional_messages_count=sum(
+                        len(
+                            babel_domain_updater.domain_locale_infos[
+                                locale
+                            ].empty_optional_messages
+                        )
+                        for babel_domain_updater in self.babel_domain_updaters
+                    ),
+                    empty_mandatory_messages_count=sum(
+                        len(
+                            babel_domain_updater.domain_locale_infos[
+                                locale
+                            ].empty_mandatory_messages
+                        )
+                        for babel_domain_updater in self.babel_domain_updaters
+                    ),
+                    flagged_messages_count={
+                        flag: sum(
+                            len(
+                                babel_domain_updater.domain_locale_infos[
+                                    locale
+                                ].flagged_messages.get(flag, [])
+                            )
+                            for babel_domain_updater in self.babel_domain_updaters
+                        )
+                        for flag in flags
+                    },
+                )
+            )
+        return '\n'.join(lines) + '\n\n'
+
+    def by_domain_markdown_text(
+        self,
+        flags: list[str],
+    ) -> str:
+        lines: list[str] = ['## Translations by domain\n']
+        lines += self.domain_markdown_lines(
+            domain=None,
+            flags=flags,
+            messages_count_by_locale={
+                locale: sum(
+                    len(babel_domain_updater.domain_locale_infos[locale].messages)
+                    for babel_domain_updater in self.babel_domain_updaters
+                )
+                for locale in self.locales
+            },
+            empty_optional_messages_count_by_locale={
+                locale: sum(
+                    len(
+                        babel_domain_updater.domain_locale_infos[
+                            locale
+                        ].empty_optional_messages
+                    )
+                    for babel_domain_updater in self.babel_domain_updaters
+                )
+                for locale in self.locales
+            },
+            empty_mandatory_messages_count_by_locale={
+                locale: sum(
+                    len(
+                        babel_domain_updater.domain_locale_infos[
+                            locale
+                        ].empty_mandatory_messages
+                    )
+                    for babel_domain_updater in self.babel_domain_updaters
+                )
+                for locale in self.locales
+            },
+            flagged_messages_count_by_locale={
+                locale: {
+                    flag: sum(
+                        len(
+                            babel_domain_updater.domain_locale_infos[
+                                locale
+                            ].flagged_messages.get(flag, [])
+                        )
+                        for babel_domain_updater in self.babel_domain_updaters
+                    )
+                    for flag in flags
+                }
+                for locale in self.locales
+            },
+        )
+        for babel_domain_updater in self.babel_domain_updaters:
+            lines += self.domain_markdown_lines(
+                domain=babel_domain_updater,
+                flags=flags,
+                messages_count_by_locale={
+                    locale: len(locale_info.messages)
+                    for locale, locale_info in babel_domain_updater.domain_locale_infos.items()
+                },
+                empty_optional_messages_count_by_locale={
+                    locale: len(locale_info.empty_optional_messages)
+                    for locale, locale_info in babel_domain_updater.domain_locale_infos.items()
+                },
+                empty_mandatory_messages_count_by_locale={
+                    locale: len(locale_info.empty_mandatory_messages)
+                    for locale, locale_info in babel_domain_updater.domain_locale_infos.items()
+                },
+                flagged_messages_count_by_locale={
+                    locale: {
+                        flag: len(locale_info.flagged_messages.get(flag, []))
+                        for flag in flags
+                    }
+                    for locale, locale_info in babel_domain_updater.domain_locale_infos.items()
+                },
+            )
+        return '\n'.join(lines) + '\n\n'
+
+    def domain_markdown_lines(
+        self,
+        domain: Domain | None,
+        flags: list[str],
+        messages_count_by_locale: dict[str, int],
+        empty_optional_messages_count_by_locale: dict[str, int],
+        empty_mandatory_messages_count_by_locale: dict[str, int],
+        flagged_messages_count_by_locale: dict[str, dict[str, int]],
+    ) -> list[str]:
+        title: str
+        if not domain:
+            title = 'Core and plugins'
+        elif domain.is_core:
+            title = 'Core'
+        else:
+            title = f'Plugin {domain.name}'
+        return (
+            [f'### {title}\n']
+            + self.markdown_header_lines(
+                column1_locale=True,
+                domain=domain,
+                flags=flags,
+            )
+            + [
+                self.markdown_line(
+                    column1_locale=True,
+                    locale=locale,
+                    domain=domain,
+                    flags=flags,
+                    messages_count=messages_count_by_locale[locale],
+                    empty_optional_messages_count=empty_optional_messages_count_by_locale[
+                        locale
+                    ],
+                    empty_mandatory_messages_count=empty_mandatory_messages_count_by_locale[
+                        locale
+                    ],
+                    flagged_messages_count=flagged_messages_count_by_locale[locale],
+                )
+                for locale in self.locales
+            ]
+            + [
+                '',
+            ]
+        )
+
+    @staticmethod
+    def markdown_header_lines(
+        column1_locale: bool,
+        domain: Domain | None,
+        flags: list[str],
+    ) -> list[str]:
+        headers: list[str] = [
+            'Locale' if column1_locale else 'Domain',
+            'Messages',
+            'Empty',
+            'Empty mandatory',
+        ] + [f'[{flag}]' for flag in flags]
+        if domain:
+            headers += [
+                'PO file',
+            ]
+        return [
+            '| ' + ' | '.join(headers) + ' |',
+            '|--' + ('|:--:' * (len(headers) - 1)) + '|',
+        ]
+
+    @staticmethod
+    def markdown_line(
+        column1_locale: bool,
+        locale: str,
+        domain: Domain | None,
+        flags: list[str],
+        messages_count: int,
+        empty_optional_messages_count: int,
+        empty_mandatory_messages_count: int,
+        flagged_messages_count: dict[str, int],
+    ) -> str:
+        column1: str
+        if column1_locale:
+            column1 = f'<img src="../../src/web{locale_flag_url(locale)}" style="height: 1em;"/>&nbsp;``{locale}``&nbsp;{locale_localized_name(locale)}'
+        elif domain:
+            column1 = 'Core' if domain.is_core else f'Plugin `{domain.name}`'
+        else:
+            column1 = 'Core and plugins'
+        line: str = f'| {column1} '
+        line += f'| {messages_count if messages_count else "-"} '
+        line += f'| {empty_optional_messages_count if empty_optional_messages_count else "-"} '
+        line += f'| {empty_mandatory_messages_count if empty_mandatory_messages_count else "-"} '
+        for flag in flags:
+            line += f'| {flagged_messages_count[flag] if flagged_messages_count[flag] else "-"} '
+        if domain:
+            po_file: Path = domain.locale_po_file(locale)
+            line += f'| [{po_file.name}](../../{"/".join(d.name for d in reversed(po_file.relative_to(BASE_DIR).parents))}) '
+        line += '|'
+        return line

--- a/src/common/i18n/babel_updaters.py
+++ b/src/common/i18n/babel_updaters.py
@@ -27,11 +27,12 @@ class BabelDomainUpdater(BabelDomainWrapper):
         default_locale: str,
     ):
         super().__init__(domain_id)
+        self.locales: list[str] = locales
         self.tmp_dir: Path = TMP_DIR / 'i18n' / self.name
         self.tmp_dir.mkdir(parents=True, exist_ok=True)
         self.domain_locale_infos: dict[str, DomainLocaleInfo] = {
             locale: DomainLocaleInfo(self.id, locale, default_locale)
-            for locale in locales
+            for locale in self.locales
         }
         self.translators: dict[str, list[Translator]] = Translator.get_translators(
             locales
@@ -43,6 +44,7 @@ class BabelDomainUpdater(BabelDomainWrapper):
         clean: bool,
     ):
         """Update all the files that need to updated (POT, PO, MO), and check the translations."""
+        logger.info('Domain [%s]: updating i18n strings...', self.name)
         if clean:
             self.pot_file.unlink(missing_ok=True)
             for domain_locale_info in self.domain_locale_infos.values():
@@ -183,7 +185,6 @@ class BabelDomainUpdater(BabelDomainWrapper):
                 logger.warning(
                     'Domain [%s]: translations are flagged for some locales.', self.name
                 )
-                ok = False
                 break
         if ok:
             logger.info('Domain [%s]: translations OK.', self.name)
@@ -305,15 +306,46 @@ class BabelDomainUpdater(BabelDomainWrapper):
         with open(self.po_for_mo_fingerprint_file(locale), 'wb') as f:
             return f.write(text_file_fingerprint(self.locale_po_file(locale)))
 
-    def markdown(self) -> str:
+    def markdown(
+        self,
+        flags: list[str],
+    ) -> str:
         """Returns the markdown associated to the plugin (or core)."""
+        return self.domain_or_total_markdown(
+            self,
+            flags,
+            {
+                locale: len(locale_info.messages)
+                for locale, locale_info in self.domain_locale_infos.items()
+            },
+            {
+                locale: len(locale_info.empty_optional_messages)
+                for locale, locale_info in self.domain_locale_infos.items()
+            },
+            {
+                locale: len(locale_info.empty_mandatory_messages)
+                for locale, locale_info in self.domain_locale_infos.items()
+            },
+            {
+                locale: {
+                    flag: len(locale_info.flagged_messages.get(flag, []))
+                    for flag in flags
+                }
+                for locale, locale_info in self.domain_locale_infos.items()
+            },
+        )
+
+    @staticmethod
+    def domain_or_total_markdown(
+        domain: Domain | None,
+        flags: list[str],
+        messages_len_by_locale: dict[str, int],
+        empty_optional_messages_len_by_locale: dict[str, int],
+        empty_mandatory_messages_len_by_locale: dict[str, int],
+        flagged_messages_len_by_locale: dict[str, dict[str, int]],
+    ) -> str:
+        """Returns the markdown associated to a domain (or all the domains if po_file is None)."""
         lines: list[str] = []
-        flags: set[str] = set()
-        for locale in self.domain_locale_infos:
-            for flag in sorted(
-                list(self.domain_locale_infos[locale].flagged_messages.keys())
-            ):
-                flags.add(flag)
         headers: list[str] = [
             'Locale',
             'Messages',
@@ -321,20 +353,38 @@ class BabelDomainUpdater(BabelDomainWrapper):
             'Empty mandatory',
         ]
         headers += [f'[{flag}]' for flag in flags]
-        headers += [
-            'PO file',
+        if domain:
+            headers += [
+                'PO file',
+            ]
+        lines.append('| ' + ' | '.join(headers) + ' |\n')
+        lines.append('|--' + ('|:--:' * (len(headers) - 1)) + '|\n')
+        for locale in messages_len_by_locale:
+            line: str = f'|<img src="../../src/web{locale_flag_url(locale)}" style="height: 1em;"/>&nbsp;``{locale}``&nbsp;{locale_localized_name(locale)} '
+            line += f'| {messages_len_by_locale[locale]} '
+            line += f'| {empty_optional_messages_len_by_locale[locale]} '
+            line += f'| {empty_mandatory_messages_len_by_locale[locale]} '
+            for flag in flags:
+                line += f'| {flagged_messages_len_by_locale[locale][flag]} '
+            if domain:
+                po_file: Path = domain.locale_po_file(locale)
+                line += f'| [{po_file.name}](../../{"/".join(d.name for d in reversed(po_file.relative_to(BASE_DIR).parents))}) '
+            line += '|\n'
+            lines.append(line)
+        lines.append('\n')
+        return ''.join(lines)
+
+    def translators_markdown(self) -> str:
+        """Returns the markdown associated to the plugin (or core)."""
+        lines: list[str] = []
+        headers: list[str] = [
+            'Locale',
             'Translators',
         ]
         lines.append('| ' + ' | '.join(headers) + ' |\n')
         lines.append('|--' + ('|:--:' * (len(headers) - 1)) + '|\n')
         for locale, locale_info in self.domain_locale_infos.items():
             line: str = f'|<img src="../../src/web{locale_flag_url(locale)}" style="height: 1em;"/>&nbsp;``{locale}``&nbsp;{locale_localized_name(locale)} '
-            line += f'| {len(locale_info.messages)} '
-            line += f'| {len(locale_info.empty_optional_messages)} '
-            line += f'| {len(locale_info.empty_mandatory_messages)} '
-            for flag in flags:
-                line += f'| {len(locale_info.flagged_messages.get(flag, []))} '
-            line += f'| [{locale_info.po_file.name}](../../{"/".join(d.name for d in reversed(locale_info.po_file.relative_to(BASE_DIR).parents))}) '
             translator_strings: list[str] = []
             for translator in self.translators[locale]:
                 if translator.github_user:
@@ -407,8 +457,9 @@ class BabelUpdater:
         locales: list[str],
         default_locale: str,
     ):
+        self.locales: list[str] = locales
         self.babel_domain_updaters: dict['Domain', BabelDomainUpdater] = {
-            domain: BabelDomainUpdater(domain.id, locales, default_locale)
+            domain: BabelDomainUpdater(domain.id, self.locales, default_locale)
             for domain in domains
         }
 
@@ -458,9 +509,79 @@ class BabelUpdater:
                     f'Could not edit [{doc_file}] (comment [{end_comment}] not found).'
                 )
                 return
+        flags: list[str] = list(
+            {
+                flag
+                for babel_domain_updater in self.babel_domain_updaters.values()
+                for locale, locale_info in babel_domain_updater.domain_locale_infos.items()
+                for flag in locale_info.flagged_messages
+            }
+        )
         new_content: str = ''.join(
             [
-                f'### {babel_domain_updater.name}\n\n{babel_domain_updater.markdown()}'
+                '## Translators\n\n',
+                list(self.babel_domain_updaters.values())[0].translators_markdown(),
+            ]
+            + [
+                '## Locales implemented and translation status\n\n',
+            ]
+            + [
+                '### Core and plugins\n\n',
+                BabelDomainUpdater.domain_or_total_markdown(
+                    None,
+                    flags,
+                    {
+                        locale: sum(
+                            len(
+                                babel_domain_updater.domain_locale_infos[
+                                    locale
+                                ].messages
+                            )
+                            for babel_domain_updater in self.babel_domain_updaters.values()
+                        )
+                        for locale in self.locales
+                    },
+                    {
+                        locale: sum(
+                            len(
+                                babel_domain_updater.domain_locale_infos[
+                                    locale
+                                ].empty_optional_messages
+                            )
+                            for babel_domain_updater in self.babel_domain_updaters.values()
+                        )
+                        for locale in self.locales
+                    },
+                    {
+                        locale: sum(
+                            len(
+                                babel_domain_updater.domain_locale_infos[
+                                    locale
+                                ].empty_mandatory_messages
+                            )
+                            for babel_domain_updater in self.babel_domain_updaters.values()
+                        )
+                        for locale in self.locales
+                    },
+                    {
+                        locale: {
+                            flag: sum(
+                                len(
+                                    babel_domain_updater.domain_locale_infos[
+                                        locale
+                                    ].flagged_messages.get(flag, [])
+                                )
+                                for babel_domain_updater in self.babel_domain_updaters.values()
+                            )
+                            for flag in flags
+                        }
+                        for locale in self.locales
+                    },
+                ),
+            ]
+            + [
+                f'### {"Core" if babel_domain_updater.is_core else f"Plugin `{babel_domain_updater.name}`"}\n\n'
+                f'{babel_domain_updater.markdown(flags)}'
                 for babel_domain_updater in self.babel_domain_updaters.values()
             ]
         )

--- a/src/common/i18n/locale_info.py
+++ b/src/common/i18n/locale_info.py
@@ -182,7 +182,10 @@ class DomainLocaleInfo(Domain):
             write_po(f, catalog, width=0, omit_header=True)  # type: ignore
         # compare line by line because files differ on CR/LF
         changed: bool = False
-        with open(self.po_file, 'r') as before_f, open(tmp_file, 'r') as after_f:
+        with (
+            open(self.po_file, 'r', encoding='utf-8') as before_f,
+            open(tmp_file, 'r', encoding='utf-8') as after_f,
+        ):
             for before_line, after_line in zip_longest(
                 before_f.readlines(), after_f.readlines()
             ):

--- a/src/common/i18n/translators.py
+++ b/src/common/i18n/translators.py
@@ -10,6 +10,13 @@ class Translator:
         self.github_user: str | None = github_user
         self.name: str = name or 'Unknown'
 
+    @property
+    def markdown(self) -> str:
+        if self.github_user:
+            return f'[{self.name}](https://github.com/{self.github_user})'
+        else:
+            return self.name
+
     @classmethod
     def get_translators(
         cls,


### PR DESCRIPTION
Improve the i18n docs to ease the translators' job and allow translations other than EN/FR to be incomplete and marked fuzzy/ai-translation.
<img width="346" height="302" alt="image" src="https://github.com/user-attachments/assets/a151b326-c8b1-47f2-8c6a-868758edd607" />
<img width="534" height="858" alt="image" src="https://github.com/user-attachments/assets/3ba7dd65-d74f-4a9d-b3e7-ed859e5a10f2" />
<img width="574" height="769" alt="image" src="https://github.com/user-attachments/assets/790939fc-eac6-401e-9f65-4b629b84fd60" />
