### PR TITLE
Ensure PGN compatibility for the PAB

### DIFF
--- a/src/data/board.py
+++ b/src/data/board.py
@@ -191,7 +191,7 @@ class Board:
     ) -> str:
         field_prefix = 'White' if is_white else 'Black'
         if tournament_player is None:
-            return f'[{field_prefix} ""]'
+            return f'[{field_prefix} ""]\n'
         rating = (
             tournament_player.rating
             if tournament_player.rating_type == PlayerRatingType.FIDE


### PR DESCRIPTION
When exporting the Pairing Allocated Bye to PGN, the black player's line does not have the carriage return.

Thus, the result line is appended to the `[Black ""]` line, leading to an invalid value.

This prevents imports into DGT LiveChess, because the PGN is invalid.



This PR solves this problem by adding back the carriage return.

