### PR TITLE
Realign rating buckets for statistics

### DIFF
--- a/src/data/print_documents/documents.py
+++ b/src/data/print_documents/documents.py
@@ -913,8 +913,8 @@ class StatisticsPrintDocument(PrintDocument):
             return None
 
         max_rating = max(ratings, default=0)
-        buckets = [(0, 1000)]
-        r = 1001
+        buckets = [(0, 999)]
+        r = 1000
         while r <= max_rating:
             buckets.append((r, r + 199))
             r += 200


### PR DESCRIPTION
The bucket starts are now aligned to 200-poin boundaries
