### PR TITLE
Store the federation names by locale

### DIFF
--- a/src/common/sharly_chess_config.py
+++ b/src/common/sharly_chess_config.py
@@ -27,6 +27,7 @@ from common.i18n import (
     normalize_bcp47_to_locale,
     read_macos_global_prefs,
     set_locale,
+    get_locale,
 )
 from common.logger import set_logging_config, get_logger
 from common.network import find_lan_interfaces, LOCALHOST_IP
@@ -52,6 +53,7 @@ class SharlyChessConfig(metaclass=Singleton):
         self.web_port: int | None = None
         self._stored_config: StoredConfig | None = None
         self._date_formatter: DateFormatter | None = None
+        self._federations_by_locale: dict[str, dict[str, str]] = {}
 
     @staticmethod
     def _get_system_user_locale() -> str | None:
@@ -532,7 +534,15 @@ class SharlyChessConfig(metaclass=Singleton):
 
     @property
     def federations(self) -> dict[str, str]:
-        """Returns The federation names."""
+        """Get the federation names. To avoid translating all
+        the names multiple times the values are stored by locale."""
+        locale_ = get_locale()
+        if locale_ not in self._federations_by_locale:
+            self._federations_by_locale[locale_] = self._get_localized_federations()
+        return self._federations_by_locale[locale_]
+
+    @staticmethod
+    def _get_localized_federations() -> dict[str, str]:
         return {
             'AFG': _('Afghanistan'),
             'ALB': _('Albania'),


### PR DESCRIPTION
This was causing the tournament and prize criteria form to take forever to load, as all the values in the list were re-translated once per federation option. This solution takes into account the previous usage that considered the federations a constant 