### PR TITLE
Prevent refreshing not visible screens

### DIFF
--- a/src/common/sharly_chess_config.py
+++ b/src/common/sharly_chess_config.py
@@ -472,20 +472,8 @@ class SharlyChessConfig(metaclass=Singleton):
     # The default delay between pages on rotators (in seconds).
     default_rotator_delay: int = 1 if TEST_ENV else 15
 
-    # The delay before checking if the user index page has changed.
-    user_index_update_delay: int = 1 if TEST_ENV else 10
-
-    # The delay before checking if a user event page has changed.
-    user_event_update_delay: int = 1 if TEST_ENV else 10
-
     # The delay before checking if a user screen page has changed.
     user_screen_update_delay: int = 1 if TEST_ENV else 10
-
-    # The numbers of columns allowed on pages with grids.
-    allowed_columns: list[int] = [1, 2, 3, 4, 6]
-
-    # The default number of columns.
-    default_columns: int = 4
 
     # The error background image.
     error_background_image: str = '/static/images/sharly-chess-error.png'

--- a/src/web/templates/user/screen.html
+++ b/src/web/templates/user/screen.html
@@ -19,7 +19,8 @@
                 <i class="bi-x-circle-fill"></i>
             </button>
         {% endif %}
-        {% set refresh_conditions = "modalIsClosed(),document.visibilityState==='visible'" %}
+        {% set refresh_conditions = "modalIsClosed() && document.visibilityState === 'visible'" %}
+        {% set becomes_visible = "visibilitychange[" ~ refresh_conditions ~ "] from:document" %}
         {% if display_controller %}
             <div
                 class="refresher display-controller-refresher"
@@ -27,7 +28,7 @@
                     hx-headers='{"If-Modified-Since": "{{ now_http_date }}"}'
                 {% endif %}
                 hx-get="{{ url_for('user-display-controller', event_uniq_id=user_event.uniq_id, display_controller_id=display_controller.id, rotator_screen_index=rotator_screen_index + 1) }}"
-                hx-trigger="every {{ display_controller.delay }}s[{{ refresh_conditions }}]"
+                hx-trigger="{{ becomes_visible }}, every {{ display_controller.delay }}s[{{ refresh_conditions }}]"
                 hx-target="body"
                 hx-indicator="#please-wait"
             ></div>
@@ -36,7 +37,7 @@
                 class="refresher rotator-refresher"
                 hx-get="{{ url_for('user-rotator', event_uniq_id=user_event.uniq_id, rotator_id=rotator.id, rotator_screen_index=rotator_screen_index + 1) }}"
                 hx-target="body"
-                hx-trigger="every {{ rotator.delay }}s[{{ refresh_conditions }}]"
+                hx-trigger="{{ becomes_visible }}, every {{ rotator.delay }}s[{{ refresh_conditions }}]"
                 hx-indicator="#please-wait"
             ></div>
         {% else %}
@@ -45,7 +46,7 @@
                 hx-headers='{"If-Modified-Since": "{{ now_http_date }}"}'
                 hx-get="{{ url_for('user-screen', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id) }}"
                 hx-target="body"
-                hx-trigger="every {{ sharly_chess_config.user_screen_update_delay }}s[{{ refresh_conditions }}] queue:none"
+                hx-trigger="{{ becomes_visible }}, every {{ sharly_chess_config.user_screen_update_delay }}s[{{ refresh_conditions }}] queue:none"
                 hx-indicator="#please-wait"
             ></div>
         {% endif %}

--- a/src/web/templates/user/screen.html
+++ b/src/web/templates/user/screen.html
@@ -19,8 +19,8 @@
                 <i class="bi-x-circle-fill"></i>
             </button>
         {% endif %}
-        {% set refresh_conditions = "modalIsClosed() && document.visibilityState === 'visible'" %}
-        {% set becomes_visible = "visibilitychange[" ~ refresh_conditions ~ "] from:document" %}
+        {% set refresh_conditions = "modalIsClosed()" ~ (" && document.visibilityState === 'visible'" if not DEVEL_ENV else '') %}
+        {% set becomes_visible = "visibilitychange[" ~ refresh_conditions ~ "] from:document," if not DEVEL_ENV else '' %}
         {% if display_controller %}
             <div
                 class="refresher display-controller-refresher"
@@ -28,7 +28,7 @@
                     hx-headers='{"If-Modified-Since": "{{ now_http_date }}"}'
                 {% endif %}
                 hx-get="{{ url_for('user-display-controller', event_uniq_id=user_event.uniq_id, display_controller_id=display_controller.id, rotator_screen_index=rotator_screen_index + 1) }}"
-                hx-trigger="{{ becomes_visible }}, every {{ display_controller.delay }}s[{{ refresh_conditions }}]"
+                hx-trigger="{{ becomes_visible }} every {{ display_controller.delay }}s[{{ refresh_conditions }}]"
                 hx-target="body"
                 hx-indicator="#please-wait"
             ></div>
@@ -37,7 +37,7 @@
                 class="refresher rotator-refresher"
                 hx-get="{{ url_for('user-rotator', event_uniq_id=user_event.uniq_id, rotator_id=rotator.id, rotator_screen_index=rotator_screen_index + 1) }}"
                 hx-target="body"
-                hx-trigger="{{ becomes_visible }}, every {{ rotator.delay }}s[{{ refresh_conditions }}]"
+                hx-trigger="{{ becomes_visible }} every {{ rotator.delay }}s[{{ refresh_conditions }}]"
                 hx-indicator="#please-wait"
             ></div>
         {% else %}
@@ -46,7 +46,7 @@
                 hx-headers='{"If-Modified-Since": "{{ now_http_date }}"}'
                 hx-get="{{ url_for('user-screen', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id) }}"
                 hx-target="body"
-                hx-trigger="{{ becomes_visible }}, every {{ sharly_chess_config.user_screen_update_delay }}s[{{ refresh_conditions }}] queue:none"
+                hx-trigger="{{ becomes_visible }} every {{ sharly_chess_config.user_screen_update_delay }}s[{{ refresh_conditions }}] queue:none"
                 hx-indicator="#please-wait"
             ></div>
         {% endif %}

--- a/src/web/templates/user/screen.html
+++ b/src/web/templates/user/screen.html
@@ -19,6 +19,7 @@
                 <i class="bi-x-circle-fill"></i>
             </button>
         {% endif %}
+        {% set refresh_conditions = "modalIsClosed(),document.visibilityState==='visible'" %}
         {% if display_controller %}
             <div
                 class="refresher display-controller-refresher"
@@ -26,7 +27,7 @@
                     hx-headers='{"If-Modified-Since": "{{ now_http_date }}"}'
                 {% endif %}
                 hx-get="{{ url_for('user-display-controller', event_uniq_id=user_event.uniq_id, display_controller_id=display_controller.id, rotator_screen_index=rotator_screen_index + 1) }}"
-                hx-trigger="every {{ display_controller.delay }}s[modalIsClosed()]"
+                hx-trigger="every {{ display_controller.delay }}s[{{ refresh_conditions }}]"
                 hx-target="body"
                 hx-indicator="#please-wait"
             ></div>
@@ -35,7 +36,7 @@
                 class="refresher rotator-refresher"
                 hx-get="{{ url_for('user-rotator', event_uniq_id=user_event.uniq_id, rotator_id=rotator.id, rotator_screen_index=rotator_screen_index + 1) }}"
                 hx-target="body"
-                hx-trigger="every {{ rotator.delay }}s[modalIsClosed()]"
+                hx-trigger="every {{ rotator.delay }}s[{{ refresh_conditions }}]"
                 hx-indicator="#please-wait"
             ></div>
         {% else %}
@@ -44,7 +45,7 @@
                 hx-headers='{"If-Modified-Since": "{{ now_http_date }}"}'
                 hx-get="{{ url_for('user-screen', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id) }}"
                 hx-target="body"
-                hx-trigger="every {{ sharly_chess_config.user_screen_update_delay }}s[modalIsClosed()] queue:none"
+                hx-trigger="every {{ sharly_chess_config.user_screen_update_delay }}s[{{ refresh_conditions }}] queue:none"
                 hx-indicator="#please-wait"
             ></div>
         {% endif %}

--- a/tests/e2e/screens/test_single_screens.py
+++ b/tests/e2e/screens/test_single_screens.py
@@ -171,8 +171,8 @@ class TestSingleScreensFunctionality:
             {'name': 'BRUNO', 'result': Result.DRAW, 'button_text': '½ - ½'},
             {'name': 'MARIA', 'result': Result.LOSS, 'button_text': '0 - 1'},
         ]
-
         for i, player in enumerate(players):
+            lan_page.bring_to_front()
             row = rows.filter(has_text=player['name'])
             expect(row.locator('div.score')).to_contain_text(f'#{i + 1}')
 
@@ -186,6 +186,7 @@ class TestSingleScreensFunctionality:
             expect(row.locator('div.score')).to_contain_text(str(player['result']))
 
             # That the other page is refreshed
+            another_lan_page.bring_to_front()
             other_row = other_page_rows.filter(has_text=player['name'])
             expect(other_row.locator('div.score')).to_contain_text(
                 str(player['result'])


### PR DESCRIPTION
screen now only refreshed when the tab is visible, + when it becomes visible to avoid consulting old data for 15s