### PR TITLE
Improve semantics for base HTML template

### DIFF
--- a/src/web/templates/admin/print/base.html
+++ b/src/web/templates/admin/print/base.html
@@ -1,9 +1,10 @@
 {% import '/common/macros.j2' as macros with context %}
+<!DOCTYPE html>
 <html translate="no">
     <head>
-        <meta http-equiv="Content-Type" content="text/html;" charset=UTF-8">
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <title>{{ document.name }}{% if tournament %} - {{ tournament.name }}{% endif %}</title>
-        <style type="text/css">
+        <style>
             {% include 'print.css' %}
             {{ extra_css }}
             {% block css %}{% endblock %}


### PR DESCRIPTION
Main change is fixing `charset` specification for the base HTML template used for generating documents: a misplaced double quote was breaking the parsing, resulting in wrong encoding when uploading the generated HTML files into my website.

Other changes:

- Add HTML 5 `DOCTYPE`  since it's a required tag for any HTML document.

- Remove unnecessary `type`  attribute for `style` tag (was reported as "obsolete" by my IDE, but the more I look into it, the more it looks like it's simply "optional" in HTML 5).
