### PR TITLE
Prevent invalid pairing settings from event duplication

### DIFF
--- a/src/plugins/pairing_acceleration/pairing_settings.py
+++ b/src/plugins/pairing_acceleration/pairing_settings.py
@@ -87,6 +87,10 @@ class PairingGroupSetting(PairingSetting[tuple[int, int]], ABC):
     def default_value(cls, tournament: 'Tournament') -> tuple[int, int]:
         return cls.default_values_by_group(tournament)[cls.group()]
 
+    @classmethod
+    def check_value(cls, tournament: 'Tournament', value: tuple[int, int]) -> bool:
+        return value[0] < value[1] <= tournament.player_count
+
 
 class Base2GroupsSetting(PairingGroupSetting, ABC):
     @staticmethod

--- a/src/web/controllers/admin/index_admin_controller.py
+++ b/src/web/controllers/admin/index_admin_controller.py
@@ -785,6 +785,7 @@ class IndexAdminController(BaseAdminController):
             if 'with_players' not in data:
                 database.delete_all_stored_players()
                 for tournament in event.tournaments:
+                    database.set_tournament_pairing_settings(tournament.id, {})
                     database.set_tournament_current_round(tournament.id, None)
             plugin_manager.hook.on_event_duplicated(event_database=database)
 


### PR DESCRIPTION
To reproduce: 
- take an event with an accelerated tournament. 
- pair the first round to set pairing numbers
- duplicate the event without players

You now have invalid pairing numbers for the acceleration groups. It fails the papi export, and when regenerating the first round pairings it has invalid numbers