### PR TITLE
Fix circular imports on script invocation

### DIFF
--- a/src/data/columns/board_table.py
+++ b/src/data/columns/board_table.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from common.i18n import _
 from data.board import Board
-from web.utils import Column, ColumnUsage
+from .column import Column, ColumnUsage
 
 
 class BoardColumn(Column[Board], ABC):

--- a/src/data/columns/column.py
+++ b/src/data/columns/column.py
@@ -1,0 +1,73 @@
+from abc import ABC
+from enum import Enum, auto
+from typing import Any
+
+
+class Column[T](ABC):
+    @property
+    def grid_column_template(self) -> str:
+        """The width definition of the content as used by grid-template-columns"""
+        return 'max-content'
+
+    @property
+    def header_content(self) -> str:
+        """The content of the header as a string.
+        A template can be used for more complex headers."""
+        name = self.__class__.__name__
+        raise NotImplementedError(
+            f'{name}: header content needs to be implemented '
+            'if a template for the header is not provided.'
+        )
+
+    @property
+    def is_header_content_safe(self) -> bool:
+        """Defines if the header content is safe to be displayed in Jinja.
+        User-input strings should not be declared as safe.
+        Useful to add light html formatting (ex: <b>last_name</b> first_name)"""
+        return False
+
+    @property
+    def header_template(self) -> str | None:
+        """The template to use for the header of the column.
+        If None, the header content is used."""
+        return None
+
+    @property
+    def header_classes(self) -> str:
+        """CSS classes to use for the header."""
+        return self.shared_classes
+
+    def get_cell_content(self, object_: T) -> Any:
+        """Get the content of a cell as a string from an object of the table.
+        A template can be used for more complex cell contents."""
+        name = self.__class__.__name__
+        raise NotImplementedError(
+            f'{name}: cell content needs to be implemented '
+            'if a template for the cell is not provided.'
+        )
+
+    @property
+    def is_cell_content_safe(self) -> bool:
+        """Defines if the cell content is safe to be displayed in Jinja.
+        User-input strings should not be declared as safe.
+        Useful to add light html formatting (ex: <b>last_name</b> first_name)"""
+        return False
+
+    @property
+    def cell_template(self) -> str | None:
+        """The template to use for the cells. If None, the cell content is used."""
+        return None
+
+    def get_cell_classes(self, object_: T) -> str:
+        """CSS classes to use for the cells."""
+        return self.shared_classes
+
+    @property
+    def shared_classes(self) -> str:
+        """Classes shared between the cells and the header."""
+        return ''
+
+
+class ColumnUsage(Enum):
+    SCREEN = auto()
+    PRINT = auto()

--- a/src/data/columns/handlers.py
+++ b/src/data/columns/handlers.py
@@ -26,7 +26,7 @@ from data.columns.players_tab import (
 from data.event import Event
 from data.tournament import Tournament
 from plugins.manager import plugin_manager
-from web.utils import ColumnUsage
+from .column import ColumnUsage
 
 
 class PlayerColumnHandler:

--- a/src/data/columns/player_datasheet.py
+++ b/src/data/columns/player_datasheet.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from data.player import Player
 from utils.enum import TournamentRating, PlayerRatingType
-from web.utils import Column
+from .column import Column
 
 
 class DatasheetColumn(Column[Player], ABC):

--- a/src/data/columns/player_table.py
+++ b/src/data/columns/player_table.py
@@ -5,7 +5,7 @@ from common.i18n import _
 from data.player import TournamentPlayer
 from data.tournament import Tournament
 from utils import Utils
-from web.utils import Column, ColumnUsage
+from .column import Column, ColumnUsage
 
 
 class TournamentPlayerTableColumn(Column[TournamentPlayer], ABC):

--- a/src/data/columns/players_tab.py
+++ b/src/data/columns/players_tab.py
@@ -10,7 +10,7 @@ from data.player_categories import PlayerCategory
 from data.tournament import Tournament
 from utils.entity import IdentifiableEntity
 from utils.enum import CheckInStatus, PlayerGender
-from web.utils import Column
+from .column import Column
 
 
 @dataclass

--- a/src/plugins/fra_schools/fra_schools_ranking_document.py
+++ b/src/plugins/fra_schools/fra_schools_ranking_document.py
@@ -20,7 +20,7 @@ from data.print_documents.documents import (
 )
 from plugins.fra_schools.fra_schools_controller import FRASchool, FRASchoolsUtils
 from utils.enum import PlayerGender
-from web.utils import ColumnUsage
+from data.columns.column import ColumnUsage
 
 
 @dataclass

--- a/src/plugins/handicap_games/handicap_games.py
+++ b/src/plugins/handicap_games/handicap_games.py
@@ -23,7 +23,7 @@ from plugins.utils import (
 )
 from utils.time_control import parse_time_control_trf25
 from web.controllers.base_controller import WebContext
-from web.utils import ColumnUsage
+from data.columns.column import ColumnUsage
 
 if TYPE_CHECKING:
     from data.event import Event

--- a/src/plugins/hookspec.py
+++ b/src/plugins/hookspec.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
     from database.sqlite.local_source_database.databases import LocalSourceDatabase
     from plugins.migration import PluginMigrationManager
     from web.controllers.admin.player_admin_controller import PlayerAdminWebContext
-    from web.utils import ColumnUsage
+    from data.columns.column import ColumnUsage
 
 hookspec = pluggy.HookspecMarker(APP_NAME)
 hookimpl = pluggy.HookimplMarker(APP_NAME)

--- a/src/web/utils.py
+++ b/src/web/utils.py
@@ -1,6 +1,4 @@
-from abc import ABC
 from dataclasses import dataclass
-from enum import Enum, auto
 from typing import Any
 
 from anyio import run
@@ -312,73 +310,3 @@ class SelectOption:
     disabled: bool = False
     classes: str = ''
     search: str | None = None
-
-
-class Column[T](ABC):
-    @property
-    def grid_column_template(self) -> str:
-        """The width definition of the content as used by grid-template-columns"""
-        return 'max-content'
-
-    @property
-    def header_content(self) -> str:
-        """The content of the header as a string.
-        A template can be used for more complex headers."""
-        name = self.__class__.__name__
-        raise NotImplementedError(
-            f'{name}: header content needs to be implemented '
-            'if a template for the header is not provided.'
-        )
-
-    @property
-    def is_header_content_safe(self) -> bool:
-        """Defines if the header content is safe to be displayed in Jinja.
-        User-input strings should not be declared as safe.
-        Useful to add light html formatting (ex: <b>last_name</b> first_name)"""
-        return False
-
-    @property
-    def header_template(self) -> str | None:
-        """The template to use for the header of the column.
-        If None, the header content is used."""
-        return None
-
-    @property
-    def header_classes(self) -> str:
-        """CSS classes to use for the header."""
-        return self.shared_classes
-
-    def get_cell_content(self, object_: T) -> Any:
-        """Get the content of a cell as a string from an object of the table.
-        A template can be used for more complex cell contents."""
-        name = self.__class__.__name__
-        raise NotImplementedError(
-            f'{name}: cell content needs to be implemented '
-            'if a template for the cell is not provided.'
-        )
-
-    @property
-    def is_cell_content_safe(self) -> bool:
-        """Defines if the cell content is safe to be displayed in Jinja.
-        User-input strings should not be declared as safe.
-        Useful to add light html formatting (ex: <b>last_name</b> first_name)"""
-        return False
-
-    @property
-    def cell_template(self) -> str | None:
-        """The template to use for the cells. If None, the cell content is used."""
-        return None
-
-    def get_cell_classes(self, object_: T) -> str:
-        """CSS classes to use for the cells."""
-        return self.shared_classes
-
-    @property
-    def shared_classes(self) -> str:
-        """Classes shared between the cells and the header."""
-        return ''
-
-
-class ColumnUsage(Enum):
-    SCREEN = auto()
-    PRINT = auto()


### PR DESCRIPTION
The previous architecture was such that the `web` package was calling the `data` package, however, a class that should have been defined in `data` was defined in the `web` package.

This lead to circular imports in certain cases: it did not happen in app invocations, but only on script calls, which made export impossible.

The spot where the file should be is up for debate, but it MUSTN'T go in `web.utils`
