### PR TITLE
Use string enums for Gender, Title and FFE Licence

### DIFF
--- a/docs/technical-appendices/databases.md
+++ b/docs/technical-appendices/databases.md
@@ -160,26 +160,26 @@
 
 ### `player` table (players)
 
-| Field           | Type      | Constraint                                 | Description                                             |
-|-----------------|-----------|--------------------------------------------|---------------------------------------------------------|
-| `id`            | `INTEGER` | NOT NULL<br/>PRIMARY KEY<br/>AUTOINCREMENT | The player ID                                           |
-| `last_name`     | `TEXT`    | NOT NULL                                   | The player's last name                                  |
-| `first_name`    | `TEXT`    |                                            | The player's first name                                 |
-| `date_of_birth` | `TEXT`    |                                            | The player's date of birth in YYYY-MM-DD format         |
-| `gender`        | `INTEGER` | NOT NULL                                   | The player's gender (1: Male, 2: Female, 0: Other)      |
-| `mail`          | `TEXT`    |                                            | The player's email address                              |
-| `phone`         | `TEXT`    |                                            | The player's phone number                               |
-| `comment`       | `TEXT`    |                                            | Comments about the player                               |
-| `owed`          | `FLOAT`   | NOT NULL                                   | Amount of money owed by the player                      |
-| `paid`          | `FLOAT`   | NOT NULL                                   | Amount of money paid by the player                      |
-| `title`         | `INTEGER` | NOT NULL                                   | The player's chess title                                |
-| `ratings`       | `TEXT`    | NOT NULL                                   | The player's ratings in JSON format                     |
-| `fide_id`       | `INTEGER` |                                            | The player's FIDE ID                                    |
-| `federation`    | `TEXT`    |                                            | The player's federation code                            |
-| `club`          | `TEXT`    |                                            | The player's chess club                                 |
-| `fixed`         | `INTEGER` |                                            | Boolean: whether the player's is assigned a fixed table |
-| `check_in`      | `INTEGER` | NOT NULL<br/>DEFAULT 0                     | Boolean: whether the player has checked in              |
-| `plugin_data`   | `TEXT`    | NOT NULL                                   | Additional data used by plugins, in JSON format         |
+| Field           | Type      | Constraint                                 | Description                                     |
+|-----------------|-----------|--------------------------------------------|-------------------------------------------------|
+| `id`            | `INTEGER` | NOT NULL<br/>PRIMARY KEY<br/>AUTOINCREMENT | The player ID                                   |
+| `last_name`     | `TEXT`    | NOT NULL                                   | The player's last name                          |
+| `first_name`    | `TEXT`    |                                            | The player's first name                         |
+| `date_of_birth` | `TEXT`    |                                            | The player's date of birth in YYYY-MM-DD format |
+| `gender`        | `TEXT`    | NOT NULL                                   | The player's gender                             |
+| `mail`          | `TEXT`    |                                            | The player's email address                      |
+| `phone`         | `TEXT`    |                                            | The player's phone number                       |
+| `comment`       | `TEXT`    |                                            | Comments about the player                       |
+| `owed`          | `FLOAT`   | NOT NULL                                   | Amount of money owed by the player              |
+| `paid`          | `FLOAT`   | NOT NULL                                   | Amount of money paid by the player              |
+| `title`         | `TEXT`    | NOT NULL                                   | The player's chess title                        |
+| `ratings`       | `TEXT`    | NOT NULL                                   | The player's ratings in JSON format             |
+| `fide_id`       | `INTEGER` |                                            | The player's FIDE ID                            |
+| `federation`    | `TEXT`    |                                            | The player's federation code                    |
+| `club`          | `TEXT`    |                                            | The player's chess club                         |
+| `fixed`         | `INTEGER` |                                            | The player's fixed table (if any)               |
+| `check_in`      | `INTEGER` | NOT NULL<br/>DEFAULT 0                     | Boolean: whether the player has checked in      |
+| `plugin_data`   | `TEXT`    | NOT NULL                                   | Additional data used by plugins, in JSON format |
 
 ### `tournament_player` table (tournament player associations)
 

--- a/src/data/board.py
+++ b/src/data/board.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional, Literal
 from database.sqlite.event.event_store import StoredBoard
 from database.sqlite.event.event_database import EventDatabase
 from utils.date_time import format_timestamp_date_time
-from utils.enum import Result, PlayerRatingType
+from utils.enum import Result, PlayerRatingType, PlayerTitle
 
 if TYPE_CHECKING:
     from _weakref import ReferenceType
@@ -203,8 +203,8 @@ class Board:
         return (
             f'[{field_prefix} "{cls._format_pgn_string(name)}"]\n'
             + (
-                f'[{field_prefix}Title "{tournament_player.title.to_fide_value}"]\n'
-                if tournament_player.title.to_fide_value
+                f'[{field_prefix}Title "{tournament_player.title.value}"]\n'
+                if tournament_player.title != PlayerTitle.NONE
                 else ''
             )
             + f'[{field_prefix}Elo "{rating}"]\n'

--- a/src/data/columns/player_datasheet.py
+++ b/src/data/columns/player_datasheet.py
@@ -79,7 +79,7 @@ class GenderColumn(DatasheetColumn):
         return 'gender'
 
     def get_cell_content(self, player: Player) -> Any:
-        return player.gender.short_name
+        return player.gender.value
 
 
 class FideIDColumn(DatasheetColumn):

--- a/src/data/columns/players_tab.py
+++ b/src/data/columns/players_tab.py
@@ -483,10 +483,10 @@ class GenderPlayersTabColumn(FilterPlayersTabColumn):
         return (player.gender,)
 
     def get_filter_key(self, player: Player) -> str:
-        return str(player.gender.value)
+        return player.gender.value
 
     def get_filter_value_from_key(self, filter_key: str, event: Event) -> Any:
-        return PlayerGender(int(filter_key))
+        return PlayerGender(filter_key)
 
     def get_filter_row_content(self, value: Any) -> str:
         return value.name

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -1162,7 +1162,7 @@ class TournamentPlayer(Player):
     def starting_rank_sort_key(self) -> tuple:
         return (
             -self.rating,
-            -self.title,
+            -self.title.sort_index,
             self.last_name,
             self.first_name or '',
         )

--- a/src/data/print_documents/place_cards/types.py
+++ b/src/data/print_documents/place_cards/types.py
@@ -65,10 +65,10 @@ class PlaceCardType(IdentifiableEntity, ABC):
         year: int = datetime.now().year
         place_card_player.year_of_birth = str(random.randint(year - 100, year - 5))
         place_card_player.gender = PlayerGender(
-            random.choice(PlayerGender.values())
+            random.choice(list(PlayerGender))
         ).short_name
         place_card_player.title = PlayerTitle(
-            random.choice(PlayerTitle.values())
+            random.choice(list(PlayerTitle))
         ).short_name
         config = SharlyChessConfig()
         place_card_player.federation = random.choice(list(config.federations.keys()))

--- a/src/database/sqlite/event/event_store.py
+++ b/src/database/sqlite/event/event_store.py
@@ -129,13 +129,13 @@ class StoredPlayer:
     first_name: str | None = None
     date_of_birth: date | None = None
     year_of_birth: int | None = None
-    gender: int = 0
+    gender: str = ''
     mail: str | None = None
     phone: str | None = None
     comment: str | None = None
     owed: float = 0.0
     paid: float = 0.0
-    title: int = 0
+    title: str = ''
     fide_id: int | None = None
     federation: str = 'FID'
     club: str | None = None

--- a/src/database/sqlite/event/migrations/m072_players_board_display.py
+++ b/src/database/sqlite/event/migrations/m072_players_board_display.py
@@ -16,14 +16,14 @@ class Migration(BaseMigration):
             for params in {
                 (
                     1,  # PlayersScreenPlayerFormat.NAME
-                    1,  # PlayersScreenPlayerFormat.MINIMAL
-                    1,  # PlayersScreenPlayerFormat.NONE
+                    1,  # PlayersScreenBoardFormat.MINIMAL
+                    1,  # PlayersScreenOpponentFormat.NONE
                     0,  # for players screens actually hiding the opponents
                 ),
                 (
                     4,  # PlayersScreenPlayerFormat.NAME_RATING_TYPE_POINTS
-                    4,  # PlayersScreenPlayerFormat.FULL
-                    5,  # PlayersScreenPlayerFormat.NAME_RATING_TYPE_POINTS
+                    4,  # PlayersScreenBoardFormat.FULL
+                    5,  # PlayersScreenOpponentFormat.NAME_RATING_TYPE_POINTS
                     1,  # for players screens actually showing the opponents
                 ),
             }:

--- a/src/database/sqlite/event/migrations/m073_use_string_for_player_gender_title.py
+++ b/src/database/sqlite/event/migrations/m073_use_string_for_player_gender_title.py
@@ -1,0 +1,68 @@
+from database.sqlite.migration import BaseMigration
+
+
+class Migration(BaseMigration):
+    GENDER_MAPPING: dict[int, str] = {
+        0: '',
+        1: 'F',
+        2: 'M',
+    }
+    TITLE_MAPPING: dict[int, str] = {
+        0: '',
+        1: 'WCM',
+        2: 'CM',
+        3: 'WFM',
+        4: 'FM',
+        5: 'WIM',
+        6: 'IM',
+        7: 'WGM',
+        8: 'GM',
+    }
+    MAPPING_BY_PLAYER_COLUMN: dict[str, dict[int, str]] = {
+        'gender': GENDER_MAPPING,
+        'title': TITLE_MAPPING,
+    }
+
+    def forward(self):
+        for column, mapping in self.MAPPING_BY_PLAYER_COLUMN.items():
+            self.database.execute(
+                f'ALTER TABLE `player` RENAME COLUMN `{column}` TO `{column}_int`'
+            )
+            self.database.execute(f'ALTER TABLE `player` ADD `{column}` TEXT')
+            for int_value, str_value in mapping.items():
+                self.database.execute(
+                    f'UPDATE `player` SET `{column}` = ? WHERE `{column}_int` = ?',
+                    (str_value, int_value),
+                )
+            self.database.execute(f'ALTER TABLE `player` DROP COLUMN `{column}_int`')
+
+        for prefix in ('tournament', 'prize'):
+            for int_value, str_value in self.GENDER_MAPPING.items():
+                self.database.execute(
+                    f'UPDATE `{prefix}_criterion` '
+                    "SET `options` = JSON_SET(options, '$.GENDER_VALUE', ?) "
+                    "WHERE JSON_EXTRACT(options, '$.GENDER_VALUE') = ?;",
+                    (str_value, int_value),
+                )
+
+    def backward(self):
+        for column, mapping in self.MAPPING_BY_PLAYER_COLUMN.items():
+            self.database.execute(
+                f'ALTER TABLE `player` RENAME COLUMN `{column}` TO `{column}_str`'
+            )
+            self.database.execute(f'ALTER TABLE `player` ADD `{column}` INTEGER')
+            for int_value, str_value in mapping.items():
+                self.database.execute(
+                    f'UPDATE `player` SET `{column}` = ? WHERE `{column}_str` = ?',
+                    (int_value, str_value),
+                )
+            self.database.execute(f'ALTER TABLE `player` DROP COLUMN `{column}_str`')
+
+        for prefix in ('tournament', 'prize'):
+            for int_value, str_value in self.GENDER_MAPPING.items():
+                self.database.execute(
+                    f'UPDATE `{prefix}_criterion` '
+                    "SET `options` = JSON_SET(options, '$.GENDER_VALUE', ?) "
+                    "WHERE JSON_EXTRACT(options, '$.GENDER_VALUE') = ?;",
+                    (int_value, str_value),
+                )

--- a/src/database/sqlite/fide/fide_database.py
+++ b/src/database/sqlite/fide/fide_database.py
@@ -122,11 +122,7 @@ class FideDatabase(LocalSourcePlayerDatabase):
             'name': ('name', None),
             'country': ('federation', lambda s: s.upper()),
             'sex': ('gender', PlayerGender.from_fide_value),
-            # exception for 1001710 Vreeken, Corry
-            'title': (
-                'fide_title',
-                lambda s: PlayerTitle.from_fide_value('' if s == 'WH' else s),
-            ),
+            'title': ('fide_title', PlayerTitle.from_fide_value),
             'rating': ('standard_rating', int),
             'rapid_rating': ('rapid_rating', int),
             'blitz_rating': ('blitz_rating', int),

--- a/src/plugins/chessevent/tournament_importer/data.py
+++ b/src/plugins/chessevent/tournament_importer/data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 
-from utils.enum import PlayerGender, TournamentRating
+from utils.enum import TournamentRating
 
 
 @dataclass
@@ -27,7 +27,7 @@ class ChessEventPlayer:
     check_in: bool | int
     board: int
     fide_id: int = 0
-    gender: PlayerGender = PlayerGender.NONE
+    gender: int = 0
     ffe_club_id: int = 0
     ffe_club: str = ''
     category: int = 0

--- a/src/plugins/chessevent/tournament_importer/importer.py
+++ b/src/plugins/chessevent/tournament_importer/importer.py
@@ -50,6 +50,7 @@ from plugins.chessevent.tournament_importer.mappers import (
     ChessEventFFELicence,
     ChessEventTitle,
     ChessEventRatingType,
+    ChessEventGender,
 )
 from plugins.chessevent.utils import ChessEventTournamentPluginData, ChessEventUtils
 from plugins.ffe.ffe import FfePlugin
@@ -263,6 +264,10 @@ class ChessEventTournamentImporter(TournamentImporter):
             title = ChessEventTitle.get_core_object(player.title)
         except KeyError:
             raise unknown_exception('title')
+        try:
+            gender = ChessEventGender.get_core_object(player.gender)
+        except KeyError:
+            raise unknown_exception('gender')
         if player.federation not in SharlyChessConfig().federations:
             # Error raised in the form as it's the only field manually input by the user
             raise ImporterError(
@@ -324,13 +329,13 @@ class ChessEventTournamentImporter(TournamentImporter):
             date_of_birth=(epoch + timedelta(seconds=float(player.birth))).astimezone(
                 paris_tz
             ),
-            gender=player.gender.value,
+            gender=gender.value,
             mail=player.email,
             phone=player.phone,
             comment=None,
             owed=float(player.fee),
             paid=float(player.paid),
-            title=title,
+            title=title.value,
             ratings=ratings,
             fide_id=player.fide_id or None,
             federation=player.federation,

--- a/src/plugins/chessevent/tournament_importer/mappers.py
+++ b/src/plugins/chessevent/tournament_importer/mappers.py
@@ -17,7 +17,7 @@ from plugins.pairing_acceleration.pairing_variations import (
     ProgressiveSwissVariation,
 )
 from utils import CoreMapper
-from utils.enum import PlayerRatingType, PlayerTitle
+from utils.enum import PlayerRatingType, PlayerTitle, PlayerGender
 
 
 class ChessEventPairingSystem(CoreMapper[int, PairingSystem]):
@@ -83,6 +83,16 @@ class ChessEventRatingType(CoreMapper[int, PlayerRatingType]):
             1: PlayerRatingType.ESTIMATED,
             2: PlayerRatingType.NATIONAL,
             3: PlayerRatingType.FIDE,
+        }
+
+
+class ChessEventGender(CoreMapper[int, PlayerGender]):
+    @staticmethod
+    def _core_object_by_outer_value() -> dict[int, PlayerGender]:
+        return {
+            0: PlayerGender.NONE,
+            1: PlayerGender.FEMALE,
+            2: PlayerGender.MALE,
         }
 
 

--- a/src/plugins/ffe/ffe.py
+++ b/src/plugins/ffe/ffe.py
@@ -327,7 +327,7 @@ class FfePlugin(Plugin):
             errors[field] = f'Invalid league value [{data[field]}].'
             data[field] = ''
         try:
-            if value := WebContext.form_data_to_int(data, field := 'ffe_licence'):
+            if value := WebContext.form_data_to_str(data, field := 'ffe_licence'):
                 PlayerFFELicence(value)
         except ValueError:
             errors[field] = f'Invalid FFE licence [{data[field]}].'

--- a/src/plugins/ffe/ffe_entity.py
+++ b/src/plugins/ffe/ffe_entity.py
@@ -320,7 +320,7 @@ class FfeLicencePlayerFilter(PlayerFilter):
         return f'{self.name} ({", ".join(licence_types)})'
 
 
-class FfeLicenceFilterOption(SelectPlayerFilterOption[int]):
+class FfeLicenceFilterOption(SelectPlayerFilterOption[str]):
     @staticmethod
     def static_id() -> str:
         return f'{PLUGIN_NAME}-LICENCES'
@@ -331,17 +331,17 @@ class FfeLicenceFilterOption(SelectPlayerFilterOption[int]):
 
     @property
     def type(self) -> type | UnionType:
-        return list[int]
+        return list[str]
 
     @property
     def default_value(self) -> Any:
         return []
 
-    def get_all_known_values(self, tournament: 'Tournament') -> list[int]:
+    def get_all_known_values(self, tournament: 'Tournament') -> list[str]:
         return [licence.value for licence in PlayerFFELicence]
 
-    def get_tournament_player_counter(self, tournament: 'Tournament') -> Counter[int]:
-        counter: Counter[int] = Counter[int]()
+    def get_tournament_player_counter(self, tournament: 'Tournament') -> Counter[str]:
+        counter: Counter[str] = Counter[str]()
         for tournament_player in tournament.tournament_players:
             if ffe_licence := FFEUtils.get_player_plugin_data(
                 tournament_player
@@ -349,15 +349,15 @@ class FfeLicenceFilterOption(SelectPlayerFilterOption[int]):
                 counter[ffe_licence] += 1
         return counter
 
-    def get_key(self, object_: int) -> str:
-        return str(object_)
+    def get_key(self, object_: str) -> str:
+        return object_
 
-    def get_name(self, object_: int) -> str:
+    def get_name(self, object_: str) -> str:
         licence = PlayerFFELicence(object_)
         return licence.compact_name
 
     def validate(self):
-        self._validate_list_type(int)
+        self._validate_list_type(str)
         if not self.value:
             raise OptionError(_('At least one licence type is expected.'), self)
 
@@ -424,10 +424,10 @@ class FfeLicencePlayersTabColumn(FilterPlayersTabColumn):
         return (FFEUtils.get_player_plugin_data(player).ffe_licence,)
 
     def get_filter_key(self, player: Player) -> str:
-        return str(FFEUtils.get_player_plugin_data(player).ffe_licence.value)
+        return FFEUtils.get_player_plugin_data(player).ffe_licence.value
 
     def get_filter_value_from_key(self, filter_key: str, event: Event) -> Any:
-        return PlayerFFELicence(int(filter_key))
+        return PlayerFFELicence(filter_key)
 
     def get_filter_row_content(self, value: Any) -> str:
         return value.compact_name
@@ -483,7 +483,7 @@ class FfeLicenceDatasheetColumn(DatasheetColumn):
         return 'ffe_licence'
 
     def get_cell_content(self, player: Player) -> Any:
-        return FFEUtils.get_player_plugin_data(player).ffe_licence.short_name
+        return FFEUtils.get_player_plugin_data(player).ffe_licence.value
 
 
 class FfeLeagueDatasheetColumn(DatasheetColumn):

--- a/src/plugins/ffe/migrations/m005_use_string_for_player_ffe_licence.py
+++ b/src/plugins/ffe/migrations/m005_use_string_for_player_ffe_licence.py
@@ -1,0 +1,61 @@
+import json
+
+from database.sqlite.migration import BaseMigration
+
+
+class Migration(BaseMigration):
+    LICENCE_MAPPING: dict[int, str] = {
+        0: '',
+        1: 'N',
+        2: 'A',
+        3: 'B',
+    }
+
+    def forward(self):
+        for int_value, str_value in self.LICENCE_MAPPING.items():
+            self.database.execute(
+                "UPDATE `player` SET plugin_data = JSON_SET(plugin_data, '$.ffe.ffe_licence', ?) "
+                "WHERE JSON_EXTRACT(plugin_data, '$.ffe.ffe_licence') = ?;",
+                (str_value, int_value),
+            )
+
+        for prefix in ('tournament', 'prize'):
+            self.database.execute(
+                f'SELECT * FROM `{prefix}_criterion` WHERE `type` = ?',
+                ('ffe-LICENCE',),
+            )
+            for row in self.database.fetchall():
+                licences = [
+                    self.LICENCE_MAPPING[int_licence]
+                    for int_licence in json.loads(row['options'])['ffe-LICENCES']
+                ]
+                self.database.execute(
+                    f'UPDATE `{prefix}_criterion` SET `options` = ? WHERE `id` = ?',
+                    (json.dumps({'ffe-LICENCES': licences}), row['id']),
+                )
+
+    def backward(self):
+        for int_value, str_value in self.LICENCE_MAPPING.items():
+            self.database.execute(
+                "UPDATE `player` SET plugin_data = JSON_SET(plugin_data, '$.ffe.ffe_licence', ?) "
+                "WHERE JSON_EXTRACT(plugin_data, '$.ffe.ffe_licence') = ?;",
+                (int_value, str_value),
+            )
+        licence_mapping = {
+            licence_str: licence_int
+            for licence_int, licence_str in self.LICENCE_MAPPING.items()
+        }
+        for prefix in ('tournament', 'prize'):
+            self.database.execute(
+                f'SELECT * FROM `{prefix}_criterion` WHERE `type` = ?',
+                ('ffe-LICENCE',),
+            )
+            for row in self.database.fetchall():
+                licences = [
+                    licence_mapping[str_licence]
+                    for str_licence in json.loads(row['options'])['ffe-LICENCES']
+                ]
+                self.database.execute(
+                    f'UPDATE `{prefix}_criterion` SET `options` = ? WHERE `id` = ?',
+                    (json.dumps({'ffe-LICENCES': licences}), row['id']),
+                )

--- a/src/plugins/ffe/templates/ffe_player_licence_cell.html
+++ b/src/plugins/ffe/templates/ffe_player_licence_cell.html
@@ -4,11 +4,11 @@
 {% set licence = player.plugin_data.ffe.ffe_licence %}
 {% set licence_number = player.plugin_data.ffe.ffe_licence_number or '' %}
 <span
-    {% if not licence_number or licence == 0 %}
+    {% if not licence_number or licence == '' %}
         {{ macros.tooltip_attributes('', licence.name, 'right') }}
     {% else %}
         class="cursor-pointer"
-        {% if licence == 1 %}
+        {% if licence == N %}
             {{ macros.click_to_copy_attributes(
                 _('%(licence_number)s (expired)', licence_number=licence_number),
                 'right',

--- a/src/plugins/ffe/utils.py
+++ b/src/plugins/ffe/utils.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass
 from datetime import datetime
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 from functools import partial
 from typing import Self, Any
 
@@ -76,11 +76,11 @@ class FFEUtils:
         return PapiConverter.papi_export_unavailable_message(tournament)
 
 
-class PlayerFFELicence(IntEnum):
-    NONE = 0
-    N = 1
-    A = 2
-    B = 3
+class PlayerFFELicence(StrEnum):
+    NONE = ''
+    N = 'N'
+    A = 'A'
+    B = 'B'
 
     @property
     def name(self) -> str:
@@ -112,17 +112,9 @@ class PlayerFFELicence(IntEnum):
 
     @property
     def short_name(self) -> str:
-        match self:
-            case PlayerFFELicence.NONE:
-                return '-'
-            case PlayerFFELicence.N:
-                return 'N'
-            case PlayerFFELicence.A:
-                return 'A'
-            case PlayerFFELicence.B:
-                return 'B'
-            case _:
-                raise ValueError(f'Unknown value: {self}')
+        if self == PlayerFFELicence.NONE:
+            return '-'
+        return self.value
 
     @staticmethod
     def validate(string: str) -> bool:
@@ -320,7 +312,7 @@ class FfePlayerPluginData(PluginData):
         return cls(
             ffe_id=WebContext.form_data_to_int(data, 'ffe_id'),
             ffe_licence=PlayerFFELicence(
-                WebContext.form_data_to_int(data, 'ffe_licence')
+                WebContext.form_data_to_str(data, 'ffe_licence')
                 or PlayerFFELicence.NONE
             ),
             ffe_licence_number=WebContext.form_data_to_str(data, 'ffe_licence_number'),

--- a/src/utils/enum.py
+++ b/src/utils/enum.py
@@ -535,14 +535,10 @@ class TournamentRating(IntEnum):
         return self.name
 
 
-class PlayerGender(IntEnum):
-    NONE = 0
-    FEMALE = 1
-    MALE = 2
-
-    @classmethod
-    def values(cls) -> tuple[int, ...]:
-        return tuple(item.value for item in cls)
+class PlayerGender(StrEnum):
+    NONE = ''
+    FEMALE = 'F'
+    MALE = 'M'
 
     @classmethod
     def from_fide_value(cls, value: str) -> 'PlayerGender':
@@ -612,72 +608,32 @@ class PlayerRatingType(IntEnum):
         return self.short_name
 
 
-class PlayerTitle(IntEnum):
+class PlayerTitle(StrEnum):
     """The possible FIDE titles: GM, WGM, IM, WIM, FM, WFM, CM, WCM.
-    Also includes the "no title" case.
-    This is for Papi-compatibility reasons."""
+    Also includes the "no title" case."""
 
-    NONE = 0
-    WOMAN_CANDIDATE_MASTER = 1
-    CANDIDATE_MASTER = 2
-    WOMAN_FIDE_MASTER = 3
-    FIDE_MASTER = 4
-    WOMAN_INTERNATIONAL_MASTER = 5
-    INTERNATIONAL_MASTER = 6
-    WOMAN_GRANDMASTER = 7
-    GRANDMASTER = 8
+    NONE = ''
+    WOMAN_CANDIDATE_MASTER = 'WCM'
+    CANDIDATE_MASTER = 'CM'
+    WOMAN_FIDE_MASTER = 'WFM'
+    FIDE_MASTER = 'FM'
+    WOMAN_INTERNATIONAL_MASTER = 'WIM'
+    INTERNATIONAL_MASTER = 'IM'
+    WOMAN_GRANDMASTER = 'WGM'
+    GRANDMASTER = 'GM'
 
-    @classmethod
-    def values(cls) -> tuple[int, ...]:
-        return tuple(item.value for item in cls)
+    @property
+    def sort_index(self) -> int:
+        if self == self.NONE:
+            return 0
+        return list(PlayerTitle).index(self)
 
     @classmethod
     def from_fide_value(cls, value: str) -> 'PlayerTitle':
-        match value.strip():
-            case '':
-                return PlayerTitle.NONE
-            case 'WCM':
-                return PlayerTitle.WOMAN_CANDIDATE_MASTER
-            case 'CM':
-                return PlayerTitle.CANDIDATE_MASTER
-            case 'WFM':
-                return PlayerTitle.WOMAN_FIDE_MASTER
-            case 'FM':
-                return PlayerTitle.FIDE_MASTER
-            case 'WIM':
-                return PlayerTitle.WOMAN_INTERNATIONAL_MASTER
-            case 'IM':
-                return PlayerTitle.INTERNATIONAL_MASTER
-            case 'WGM':
-                return PlayerTitle.WOMAN_GRANDMASTER
-            case 'GM':
-                return PlayerTitle.GRANDMASTER
-            case _:
-                raise ValueError(f'Unknown title value: {value}')
-
-    @property
-    def to_fide_value(self) -> str:
-        match self:
-            case PlayerTitle.NONE:
-                return ''
-            case PlayerTitle.WOMAN_CANDIDATE_MASTER:
-                return 'WCM'
-            case PlayerTitle.CANDIDATE_MASTER:
-                return 'CM'
-            case PlayerTitle.WOMAN_FIDE_MASTER:
-                return 'WFM'
-            case PlayerTitle.FIDE_MASTER:
-                return 'FM'
-            case PlayerTitle.WOMAN_INTERNATIONAL_MASTER:
-                return 'WIM'
-            case PlayerTitle.INTERNATIONAL_MASTER:
-                return 'IM'
-            case PlayerTitle.WOMAN_GRANDMASTER:
-                return 'WGM'
-            case PlayerTitle.GRANDMASTER:
-                return 'GM'
-            case _:
-                raise ValueError(f'Unknown title: {self}')
+        try:
+            return cls(value)
+        except ValueError:
+            return cls.NONE
 
     @property
     def name(self) -> str:

--- a/src/web/controllers/admin/player_admin_controller.py
+++ b/src/web/controllers/admin/player_admin_controller.py
@@ -686,11 +686,11 @@ class PlayerAdminController(BaseEventAdminController):
             first_name: str | None = None
             last_name: str | None = None
             date_of_birth: str | None = None
-            gender: int = PlayerGender.NONE.value
+            gender = PlayerGender.NONE.value
             ratings: dict[TournamentRating, PlayerRating] = {
                 tr: PlayerRating(estimated=0) for tr in TournamentRating
             }
-            title: int = PlayerTitle.NONE.value
+            title = PlayerTitle.NONE.value
             federation = event.federation
             club: str | None = None
             fide_id: int | None = None
@@ -994,14 +994,14 @@ class PlayerAdminController(BaseEventAdminController):
                         ),
                     )
         try:
-            if value := WebContext.form_data_to_int(data, field := 'gender'):
+            if value := WebContext.form_data_to_str(data, field := 'gender'):
                 PlayerGender(value)
         except ValueError:
             # should never happen, not translated.
             errors[field] = f'Invalid gender value [{data[field]}].'
             data[field] = ''
         try:
-            if value := WebContext.form_data_to_int(data, field := 'title'):
+            if value := WebContext.form_data_to_str(data, field := 'title'):
                 PlayerTitle(value)
         except ValueError:
             # should never happen, not translated.
@@ -1082,14 +1082,14 @@ class PlayerAdminController(BaseEventAdminController):
             last_name=(WebContext.form_data_to_str(data, 'last_name') or '').upper(),
             date_of_birth=date_of_birth,
             year_of_birth=year_of_birth,
-            gender=WebContext.form_data_to_int(data, 'gender')
+            gender=WebContext.form_data_to_str(data, 'gender')
             or PlayerGender.NONE.value,
             mail=WebContext.form_data_to_str(data, 'mail'),
             phone=WebContext.form_data_to_str(data, 'phone'),
             comment=data.get('comment'),
             owed=WebContext.form_data_to_float(data, 'owed') or 0.0,
             paid=WebContext.form_data_to_float(data, 'paid') or 0.0,
-            title=WebContext.form_data_to_int(data, 'title') or PlayerTitle.NONE.value,
+            title=WebContext.form_data_to_str(data, 'title') or PlayerTitle.NONE.value,
             ratings={
                 tr.value: PlayerRating(
                     estimated=WebContext.form_data_to_int(


### PR DESCRIPTION
This is a step towards player import, in order to have in our databases the same data we will ask to import (we don't wanna ask users to know our enum values, but instead clear understandable values).   
example with gender: 0, 1, 2 --> '', 'F', 'M'  