### PR TITLE
Uniformize disabled byes logic

### DIFF
--- a/src/web/templates/admin/pairings/unpaired_player_modal.html
+++ b/src/web/templates/admin/pairings/unpaired_player_modal.html
@@ -1,7 +1,7 @@
 {% import '/common/macros.j2' as macros with context %}
 
 {% with
-    no_bye_possible = admin_round >= tournament_player.tournament.rounds - tournament_player.tournament.last_rounds_no_byes,
+    no_bye_possible = admin_round > tournament_player.tournament.rounds - tournament_player.tournament.last_rounds_no_byes,
     pairing = tournament_player.pairings[admin_round]
 %}
     <div style="--bs-modal-width: min(90vw, 400px);" class="modal-dialog pairing-modal">


### PR DESCRIPTION
byes do not appear disabled the same if you are in the unpaired player modal or in the record modal. This uniformizes it