### PR TITLE
Use bootstrap format on all checkboxes

### DIFF
--- a/src/web/static/css/admin.css
+++ b/src/web/static/css/admin.css
@@ -284,6 +284,15 @@
     font-size: 1.25rem;
 }
 
+.blue-checkbox {
+    font-size: 90%;
+}
+
+.blue-checkbox:checked {
+    background-color: #0d6efd !important;
+    border-color: #0d6efd !important;
+}
+
 /* Air DatePicker */
 
 #air-datepicker-global-container {

--- a/src/web/static/css/base.css
+++ b/src/web/static/css/base.css
@@ -677,8 +677,8 @@ body[data-bs-theme=light] .btn-primary {
 [data-bs-theme=dark] .dropdown-menu {
     --bs-dropdown-bg: #515b5c;
     --bs-dropdown-link-color: var(--bs-body-color);
-    --bs-dropdown-link-hover-color: var(--pw-contrast-text);
-    --bs-dropdown-link-hover-bg: var(--bs-primary);
+    --bs-dropdown-link-hover-color: var(--bs-body-color);
+    --bs-dropdown-link-hover-bg: var(--bs-secondary);
     --bs-dropdown-link-active-color: var(--pw-contrast-text);
     --bs-dropdown-link-active-bg: var(--bs-primary);
     --bs-dropdown-link-disabled-color: var(--bs-tertiary-color);

--- a/src/web/templates/admin/common/macros.j2
+++ b/src/web/templates/admin/common/macros.j2
@@ -802,9 +802,9 @@ with_indicator: display a loading indicator, optional
                                 id="{{ default_checkbox_id }}"
                                 name="{{ default_checkbox_name }}"
                                 type="checkbox"
+                                class="form-check-input me-2 mb-2"
                                 aria-describedby="{{ id }}-help {{ id }}-error"
                                 {% if data[default_checkbox_name] == 'on' %}checked{% endif %}
-                                class="me-2"
 
                             />
                             {{ default_checkbox_text or _('Use default') }}

--- a/src/web/templates/admin/players/filter_columns.html
+++ b/src/web/templates/admin/players/filter_columns.html
@@ -26,6 +26,7 @@
             <li class="dropdown-item title text-nowrap">
                 <input
                     type="checkbox"
+                    class="form-check-input blue-checkbox"
                     {% if enabled_columns|length == visible_columns|length %}checked{% endif %}
                     onclick="$('input.hideable-columns').prop('checked', this.checked)"
                 />
@@ -42,9 +43,9 @@
                         id="{{ name }}-{{ loop.index }}"
                         name="{{ name }}"
                         value="{{ column.id }}"
+                        class="form-check-input blue-checkbox mb-1 {% if column.is_hideable %}hideable-columns{% endif %}"
                         {% if column.is_visible %}checked{% endif %}
                         {% if not column.is_hideable %}disabled{% endif %}
-                        class="{% if column.is_hideable %}hideable-columns{% endif %}"
                     />
                     <label for="{{ name }}-{{ loop.index }}" class="form-label w-100 my-0">
                         {{ column.name }}

--- a/src/web/templates/admin/players/players_diff_modal.html
+++ b/src/web/templates/admin/players/players_diff_modal.html
@@ -67,6 +67,7 @@
                             {% if update_enabled %}
                                 <th scope="col" class="text-nowrap text-center">
                                     <input
+                                        class="form-check-input blue-checkbox"
                                         type="checkbox"
                                         onclick="
                                             $('input.player-id-checkbox').prop('checked', this.checked);
@@ -81,10 +82,10 @@
                                     {% if update_enabled and field.id in updated_field_ids %}
                                         <input
                                             type="checkbox"
+                                            class="form-check-input blue-checkbox field-id-checkbox"
                                             name="field_ids"
                                             value="{{ field.id }}"
                                             checked
-                                            class="field-id-checkbox"
                                         />
                                     {% endif %}
                                     {{ field.name }}
@@ -124,7 +125,7 @@
                                                 onclick="
                                                     $('#update-players-button').prop('disabled', $('input.player-id-checkbox:checked').length == 0);
                                                 "
-                                                class="player-id-checkbox"
+                                                class="form-check-input blue-checkbox player-id-checkbox"
                                             />
                                         {% endif %}
                                     </td>

--- a/src/web/templates/admin/players/players_import_diff_modal.html
+++ b/src/web/templates/admin/players/players_import_diff_modal.html
@@ -74,6 +74,7 @@
                             <th class="text-nowrap text-start">
                                 <input
                                     type="checkbox"
+                                    class="form-check-input blue-checkbox"
                                     onclick="
                                         $('.row-index-checkbox').prop('checked', this.checked);
                                         $('.row-index-checkbox').trigger('change');"
@@ -112,7 +113,7 @@
                                             ></i>
                                         {% else %}
                                             <input
-                                                class="row-index-checkbox ps-1"
+                                                class="form-check-input blue-checkbox row-index-checkbox ps-1"
                                                 type="checkbox"
                                                 name="row_indexes"
                                                 value="{{ index }}"

--- a/src/web/templates/admin/players/table/filter.html
+++ b/src/web/templates/admin/players/table/filter.html
@@ -31,6 +31,7 @@
             <li class="dropdown-item title text-nowrap">
                 <input
                     type="checkbox"
+                    class="form-check-input blue-checkbox"
                     {% if column.all_filter_value_active %}checked{% endif %}
                     onclick="$('input.filter-{{ column.id }}').prop('checked', this.checked)"
                 />
@@ -50,9 +51,9 @@
                         type="checkbox"
                         id="{{ column.id }}-{{ loop.index }}"
                         name="{{ name }}"
+                        class="form-check-input blue-checkbox mb-1 filter-{{ column.id }}"
                         value="{{ filter_value.key }}"
                         {% if filter_value.is_active %}checked{% endif %}
-                        class="filter-{{ column.id }}"
                     />
                     <label for="{{ column.id }}-{{ loop.index }}" class="form-label w-100 my-0">
                         {% if column.filter_row_template %}

--- a/src/web/templates/admin/tournaments/distribute_players_modal.html
+++ b/src/web/templates/admin/tournaments/distribute_players_modal.html
@@ -67,7 +67,7 @@
                                     id="tournament-checkbox-{{ tournament.id }}"
                                     name="tournament_ids"
                                     value="{{ tournament.id }}"
-                                    class="tournament-checkbox mb-1"
+                                    class="form-check-input tournament-checkbox mb-2"
                                     type="checkbox"
                                     {% if tournament.id not in unselected_tournament_ids %}
                                         checked


### PR DESCRIPTION
Before:  
<img width="273" height="214" alt="image" src="https://github.com/user-attachments/assets/8dd31877-1d51-496f-9586-1532aba2ae28" />
<img width="620" height="108" alt="image" src="https://github.com/user-attachments/assets/c862b940-70b4-4310-a8e9-41650e7b4bf7" />

After:  
<img width="308" height="188" alt="image" src="https://github.com/user-attachments/assets/340d62b0-0099-458c-977d-81f032bb9d90" />
<img width="616" height="116" alt="image" src="https://github.com/user-attachments/assets/e21c68c6-9700-4d42-b56c-2270e1e07760" />  

Blue color kept on places where primary was not appropriate (ex: table headers with primary color)