### PR TITLE
chore: Convert stored timestamp fields from float to datetime (#871)

### DIFF
--- a/src/data/event.py
+++ b/src/data/event.py
@@ -32,7 +32,7 @@ from database.sqlite.event.event_database import EventDatabase
 from plugins.manager import plugin_manager
 from plugins.utils import PluginData, Plugin
 from utils import Utils
-from utils.date_time import format_date, format_date_range, format_datetime
+from utils.date_time import format_date, format_date_range
 from utils.enum import (
     RoleType,
     ScreenType,
@@ -298,10 +298,6 @@ class Event:
     @property
     def last_update(self) -> datetime:
         return EventDatabase.database_modified_at(self.uniq_id)
-
-    @cached_property
-    def last_update_str(self) -> str:
-        return format_datetime(self.last_update)
 
     @cached_property
     def timers_by_id(self) -> dict[int, Timer]:

--- a/src/data/event.py
+++ b/src/data/event.py
@@ -2,7 +2,7 @@ import copy
 import itertools
 from collections import defaultdict
 from contextlib import suppress
-from datetime import date
+from datetime import date, datetime
 from functools import total_ordering, cached_property
 from logging import Logger
 from operator import attrgetter
@@ -32,7 +32,7 @@ from database.sqlite.event.event_database import EventDatabase
 from plugins.manager import plugin_manager
 from plugins.utils import PluginData, Plugin
 from utils import Utils
-from utils.date_time import format_date, format_date_range, format_timestamp_date_time
+from utils.date_time import format_date, format_date_range, format_datetime
 from utils.enum import (
     RoleType,
     ScreenType,
@@ -296,12 +296,12 @@ class Event:
         return [rotator for rotator in self.sorted_rotators if rotator.public]
 
     @property
-    def last_update(self) -> float:
-        return EventDatabase.database_modified_timestamp(self.uniq_id)
+    def last_update(self) -> datetime:
+        return EventDatabase.database_modified_at(self.uniq_id)
 
     @cached_property
     def last_update_str(self) -> str:
-        return format_timestamp_date_time(self.last_update)
+        return format_datetime(self.last_update)
 
     @cached_property
     def timers_by_id(self) -> dict[int, Timer]:

--- a/src/data/family.py
+++ b/src/data/family.py
@@ -1,5 +1,6 @@
 import functools
 import weakref
+from datetime import datetime
 from functools import cached_property
 from math import ceil
 from typing import TYPE_CHECKING, Optional
@@ -7,7 +8,7 @@ from _weakref import ReferenceType
 
 from common.i18n import _
 from data.screen import Screen
-from utils.date_time import format_timestamp_date_time
+from utils.date_time import format_datetime
 from utils.enum import (
     ScreenType,
     PlayersScreenPlayerFormat,
@@ -249,12 +250,12 @@ class Family:
         )
 
     @property
-    def last_update(self) -> float | None:
+    def last_update(self) -> datetime | None:
         return self.stored_family.last_update
 
     @property
     def last_update_str(self) -> str | None:
-        return format_timestamp_date_time(self.last_update)
+        return format_datetime(self.last_update) if self.last_update else None
 
     def _calculate_screens(self) -> bool:
         players_instead_of_boards: bool

--- a/src/data/family.py
+++ b/src/data/family.py
@@ -8,7 +8,7 @@ from _weakref import ReferenceType
 
 from common.i18n import _
 from data.screen import Screen
-from utils.date_time import format_datetime
+
 from utils.enum import (
     ScreenType,
     PlayersScreenPlayerFormat,
@@ -252,10 +252,6 @@ class Family:
     @property
     def last_update(self) -> datetime | None:
         return self.stored_family.last_update
-
-    @property
-    def last_update_str(self) -> str | None:
-        return format_datetime(self.last_update) if self.last_update else None
 
     def _calculate_screens(self) -> bool:
         players_instead_of_boards: bool

--- a/src/data/screen.py
+++ b/src/data/screen.py
@@ -714,7 +714,7 @@ class Screen:
             return self.stored_screen.last_update or 0.0
         if self.family is None:
             raise RuntimeError('Family reference unexpectedly None')
-        return self.family.last_update or 0.0
+        return self.family.last_update.timestamp() if self.family.last_update else 0.0
 
     @property
     def background_image(self) -> str:

--- a/src/data/screen.py
+++ b/src/data/screen.py
@@ -14,7 +14,7 @@ from common.sharly_chess_config import SharlyChessConfig
 from data.board import Board
 from data.screen_set import ScreenSet
 from data.timer import Timer
-from utils.date_time import format_datetime
+
 from utils.enum import (
     ScreenType,
     PlayersScreenPlayerFormat,
@@ -750,7 +750,3 @@ class Screen:
         if self.family is None:
             raise RuntimeError('Family reference unexpectedly None')
         return self.family.message_text
-
-    @property
-    def last_update_str(self) -> str | None:
-        return format_datetime(self.last_update) if self.last_update else None

--- a/src/data/screen.py
+++ b/src/data/screen.py
@@ -14,7 +14,7 @@ from common.sharly_chess_config import SharlyChessConfig
 from data.board import Board
 from data.screen_set import ScreenSet
 from data.timer import Timer
-from utils.date_time import format_timestamp_date_time
+from utils.date_time import format_datetime
 from utils.enum import (
     ScreenType,
     PlayersScreenPlayerFormat,
@@ -709,12 +709,12 @@ class Screen:
                 raise ValueError(f'type=[{self.type}]')
 
     @property
-    def last_update(self) -> float:
+    def last_update(self) -> datetime | None:
         if self.stored_screen:
-            return self.stored_screen.last_update or 0.0
+            return self.stored_screen.last_update
         if self.family is None:
             raise RuntimeError('Family reference unexpectedly None')
-        return self.family.last_update.timestamp() if self.family.last_update else 0.0
+        return self.family.last_update
 
     @property
     def background_image(self) -> str:
@@ -753,4 +753,4 @@ class Screen:
 
     @property
     def last_update_str(self) -> str | None:
-        return format_timestamp_date_time(self.last_update)
+        return format_datetime(self.last_update) if self.last_update else None

--- a/src/data/screen_set.py
+++ b/src/data/screen_set.py
@@ -463,7 +463,9 @@ class ScreenSet:
             return self.stored_screen_set.last_update
         else:
             assert self.family is not None
-            return self.family.last_update
+            return (
+                self.family.last_update.timestamp() if self.family.last_update else None
+            )
 
     @property
     def last_update_str(self) -> str:

--- a/src/data/screen_set.py
+++ b/src/data/screen_set.py
@@ -9,7 +9,7 @@ from common.i18n import _
 from data.board import Board
 from data.player import TournamentPlayer
 from datetime import datetime
-from utils.date_time import format_datetime
+
 from utils.enum import (
     ScreenType,
     PlayersScreenPlayerFormat,
@@ -465,10 +465,6 @@ class ScreenSet:
         else:
             assert self.family is not None
             return self.family.last_update
-
-    @property
-    def last_update_str(self) -> str | None:
-        return format_datetime(self.last_update) if self.last_update else None
 
     @property
     def numbers_str(self) -> str:

--- a/src/data/screen_set.py
+++ b/src/data/screen_set.py
@@ -8,7 +8,8 @@ from _weakref import ReferenceType
 from common.i18n import _
 from data.board import Board
 from data.player import TournamentPlayer
-from utils.date_time import format_timestamp_date_time
+from datetime import datetime
+from utils.date_time import format_datetime
 from utils.enum import (
     ScreenType,
     PlayersScreenPlayerFormat,
@@ -458,18 +459,16 @@ class ScreenSet:
         return self.last_item
 
     @property
-    def last_update(self) -> float | None:
+    def last_update(self) -> datetime | None:
         if self.stored_screen_set:
             return self.stored_screen_set.last_update
         else:
             assert self.family is not None
-            return (
-                self.family.last_update.timestamp() if self.family.last_update else None
-            )
+            return self.family.last_update
 
     @property
-    def last_update_str(self) -> str:
-        return format_timestamp_date_time(self.last_update)
+    def last_update_str(self) -> str | None:
+        return format_datetime(self.last_update) if self.last_update else None
 
     @property
     def numbers_str(self) -> str:

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 import weakref
 from babel.lists import format_list
 from common.i18n import get_locale
@@ -218,15 +218,15 @@ class Tournament:
             return self.stored_tournament.last_rounds_no_byes
 
     @property
-    def last_update(self) -> float:
+    def last_update(self) -> datetime | None:
         return self.stored_tournament.last_update
 
     @property
-    def last_player_update(self) -> float:
+    def last_player_update(self) -> datetime | None:
         return self.stored_tournament.last_player_update
 
     @property
-    def last_pairing_update(self) -> float:
+    def last_pairing_update(self) -> datetime | None:
         return self.stored_tournament.last_pairing_update
 
     @property

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -1334,7 +1334,9 @@ class EventDatabase(MigrationDatabase):
             number=row['number'],
             message_default=cls.load_bool_from_database_field(row['message_default']),
             message_text=row['message_text'],
-            last_update=row['last_update'],
+            last_update=cls.load_optional_timestamp_from_database_field(
+                row['last_update']
+            ),
         )
 
     def get_stored_family(self, family_id: int) -> StoredFamily | None:

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -587,9 +587,15 @@ class EventDatabase(MigrationDatabase):
             check_in_open=cls.load_bool_from_database_field(row['check_in_open']),
             rounds=row['rounds'],
             rating=row['rating'],
-            last_update=row['last_update'],
-            last_player_update=row['last_player_update'],
-            last_pairing_update=row['last_pairing_update'],
+            last_update=cls.load_optional_timestamp_from_database_field(
+                row['last_update']
+            ),
+            last_player_update=cls.load_optional_timestamp_from_database_field(
+                row['last_player_update']
+            ),
+            last_pairing_update=cls.load_optional_timestamp_from_database_field(
+                row['last_pairing_update']
+            ),
             start_date=cls.load_optional_date_from_database_field(row['start_date']),
             stop_date=cls.load_optional_date_from_database_field(row['stop_date']),
             location=row['location'],
@@ -1499,7 +1505,9 @@ class EventDatabase(MigrationDatabase):
             background_color=row['background_color'],
             message_default=cls.load_bool_from_database_field(row['message_default']),
             message_text=row['message_text'],
-            last_update=row['last_update'],
+            last_update=cls.load_optional_timestamp_from_database_field(
+                row['last_update']
+            ),
         )
 
     def get_stored_screen(self, screen_id: int) -> StoredScreen | None:
@@ -1655,8 +1663,8 @@ class EventDatabase(MigrationDatabase):
     # StoredScreenSet
     # ---------------------------------------------------------------------------------
 
-    @staticmethod
-    def _row_to_stored_screen_set(row: dict[str, Any]) -> StoredScreenSet:
+    @classmethod
+    def _row_to_stored_screen_set(cls, row: dict[str, Any]) -> StoredScreenSet:
         return StoredScreenSet(
             id=row['id'],
             screen_id=row['screen_id'],
@@ -1666,7 +1674,9 @@ class EventDatabase(MigrationDatabase):
             fixed_boards_str=row['fixed_boards_str'],
             first=row['first'],
             last=row['last'],
-            last_update=row['last_update'],
+            last_update=cls.load_optional_timestamp_from_database_field(
+                row['last_update']
+            ),
         )
 
     def get_stored_screen_set(self, screen_set_id: int) -> StoredScreenSet | None:
@@ -1771,7 +1781,6 @@ class EventDatabase(MigrationDatabase):
         assert stored_screen_set is not None
         stored_screen_set.id = None
         stored_screen_set.screen_id = screen_id
-        stored_screen_set.last_update = time.time()
         stored_screen_set.order = self.get_stored_screen_next_set_order(
             stored_screen_set.screen_id
         )

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -179,8 +179,8 @@ class EventDatabase(MigrationDatabase):
         return EVENTS_DIR / f'{uniq_id}.{SharlyChessConfig.event_database_ext}'
 
     @classmethod
-    def database_modified_timestamp(cls, uniq_id: str) -> float:
-        return cls.event_database_path(uniq_id).lstat().st_mtime
+    def database_modified_at(cls, uniq_id: str) -> datetime:
+        return datetime.fromtimestamp(cls.event_database_path(uniq_id).lstat().st_mtime)
 
     def delete(self) -> Path:
         """Soft-deletes the event database file by archiving it."""

--- a/src/database/sqlite/event/event_store.py
+++ b/src/database/sqlite/event/event_store.py
@@ -282,7 +282,7 @@ class StoredFamily:
     public: bool = True
     message_default: bool = True
     message_text: str | None = None
-    last_update: float = 0.0
+    last_update: datetime | None = None
     errors: dict[str, str] = field(default_factory=dict[str, str])
 
 

--- a/src/database/sqlite/event/event_store.py
+++ b/src/database/sqlite/event/event_store.py
@@ -172,9 +172,9 @@ class StoredTournament:
     rounds: int = 1
     rating: int = 1
     player_rating_type: int | None = None
-    last_update: float = 0.0
-    last_player_update: float = 0.0
-    last_pairing_update: float = 0.0
+    last_update: datetime | None = None
+    last_player_update: datetime | None = None
+    last_pairing_update: datetime | None = None
     three_points_for_a_win: bool = False
     override_unrated_rapid_blitz: bool = True
     pab_value: int = Result.WIN.value
@@ -212,7 +212,7 @@ class StoredScreenSet:
     fixed_boards_str: str | None
     first: int | None
     last: int | None
-    last_update: float = 0.0
+    last_update: datetime | None = None
     errors: dict[str, str] = field(default_factory=dict[str, str])
 
 
@@ -245,7 +245,7 @@ class StoredScreen:
     stored_screen_sets: list[StoredScreenSet] = field(
         default_factory=list[StoredScreenSet]
     )
-    last_update: float = 0.0
+    last_update: datetime | None = None
     public: bool = True
     message_default: bool = True
     message_text: str | None = None

--- a/src/database/sqlite/sqlite_database.py
+++ b/src/database/sqlite/sqlite_database.py
@@ -170,6 +170,12 @@ class SQLiteDatabase:
         return datetime.fromtimestamp(ts) if ts else None
 
     @staticmethod
+    def dump_optional_datetime_to_timestamp_field(
+        datetime_: datetime | None,
+    ) -> float | None:
+        return datetime_.timestamp() if datetime_ else None
+
+    @staticmethod
     def dump_datetime_to_database_field(datetime_: datetime) -> str:
         return datetime_.strftime('%Y-%m-%dT%H:%M')
 

--- a/src/plugins/chess_results/chess_results_background_uploader.py
+++ b/src/plugins/chess_results/chess_results_background_uploader.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from enum import IntEnum
 from functools import partial
 from threading import Thread, Timer
-from time import time
 
 from common.i18n import _, set_locale
 from common.logger import (
@@ -109,7 +109,7 @@ class ChessResultsBackgroundUploader:
     @classmethod
     def chess_results_last_upload(
         cls, tournament: Tournament | StoredTournament
-    ) -> float:
+    ) -> datetime | None:
         plugin_data: ChessResultsTournamentPluginData
         if isinstance(tournament, Tournament):
             assert isinstance(tournament, Tournament)
@@ -120,20 +120,16 @@ class ChessResultsBackgroundUploader:
                 raw_plugin_data
             )
 
-        return plugin_data.last_upload or 0.0
+        return plugin_data.last_upload
 
     @classmethod
     def chess_results_upload_needed(
         cls, tournament: Tournament | StoredTournament
     ) -> bool:
-        return cls.chess_results_last_upload(tournament) < max(
-            tournament.last_update.timestamp() if tournament.last_update else 0,
-            tournament.last_player_update.timestamp()
-            if tournament.last_player_update
-            else 0,
-            tournament.last_pairing_update.timestamp()
-            if tournament.last_pairing_update
-            else 0,
+        return (cls.chess_results_last_upload(tournament) or datetime.min) < max(
+            tournament.last_update or datetime.min,
+            tournament.last_player_update or datetime.min,
+            tournament.last_pairing_update or datetime.min,
         )
 
     @classmethod
@@ -333,8 +329,13 @@ class ChessResultsBackgroundUploader:
         delay = ChessResultsUtils.resolve_auto_upload_delay(tournament.event)
         wait_time = 0.1
         result_id = cls.result_id(tournament.event.uniq_id, tournament.id)
-        if not force and time() < chess_results_last_upload + delay * 60:
-            wait_time = max(delay * 60 - (time() - chess_results_last_upload), 0.1)
+        if (
+            not force
+            and chess_results_last_upload
+            and datetime.now() < chess_results_last_upload + timedelta(minutes=delay)
+        ):
+            elapsed = (datetime.now() - chess_results_last_upload).total_seconds()
+            wait_time = max(delay * 60 - elapsed, 0.1)
             cls.upload_status_messages[result_id] = ChessResultsUploadResult(
                 ChessResultsUploadStatus.PENDING,
                 _('Tournament modified, awaiting auto-upload'),

--- a/src/plugins/chess_results/chess_results_background_uploader.py
+++ b/src/plugins/chess_results/chess_results_background_uploader.py
@@ -127,9 +127,13 @@ class ChessResultsBackgroundUploader:
         cls, tournament: Tournament | StoredTournament
     ) -> bool:
         return cls.chess_results_last_upload(tournament) < max(
-            tournament.last_update,
-            tournament.last_player_update,
-            tournament.last_pairing_update,
+            tournament.last_update.timestamp() if tournament.last_update else 0,
+            tournament.last_player_update.timestamp()
+            if tournament.last_player_update
+            else 0,
+            tournament.last_pairing_update.timestamp()
+            if tournament.last_pairing_update
+            else 0,
         )
 
     @classmethod

--- a/src/plugins/chess_results/utils.py
+++ b/src/plugins/chess_results/utils.py
@@ -18,6 +18,7 @@ from common import DEVEL_ENV, SharlyChessException
 from common.logger import get_logger
 from data.event import Event
 from data.tournament import Tournament
+from database.sqlite.sqlite_database import SQLiteDatabase
 from plugins.chess_results import PLUGIN_NAME, PLUGIN_DIR
 from plugins.utils import PluginData, PluginUtils
 from web.controllers.base_controller import WebContext
@@ -294,9 +295,9 @@ class ChessResultsTournamentPluginData(PluginData):
             auto_upload=stored_value.get('auto_upload', None),
             remark=stored_value.get('remark'),
             remark_default=stored_value.get('remark_default', True),
-            last_upload=datetime.fromtimestamp(ts)
-            if (ts := stored_value.get('last_upload'))
-            else None,
+            last_upload=SQLiteDatabase.load_optional_timestamp_from_database_field(
+                stored_value.get('last_upload')
+            ),
         )
 
     def to_stored_value(self) -> dict[str, Any]:
@@ -306,7 +307,9 @@ class ChessResultsTournamentPluginData(PluginData):
             'auto_upload': self.auto_upload,
             'remark': self.remark,
             'remark_default': self.remark_default,
-            'last_upload': self.last_upload.timestamp() if self.last_upload else None,
+            'last_upload': SQLiteDatabase.dump_optional_datetime_to_timestamp_field(
+                self.last_upload
+            ),
         }
 
     @classmethod

--- a/src/plugins/chess_results/utils.py
+++ b/src/plugins/chess_results/utils.py
@@ -282,7 +282,7 @@ class ChessResultsTournamentPluginData(PluginData):
     auto_upload: bool | None = None
     tnr: str | None = None
     creator_id: str | None = None
-    last_upload: float | None = None
+    last_upload: datetime | None = None
     remark: str | None = None
     remark_default: bool = True
 
@@ -294,7 +294,9 @@ class ChessResultsTournamentPluginData(PluginData):
             auto_upload=stored_value.get('auto_upload', None),
             remark=stored_value.get('remark'),
             remark_default=stored_value.get('remark_default', True),
-            last_upload=stored_value.get('last_upload', 0.0),
+            last_upload=datetime.fromtimestamp(ts)
+            if (ts := stored_value.get('last_upload'))
+            else None,
         )
 
     def to_stored_value(self) -> dict[str, Any]:
@@ -304,7 +306,7 @@ class ChessResultsTournamentPluginData(PluginData):
             'auto_upload': self.auto_upload,
             'remark': self.remark,
             'remark_default': self.remark_default,
-            'last_upload': self.last_upload,
+            'last_upload': self.last_upload.timestamp() if self.last_upload else None,
         }
 
     @classmethod
@@ -316,7 +318,7 @@ class ChessResultsTournamentPluginData(PluginData):
     ) -> Self:
         tnr: str | None = None
         creator_id: str | None = None
-        last_upload: float | None = None
+        last_upload: datetime | None = None
         if previous_object and action != 'clone':
             tnr = previous_object.tnr
             creator_id = previous_object.creator_id

--- a/src/plugins/chessevent/tournament_importer/importer.py
+++ b/src/plugins/chessevent/tournament_importer/importer.py
@@ -1,5 +1,4 @@
 import json
-import time
 import zoneinfo
 from datetime import datetime, timedelta
 
@@ -181,7 +180,7 @@ class ChessEventTournamentImporter(TournamentImporter):
             event_id=request_data.event_id,
             tournament_name=request_data.tournament_name,
             status=SuccessChessEventStatus().id,
-            last_sync=time.time(),
+            last_sync=datetime.now(),
         ).to_stored_value()
 
         stored_players: list[StoredPlayer] = []

--- a/src/plugins/chessevent/utils.py
+++ b/src/plugins/chessevent/utils.py
@@ -5,6 +5,7 @@ from typing import Any, Self, override
 
 from data.event import Event
 from data.tournament import Tournament
+from database.sqlite.sqlite_database import SQLiteDatabase
 from plugins.chessevent import PLUGIN_NAME
 from plugins.utils import PluginData, PluginUtils
 from plugins.chessevent.chessevent_status import (
@@ -171,9 +172,9 @@ class ChessEventTournamentPluginData(PluginData):
             event_id=stored_value.get('event_id'),
             tournament_name=stored_value.get('tournament_name'),
             status=stored_value.get('status'),
-            last_sync=datetime.fromtimestamp(ts)
-            if (ts := stored_value.get('last_sync'))
-            else None,
+            last_sync=SQLiteDatabase.load_optional_timestamp_from_database_field(
+                stored_value.get('last_sync')
+            ),
         )
 
     def to_stored_value(self) -> dict[str, Any]:
@@ -183,7 +184,9 @@ class ChessEventTournamentPluginData(PluginData):
             'event_id': self.event_id,
             'tournament_name': self.tournament_name,
             'status': self.status,
-            'last_sync': self.last_sync.timestamp() if self.last_sync else None,
+            'last_sync': SQLiteDatabase.dump_optional_datetime_to_timestamp_field(
+                self.last_sync
+            ),
         }
 
     @classmethod

--- a/src/plugins/chessevent/utils.py
+++ b/src/plugins/chessevent/utils.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from functools import partial
 from typing import Any, Self, override
 
@@ -160,7 +161,7 @@ class ChessEventTournamentPluginData(PluginData):
     event_id: str | None = None
     tournament_name: str | None = None
     status: str | None = None
-    last_sync: float | None = None
+    last_sync: datetime | None = None
 
     @classmethod
     def from_stored_value(cls, stored_value: dict[str, Any]) -> Self:
@@ -170,7 +171,9 @@ class ChessEventTournamentPluginData(PluginData):
             event_id=stored_value.get('event_id'),
             tournament_name=stored_value.get('tournament_name'),
             status=stored_value.get('status'),
-            last_sync=stored_value.get('last_sync', 0.0),
+            last_sync=datetime.fromtimestamp(ts)
+            if (ts := stored_value.get('last_sync'))
+            else None,
         )
 
     def to_stored_value(self) -> dict[str, Any]:
@@ -180,7 +183,7 @@ class ChessEventTournamentPluginData(PluginData):
             'event_id': self.event_id,
             'tournament_name': self.tournament_name,
             'status': self.status,
-            'last_sync': self.last_sync,
+            'last_sync': self.last_sync.timestamp() if self.last_sync else None,
         }
 
     @classmethod
@@ -195,7 +198,7 @@ class ChessEventTournamentPluginData(PluginData):
         event_id: str | None = None
         tournament_name: str | None = None
         status: str | None = None
-        last_sync: float | None = None
+        last_sync: datetime | None = None
         if previous_object and action != 'clone':
             user = previous_object.user
             password = previous_object.password

--- a/src/plugins/ffe/ffe_background_uploader.py
+++ b/src/plugins/ffe/ffe_background_uploader.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from enum import IntEnum
 from functools import partial
 from threading import Thread, Timer
-from time import time
 
 from common.i18n import _, set_locale
 from common.logger import (
@@ -118,7 +118,9 @@ class FfeBackgroundUploader:
         return True
 
     @classmethod
-    def ffe_last_upload(cls, tournament: Tournament | StoredTournament) -> float:
+    def ffe_last_upload(
+        cls, tournament: Tournament | StoredTournament
+    ) -> datetime | None:
         plugin_data: FfeTournamentPluginData
         if isinstance(tournament, Tournament):
             assert isinstance(tournament, Tournament)
@@ -127,18 +129,14 @@ class FfeBackgroundUploader:
             raw_plugin_data = tournament.plugin_data.get(PLUGIN_NAME, {})
             plugin_data = FfeTournamentPluginData.from_stored_value(raw_plugin_data)
 
-        return plugin_data.last_upload or 0.0
+        return plugin_data.last_upload
 
     @classmethod
     def ffe_upload_needed(cls, tournament: Tournament | StoredTournament) -> bool:
-        return cls.ffe_last_upload(tournament) < max(
-            tournament.last_update.timestamp() if tournament.last_update else 0,
-            tournament.last_player_update.timestamp()
-            if tournament.last_player_update
-            else 0,
-            tournament.last_pairing_update.timestamp()
-            if tournament.last_pairing_update
-            else 0,
+        return (cls.ffe_last_upload(tournament) or datetime.min) < max(
+            tournament.last_update or datetime.min,
+            tournament.last_player_update or datetime.min,
+            tournament.last_pairing_update or datetime.min,
         )
 
     @classmethod
@@ -341,8 +339,13 @@ class FfeBackgroundUploader:
         delay = FFEUtils.resolve_auto_upload_delay(tournament.event)
         wait_time = 0.1
         result_id = cls.result_id(tournament.event.uniq_id, tournament.id)
-        if not force and time() < ffe_last_upload + delay * 60:
-            wait_time = max(delay * 60 - (time() - ffe_last_upload), 0.1)
+        if (
+            not force
+            and ffe_last_upload
+            and datetime.now() < ffe_last_upload + timedelta(minutes=delay)
+        ):
+            elapsed = (datetime.now() - ffe_last_upload).total_seconds()
+            wait_time = max(delay * 60 - elapsed, 0.1)
             cls.upload_status_messages[result_id] = FfeUploadResult(
                 FfeUploadStatus.PENDING, _('Tournament modified, awaiting auto-upload')
             )

--- a/src/plugins/ffe/ffe_background_uploader.py
+++ b/src/plugins/ffe/ffe_background_uploader.py
@@ -132,9 +132,13 @@ class FfeBackgroundUploader:
     @classmethod
     def ffe_upload_needed(cls, tournament: Tournament | StoredTournament) -> bool:
         return cls.ffe_last_upload(tournament) < max(
-            tournament.last_update,
-            tournament.last_player_update,
-            tournament.last_pairing_update,
+            tournament.last_update.timestamp() if tournament.last_update else 0,
+            tournament.last_player_update.timestamp()
+            if tournament.last_player_update
+            else 0,
+            tournament.last_pairing_update.timestamp()
+            if tournament.last_pairing_update
+            else 0,
         )
 
     @classmethod

--- a/src/plugins/ffe/utils.py
+++ b/src/plugins/ffe/utils.py
@@ -247,8 +247,8 @@ class FfeTournamentPluginData(PluginData):
     ffe_id: int | None = None
     password: str | None = None
     auto_upload: bool | None = False
-    last_upload: float | None = None
-    last_rules_upload: float | None = None
+    last_upload: datetime | None = None
+    last_rules_upload: datetime | None = None
 
     @classmethod
     def from_stored_value(cls, stored_value: dict[str, Any]) -> Self:
@@ -256,8 +256,12 @@ class FfeTournamentPluginData(PluginData):
             ffe_id=stored_value.get('ffe_id', None),
             password=stored_value.get('password', None),
             auto_upload=stored_value.get('auto_upload', None),
-            last_upload=stored_value.get('last_upload', 0.0),
-            last_rules_upload=stored_value.get('last_rules_upload', 0.0),
+            last_upload=datetime.fromtimestamp(ts)
+            if (ts := stored_value.get('last_upload'))
+            else None,
+            last_rules_upload=datetime.fromtimestamp(ts)
+            if (ts := stored_value.get('last_rules_upload'))
+            else None,
         )
 
     def to_stored_value(self) -> dict[str, Any]:
@@ -265,8 +269,10 @@ class FfeTournamentPluginData(PluginData):
             'ffe_id': self.ffe_id,
             'password': self.password,
             'auto_upload': self.auto_upload,
-            'last_upload': self.last_upload,
-            'last_rules_upload': self.last_rules_upload,
+            'last_upload': self.last_upload.timestamp() if self.last_upload else None,
+            'last_rules_upload': self.last_rules_upload.timestamp()
+            if self.last_rules_upload
+            else None,
         }
 
     @classmethod
@@ -276,8 +282,8 @@ class FfeTournamentPluginData(PluginData):
         previous_object: Self | None = None,
         action: str | None = None,
     ) -> Self:
-        last_upload: float | None = None
-        last_rules_upload: float | None = None
+        last_upload: datetime | None = None
+        last_rules_upload: datetime | None = None
         if previous_object and action != 'clone':
             last_upload = previous_object.last_upload
             last_rules_upload = previous_object.last_rules_upload

--- a/src/plugins/ffe/utils.py
+++ b/src/plugins/ffe/utils.py
@@ -10,6 +10,7 @@ from data.account import Account
 from data.event import Event
 from data.player import Player
 from data.tournament import Tournament
+from database.sqlite.sqlite_database import SQLiteDatabase
 from plugins.ffe import PLUGIN_NAME
 from plugins.utils import PluginUtils, PluginData
 from utils.enum import FormAction
@@ -256,12 +257,12 @@ class FfeTournamentPluginData(PluginData):
             ffe_id=stored_value.get('ffe_id', None),
             password=stored_value.get('password', None),
             auto_upload=stored_value.get('auto_upload', None),
-            last_upload=datetime.fromtimestamp(ts)
-            if (ts := stored_value.get('last_upload'))
-            else None,
-            last_rules_upload=datetime.fromtimestamp(ts)
-            if (ts := stored_value.get('last_rules_upload'))
-            else None,
+            last_upload=SQLiteDatabase.load_optional_timestamp_from_database_field(
+                stored_value.get('last_upload')
+            ),
+            last_rules_upload=SQLiteDatabase.load_optional_timestamp_from_database_field(
+                stored_value.get('last_rules_upload')
+            ),
         )
 
     def to_stored_value(self) -> dict[str, Any]:
@@ -269,10 +270,12 @@ class FfeTournamentPluginData(PluginData):
             'ffe_id': self.ffe_id,
             'password': self.password,
             'auto_upload': self.auto_upload,
-            'last_upload': self.last_upload.timestamp() if self.last_upload else None,
-            'last_rules_upload': self.last_rules_upload.timestamp()
-            if self.last_rules_upload
-            else None,
+            'last_upload': SQLiteDatabase.dump_optional_datetime_to_timestamp_field(
+                self.last_upload
+            ),
+            'last_rules_upload': SQLiteDatabase.dump_optional_datetime_to_timestamp_field(
+                self.last_rules_upload
+            ),
         }
 
     @classmethod

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -64,7 +64,7 @@ class ScreenUserController(BaseScreenUserController):
         date_dt = datetime.fromtimestamp(date)
         if web_context.screen:
             assert web_context.screen.event is not None
-            if web_context.screen.event.last_update > date:
+            if web_context.screen.event.last_update > date_dt:
                 return True
             if (
                 web_context.screen.last_update
@@ -112,7 +112,7 @@ class ScreenUserController(BaseScreenUserController):
             assert web_context.family.event is not None
             if (
                 max(
-                    datetime.fromtimestamp(web_context.family.event.last_update),
+                    web_context.family.event.last_update,
                     web_context.family.last_update or datetime.min,
                 )
                 > date_dt

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -1,4 +1,5 @@
 from contextlib import suppress
+from datetime import datetime
 
 from litestar import head, get
 from litestar.plugins.htmx import HTMXRequest, Reswap
@@ -29,15 +30,13 @@ class ScreenUserController(BaseScreenUserController):
     @staticmethod
     def _user_screen_set_refresh_needed(
         screen_set: ScreenSet,
-        date: float,
+        date: datetime,
     ) -> bool:
         tournament: Tournament = screen_set.tournament
         if (
             max(
-                tournament.last_update.timestamp() if tournament.last_update else 0,
-                tournament.last_player_update.timestamp()
-                if tournament.last_player_update
-                else 0,
+                tournament.last_update or datetime.min,
+                tournament.last_player_update or datetime.min,
             )
             > date
         ):
@@ -46,7 +45,7 @@ class ScreenUserController(BaseScreenUserController):
             case ScreenType.BOARDS | ScreenType.INPUT | ScreenType.RANKING:
                 if (
                     tournament.last_pairing_update
-                    and tournament.last_pairing_update.timestamp() > date
+                    and tournament.last_pairing_update > date
                 ):
                     return True
             case ScreenType.PLAYERS:
@@ -62,13 +61,14 @@ class ScreenUserController(BaseScreenUserController):
         | DisplayControllerUserWebContext,
         date: float,
     ) -> bool:
+        date_dt = datetime.fromtimestamp(date)
         if web_context.screen:
             assert web_context.screen.event is not None
             if web_context.screen.event.last_update > date:
                 return True
             if (
                 web_context.screen.last_update
-                and web_context.screen.last_update.timestamp() > date
+                and web_context.screen.last_update > date_dt
             ):
                 return True
             match web_context.screen.type:
@@ -81,7 +81,7 @@ class ScreenUserController(BaseScreenUserController):
                     | ScreenType.RANKING
                 ):
                     for screen_set in web_context.screen.screen_sets:
-                        if cls._user_screen_set_refresh_needed(screen_set, date):
+                        if cls._user_screen_set_refresh_needed(screen_set, date_dt):
                             return True
                 case ScreenType.RESULTS:
                     assert web_context.screen.event is not None
@@ -99,14 +99,10 @@ class ScreenUserController(BaseScreenUserController):
                             )
                             if (
                                 max(
-                                    tournament.last_update.timestamp()
-                                    if tournament.last_update
-                                    else 0,
-                                    tournament.last_pairing_update.timestamp()
-                                    if tournament.last_pairing_update
-                                    else 0,
+                                    tournament.last_update or datetime.min,
+                                    tournament.last_pairing_update or datetime.min,
                                 )
-                                > date
+                                > date_dt
                             ):
                                 return True
                 case _:
@@ -116,12 +112,10 @@ class ScreenUserController(BaseScreenUserController):
             assert web_context.family.event is not None
             if (
                 max(
-                    web_context.family.event.last_update,
-                    web_context.family.last_update.timestamp()
-                    if web_context.family.last_update
-                    else 0,
+                    datetime.fromtimestamp(web_context.family.event.last_update),
+                    web_context.family.last_update or datetime.min,
                 )
-                > date
+                > date_dt
             ):
                 return True
         return False

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -105,7 +105,9 @@ class ScreenUserController(BaseScreenUserController):
             if (
                 max(
                     web_context.family.event.last_update,
-                    web_context.family.last_update or 0,
+                    web_context.family.last_update.timestamp()
+                    if web_context.family.last_update
+                    else 0,
                 )
                 > date
             ):

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -34,15 +34,20 @@ class ScreenUserController(BaseScreenUserController):
         tournament: Tournament = screen_set.tournament
         if (
             max(
-                tournament.last_update,
-                tournament.last_player_update,
+                tournament.last_update.timestamp() if tournament.last_update else 0,
+                tournament.last_player_update.timestamp()
+                if tournament.last_player_update
+                else 0,
             )
             > date
         ):
             return True
         match screen_set.type:
             case ScreenType.BOARDS | ScreenType.INPUT | ScreenType.RANKING:
-                if tournament.last_pairing_update > date:
+                if (
+                    tournament.last_pairing_update
+                    and tournament.last_pairing_update.timestamp() > date
+                ):
                     return True
             case ScreenType.PLAYERS:
                 pass
@@ -61,7 +66,10 @@ class ScreenUserController(BaseScreenUserController):
             assert web_context.screen.event is not None
             if web_context.screen.event.last_update > date:
                 return True
-            if web_context.screen.last_update > date:
+            if (
+                web_context.screen.last_update
+                and web_context.screen.last_update.timestamp() > date
+            ):
                 return True
             match web_context.screen.type:
                 case ScreenType.IMAGE:
@@ -91,8 +99,12 @@ class ScreenUserController(BaseScreenUserController):
                             )
                             if (
                                 max(
-                                    tournament.last_update,
-                                    tournament.last_pairing_update,
+                                    tournament.last_update.timestamp()
+                                    if tournament.last_update
+                                    else 0,
+                                    tournament.last_pairing_update.timestamp()
+                                    if tournament.last_pairing_update
+                                    else 0,
                                 )
                                 > date
                             ):


### PR DESCRIPTION
The PR wraps up the code cleaning targets specified in https://github.com/Sharly-Chess/sharly-chess/issues/871

- Change StoredFamily, StoredScreen, StoredScreenSet, and StoredTournament timestamp fields (last_update, last_player_update, last_pairing_update) from float to datetime | None
- Convert float→datetime at the DB read boundary using load_optional_timestamp_from_database_field() in _row_to_stored_* methods; DB write path remains as float
- Update wrapper classes (Family, Screen, ScreenSet, Tournament) to return datetime | None directly and use format_datetime() for display
- Add .timestamp() bridges at comparison sites for uploaders and screen poller.