### PR TITLE
Fix various norm bugs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,11 @@
 - Upgrade bbpPairings engine to v6.0.0 (3.6.0)
 - Display player history on crosstable document (3.6.0)
 
+## Norms
+
+- Fix player norms computation (3.6.2)
+- Added a note that norms are only computed based on completed games (3.6.2)
+
 ## Prizes
 
 - Added criteria type _Comment_ (3.6.0)

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -3316,6 +3316,9 @@ msgstr "N"
 msgid "NA *** SHORT NAME FOR National Arbiter"
 msgstr "NA"
 
+msgid "NOTE: Norms are computed only on <em>completed</em> games."
+msgstr ""
+
 msgid "Name"
 msgstr ""
 

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -3316,7 +3316,7 @@ msgstr "N"
 msgid "NA *** SHORT NAME FOR National Arbiter"
 msgstr "NA"
 
-msgid "NOTE: Norms are computed only on <em>completed</em> games."
+msgid "NOTE: Norms are computed based only on <em>completed</em> games."
 msgstr ""
 
 msgid "Name"

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -3316,8 +3316,8 @@ msgstr "N"
 msgid "NA *** SHORT NAME FOR National Arbiter"
 msgstr "AN"
 
-msgid "NOTE: Norms are computed only on <em>completed</em> games."
-msgstr "NOTE : Les normes ne sont calculés qu'à partir des parties <em>terminées</em>."
+msgid "NOTE: Norms are computed based only on <em>completed</em> games."
+msgstr "NOTE : Les normes ne sont calculées qu'à partir des parties <em>terminées</em>."
 
 msgid "Name"
 msgstr "Nom"

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -3316,6 +3316,9 @@ msgstr "N"
 msgid "NA *** SHORT NAME FOR National Arbiter"
 msgstr "AN"
 
+msgid "NOTE: Norms are computed only on <em>completed</em> games."
+msgstr "NOTE : Les normes ne sont calculés qu'à partir des parties <em>terminées</em>."
+
 msgid "Name"
 msgstr "Nom"
 

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -914,7 +914,7 @@ class TournamentPlayer(Player):
                 continue
             if (
                 p.federation == Federation(self.tournament.event.federation)
-                or p.federation == 'NON'  # 1.4.2a
+                or p.federation == Federation('NON')  # 1.4.2a
             ):
                 continue
             missed_rounds = 0

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -689,7 +689,7 @@ class TournamentPlayer(Player):
 
         is_round_robin = self.tournament.pairing_system == RoundRobinPairingSystem()
 
-        for rnd, pairing in self.pairings_by_round.items():
+        for pairing in self.pairings_by_round.values():
             if pairing.result.is_board_bye or pairing.result == Result.FORFEIT_WIN:
                 forfeits_or_byes += 1
 
@@ -918,76 +918,50 @@ class TournamentPlayer(Player):
             ):
                 continue
             missed_rounds = 0
-            for r, pairing in p.pairings_by_round.items():
+            for pairing in p.pairings_by_round.values():
                 if pairing.unplayed and pairing.result not in [
-                    Result.FORFEIT_WIN,
                     Result.PAIRING_ALLOCATED_BYE,
                     Result.REST_GAME,
                 ]:
                     missed_rounds += 1
-            if missed_rounds > 1:
-                continue
-
-            eligible_players.append(p)
-
-        # Per-round counts among eligible & present -----------------
-        worst_players: float = float('inf')
-        worst_federations: float = float('inf')
-        worst_titled: float = float('inf')
-        meets_156 = True
-
-        for rnd in range(1, self.tournament.rounds + 1):
-            present: list[TournamentPlayer] = []
-            for p in eligible_players:
-                missing_games: int = 0
-                pairing: Pairing | None = p.pairings_by_round.get(rnd)
-                if pairing and (
-                    pairing.played
-                    or pairing.result
-                    in [
-                        Result.PAIRING_ALLOCATED_BYE,
-                        Result.REST_GAME,
-                    ]
-                ):
-                    missing_games += 1
-                    if missing_games > 1:
+                    if missed_rounds > 1:
+                        # stop searching once we get 2 missing rounds
                         break
-                else:
-                    present.append(p)
+            else:  # no-break
+                eligible_players.append(p)
 
-            n_players = len(present)
-            n_titled = sum(1 for p in present if p.title != PlayerTitle.NONE)
+        # NOTE(Amaras): here `eligible_players` holds *all* the FIDE-rated players not from
+        # the host federation that have missed at most 1 round
 
-            # 1.4.2a
-            present_not_fid = [p for p in present if p.federation != 'FID']
-            n_feds = len({p.federation for p in present_not_fid})
-
-            # Track worst (minimum) across rounds
-            worst_players = min(worst_players, n_players)
-            worst_federations = min(worst_federations, n_feds)
-            worst_titled = min(worst_titled, n_titled)
-
-        # Handle case of zero rounds gracefully
-        if worst_players is float('inf'):
-            worst_players = 0
-            worst_federations = 0
-            worst_titled = 0
+        foreign_rated = len(eligible_players)
+        other_federations = len({p.federation for p in eligible_players})
+        foreign_titled = sum(
+            1
+            for p in eligible_players
+            if p.title
+            in (
+                PlayerTitle.GRANDMASTER,
+                PlayerTitle.INTERNATIONAL_MASTER,
+                PlayerTitle.WOMAN_GRANDMASTER,
+                PlayerTitle.WOMAN_INTERNATIONAL_MASTER,
+            )
+        )
 
         msg = _(
             '<b>1.4.3d</b> Swiss System tournaments in which participants include in every round at least 20 FIDE rated players, not from the host federation, from at least 3 different federations, at least 10 of whom hold GM, IM, WGM or WIM titles.'
         )
         for tn, res in results.items():
-            res.all_federations_count = int(worst_federations)
+            res.all_federations_count = int(other_federations)
             res.not_enough_all_federations = (
                 msg if res.all_federations_count < 3 else None
             )
 
-            res.eligible_players_title_count = int(worst_titled)
+            res.eligible_players_title_count = int(foreign_titled)
             res.not_enough_all_title_holders = (
                 msg if res.eligible_players_title_count < 10 else None
             )
 
-            res.eligible_players_count = int(worst_players)
+            res.eligible_players_count = int(foreign_rated)
             res.not_enough_foreign_players = (
                 msg if res.eligible_players_count < 20 else None
             )
@@ -1003,53 +977,30 @@ class TournamentPlayer(Player):
             if p.rating_type != PlayerRatingType.FIDE:
                 continue
             if (
-                p.federation == 'NON'  # 1.4.2a
+                p.federation == Federation('NON')  # 1.4.2a
             ):
                 continue
-
-            missed_rounds = 0
-            for r, pairing in p.pairings_by_round.items():
+            missed_rounds: int = 0
+            for pairing in p.pairings_by_round.values():
                 if pairing.unplayed and pairing.result not in [
-                    Result.FORFEIT_WIN,
                     Result.PAIRING_ALLOCATED_BYE,
                     Result.REST_GAME,
                 ]:
                     missed_rounds += 1
-            if missed_rounds > 1:
-                continue
-
-            eligible_players.append(p)
-
-        for rnd in range(1, self.tournament.rounds + 1):
-            present: list[TournamentPlayer] = []
-            for p in eligible_players:
-                missed_rounds: int = 0
-                pairing: Pairing | None = p.pairings_by_round.get(rnd)
-                if pairing and (
-                    pairing.played
-                    or pairing.result
-                    in [
-                        Result.PAIRING_ALLOCATED_BYE,
-                        Result.REST_GAME,
-                    ]
-                ):
-                    missed_rounds += 1
                     if missed_rounds > 1:
                         break
-                else:
-                    present.append(p)
-
-            n_players = len(present)
-
-            # 1.5.6a
-            # Check if the average rating of the top 40 eligible players is at least 2000 in every round
-            if n_players < 40:
-                meets_156 = False
             else:
-                top_rated = sorted([p.rating for p in present], reverse=True)[:40]
-                avg: float = sum(top_rated) / len(top_rated) if top_rated else 0
-                if avg < 2000:
-                    meets_156 = False
+                eligible_players.append(p)
+
+        # NOTE(Amaras): here `eligible_players` hold all players from valid federations who
+        # missed at most one round.
+
+        top_rated = sorted([p.rating for p in eligible_players])[:40]
+        if len(top_rated) < 40:
+            meets_156 = False
+        else:
+            avg = sum(top_rated) / len(top_rated)
+            meets_156 = avg >= 2000
 
         for tn, res in results.items():
             res.requirement_156a_met = meets_156

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -999,7 +999,7 @@ class TournamentPlayer(Player):
         if len(top_rated) < 40:
             meets_156 = False
         else:
-            avg = sum(top_rated) / len(top_rated)
+            avg: float = sum(top_rated) / len(top_rated)
             meets_156 = avg >= 2000
 
         for tn, res in results.items():

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -689,7 +689,7 @@ class TournamentPlayer(Player):
 
         is_round_robin = self.tournament.pairing_system == RoundRobinPairingSystem()
 
-        for pairing in self.pairings_by_round.values():
+        for rnd, pairing in self.pairings_by_round.items():
             if pairing.result.is_board_bye or pairing.result == Result.FORFEIT_WIN:
                 forfeits_or_byes += 1
 
@@ -918,50 +918,80 @@ class TournamentPlayer(Player):
             ):
                 continue
             missed_rounds = 0
-            for pairing in p.pairings_by_round.values():
+            for r, pairing in p.pairings_by_round.items():
                 if pairing.unplayed and pairing.result not in [
+                    Result.FORFEIT_WIN,
                     Result.PAIRING_ALLOCATED_BYE,
                     Result.REST_GAME,
                 ]:
                     missed_rounds += 1
-                    if missed_rounds > 1:
-                        # stop searching once we get 2 missing rounds
-                        break
-            else:  # no-break
-                eligible_players.append(p)
+            if missed_rounds > 1:
+                continue
+            eligible_players.append(p)
 
-        # NOTE(Amaras): here `eligible_players` holds *all* the FIDE-rated players not from
-        # the host federation that have missed at most 1 round
+        # Per-round counts among eligible & present -----------------
+        worst_players: float = float('inf')
+        worst_federations: float = float('inf')
+        worst_titled: float = float('inf')
+        meets_156 = True
 
-        foreign_rated = len(eligible_players)
-        other_federations = len({p.federation for p in eligible_players})
-        foreign_titled = sum(
-            1
-            for p in eligible_players
-            if p.title
-            in (
-                PlayerTitle.GRANDMASTER,
-                PlayerTitle.INTERNATIONAL_MASTER,
-                PlayerTitle.WOMAN_GRANDMASTER,
-                PlayerTitle.WOMAN_INTERNATIONAL_MASTER,
+        for rnd in range(1, self.tournament.rounds + 1):
+            present: list[TournamentPlayer] = []
+            for p in eligible_players:
+                pairing: Pairing | None = p.pairings_by_round.get(rnd)
+                if pairing and (
+                    pairing.played
+                    or pairing.result
+                    in [
+                        Result.PAIRING_ALLOCATED_BYE,
+                        Result.REST_GAME,
+                    ]
+                ):
+                    present.append(p)
+
+            n_players = len(present)
+            n_titled = sum(
+                1
+                for p in present
+                if p.title
+                in (
+                    PlayerTitle.GRANDMASTER,
+                    PlayerTitle.INTERNATIONAL_MASTER,
+                    PlayerTitle.WOMAN_GRANDMASTER,
+                    PlayerTitle.WOMAN_INTERNATIONAL_MASTER,
+                )
             )
-        )
+
+            # 1.4.2a
+            present_not_fid = [p for p in present if p.federation != Federation('FID')]
+            n_feds = len({p.federation for p in present_not_fid})
+
+            # Track worst (minimum) across rounds
+            worst_players = min(worst_players, n_players)
+            worst_federations = min(worst_federations, n_feds)
+            worst_titled = min(worst_titled, n_titled)
+
+        # Handle case of zero rounds gracefully
+        if worst_players is float('inf'):
+            worst_players = 0
+            worst_federations = 0
+            worst_titled = 0
 
         msg = _(
             '<b>1.4.3d</b> Swiss System tournaments in which participants include in every round at least 20 FIDE rated players, not from the host federation, from at least 3 different federations, at least 10 of whom hold GM, IM, WGM or WIM titles.'
         )
         for tn, res in results.items():
-            res.all_federations_count = int(other_federations)
+            res.all_federations_count = int(worst_federations)
             res.not_enough_all_federations = (
                 msg if res.all_federations_count < 3 else None
             )
 
-            res.eligible_players_title_count = int(foreign_titled)
+            res.eligible_players_title_count = int(worst_titled)
             res.not_enough_all_title_holders = (
                 msg if res.eligible_players_title_count < 10 else None
             )
 
-            res.eligible_players_count = int(foreign_rated)
+            res.eligible_players_count = int(worst_players)
             res.not_enough_foreign_players = (
                 msg if res.eligible_players_count < 20 else None
             )
@@ -980,27 +1010,44 @@ class TournamentPlayer(Player):
                 p.federation == Federation('NON')  # 1.4.2a
             ):
                 continue
+
             missed_rounds: int = 0
-            for pairing in p.pairings_by_round.values():
+            for r, pairing in p.pairings_by_round.items():
                 if pairing.unplayed and pairing.result not in [
+                    Result.FORFEIT_WIN,
                     Result.PAIRING_ALLOCATED_BYE,
                     Result.REST_GAME,
                 ]:
                     missed_rounds += 1
-                    if missed_rounds > 1:
-                        break
-            else:
-                eligible_players.append(p)
+            if missed_rounds > 1:
+                continue
+            eligible_players.append(p)
 
-        # NOTE(Amaras): here `eligible_players` hold all players from valid federations who
-        # missed at most one round.
+        for rnd in range(1, self.tournament.rounds + 1):
+            present: list[TournamentPlayer] = []
+            for p in eligible_players:
+                pairing: Pairing | None = p.pairings_by_round.get(rnd)
+                if pairing and (
+                    pairing.played
+                    or pairing.result
+                    in [
+                        Result.PAIRING_ALLOCATED_BYE,
+                        Result.REST_GAME,
+                    ]
+                ):
+                    present.append(p)
 
-        top_rated = sorted([p.rating for p in eligible_players])[:40]
-        if len(top_rated) < 40:
-            meets_156 = False
-        else:
+            # 1.5.6a
+            # Check if the average rating of the top 40 eligible players is at least 2000 in every round
+            # if n_players < 40:
+            #     meets_156 = False
+            top_rated = sorted([p.rating for p in present], reverse=True)[:40]
+            if len(top_rated) < 40:
+                meets_156 = False
             avg: float = sum(top_rated) / len(top_rated)
-            meets_156 = avg >= 2000
+            meets_156 = meets_156 and avg >= 2000
+            if not meets_156:
+                break
 
         for tn, res in results.items():
             res.requirement_156a_met = meets_156

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -715,7 +715,7 @@ class TournamentPlayer(Player):
                         continue
 
                 # 1.4.2a (Ignore games against opponents who do not belong to FIDE federations)
-                if opponent.federation == 'NON':
+                if opponent.federation == Federation('NON'):
                     ignored_opponents_ids.add(opponent.id)
                     continue
                 else:

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -939,6 +939,7 @@ class TournamentPlayer(Player):
         for rnd in range(1, self.tournament.rounds + 1):
             present: list[TournamentPlayer] = []
             for p in eligible_players:
+                missing_games: int = 0
                 pairing: Pairing | None = p.pairings_by_round.get(rnd)
                 if pairing and (
                     pairing.played
@@ -948,6 +949,10 @@ class TournamentPlayer(Player):
                         Result.REST_GAME,
                     ]
                 ):
+                    missing_games += 1
+                    if missing_games > 1:
+                        break
+                else:
                     present.append(p)
 
             n_players = len(present)
@@ -1018,6 +1023,7 @@ class TournamentPlayer(Player):
         for rnd in range(1, self.tournament.rounds + 1):
             present: list[TournamentPlayer] = []
             for p in eligible_players:
+                missed_rounds: int = 0
                 pairing: Pairing | None = p.pairings_by_round.get(rnd)
                 if pairing and (
                     pairing.played
@@ -1027,6 +1033,10 @@ class TournamentPlayer(Player):
                         Result.REST_GAME,
                     ]
                 ):
+                    missed_rounds += 1
+                    if missed_rounds > 1:
+                        break
+                else:
                     present.append(p)
 
             n_players = len(present)

--- a/src/data/player.py
+++ b/src/data/player.py
@@ -1039,8 +1039,6 @@ class TournamentPlayer(Player):
 
             # 1.5.6a
             # Check if the average rating of the top 40 eligible players is at least 2000 in every round
-            # if n_players < 40:
-            #     meets_156 = False
             top_rated = sorted([p.rating for p in present], reverse=True)[:40]
             if len(top_rated) < 40:
                 meets_156 = False

--- a/src/web/templates/admin/print/norm_report.html
+++ b/src/web/templates/admin/print/norm_report.html
@@ -205,6 +205,8 @@
                     {{_('Unmet requirements are highlighted in red and should be verified. They will appear in black when printed.')}}
                     <br />
                     {{_('All values may be modified by the arbiter if necessary.')}}
+                    <br />
+                    {{_('NOTE: Norms are computed only on <em>completed</em> games.')}}
                 </div>
             {% else %}
                 <div class="spacer"></div>

--- a/src/web/templates/admin/print/norm_report.html
+++ b/src/web/templates/admin/print/norm_report.html
@@ -351,7 +351,7 @@
                             norm.not_enough_federations or
                             norm.too_many_own_federation or
                             norm.too_many_one_federation
-                        ) and norm.is_143d_met
+                        )
                     %}
                     <div style="font-size: 0.9rem; font-weight: bold;">Where applying 1.4.3d:</div>
                     <div class="grid" style="grid-template-columns: 3fr 5fr;">

--- a/src/web/templates/admin/print/norm_report.html
+++ b/src/web/templates/admin/print/norm_report.html
@@ -206,7 +206,7 @@
                     <br />
                     {{_('All values may be modified by the arbiter if necessary.')}}
                     <br />
-                    {{_('NOTE: Norms are computed only on <em>completed</em> games.')}}
+                    {{_('NOTE: Norms are computed based only on <em>completed</em> games.')}}
                 </div>
             {% else %}
                 <div class="spacer"></div>


### PR DESCRIPTION
This PR aimed to fix various bugs in the player norm computation code.



1. The "NON" federation was not properly handled, since `str` and `Federation` do not compare properly.
2. There is a subtle bug in the count of players in 1.4.3.d and 1.5.6.a.

&nbsp;   1. The FIDE Handbooks count players in if they miss at most one round (excluding PAB/Rest games)

&nbsp;   2. We count them in if they don't miss any game (excluding PAB/Rest games)



Both are fixed in this PR.



NOTE: while writing this message, I got a phone call from Pierre Lapeyre about erroneous averages, so I will try to get the right values in this PR.

