### PR TITLE
Fix CSV import with one column

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@
 
 - Import players from CSV files (3.6.0)
 - Fixed the number of titled players on norm reports (3.6.1)
+- Fixed CSV import with one column (3.6.2)
 
 ## Pairings
 

--- a/src/web/controllers/admin/player_admin_controller.py
+++ b/src/web/controllers/admin/player_admin_controller.py
@@ -1630,7 +1630,11 @@ class PlayerAdminController(BaseEventAdminController):
         with open(file_path, 'rb') as raw_file:
             encoding = chardet.detect(raw_file.read())['encoding']
         with open(file_path, 'r', encoding=encoding) as csvfile:
-            dialect = csv.Sniffer().sniff(''.join(islice(csvfile, 2)))
+            try:
+                dialect = csv.Sniffer().sniff(''.join(islice(csvfile, 2)))
+            except csv.Error:
+                dialect = csv.excel
+
             csvfile.seek(0)
             reader = csv.DictReader(csvfile, dialect=dialect)
             if reader.fieldnames:


### PR DESCRIPTION
With one column the sniffer (allows to find the delimiter of a file, ',' or ';') can't find a delimiter and just fails. 