### PR TITLE
Fix pairings search emptied on result modal input

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,7 @@
 
 - Upgrade bbpPairings engine to v6.0.0 (3.6.0)
 - Display player history on crosstable document (3.6.0)
+- Fixed search removed after manual result input (3.6.4)
 
 ## Prizes
 

--- a/src/web/templates/admin/pairings/round_controls.html
+++ b/src/web/templates/admin/pairings/round_controls.html
@@ -1,13 +1,4 @@
 <div id="round-controls" class="d-flex row-gap-2 column-gap-3 ms-auto align-items-center flex-wrap justify-content-end">
-    <span {{ macros.tooltip_attributes('info', _('Search for player'), 'bottom') }} style="z-index: 1;">
-        {{ admin_macros.text_input(
-            name='search_player',
-            input_type='search',
-            label='',
-            placeholder=_('Player'),
-        ) }}
-    </span>
-
     <div class="d-inline-flex gap-1">
         <span {{ macros.tooltip_attributes('info', _('First round'), 'bottom') }}>
             <button

--- a/src/web/templates/admin/pairings/tab.html
+++ b/src/web/templates/admin/pairings/tab.html
@@ -3,6 +3,18 @@
         {{ admin_macros.admin_title(_('Pairings'), 'pairings') }}
         <div class="flex-grow-1"></div>
         {% if admin_tournament %}
+            <span
+                class="pe-2 me-1"
+                    style="z-index: 1;"
+                {{ macros.tooltip_attributes('info', _('Search for player'), 'bottom') }}
+            >
+                {{ admin_macros.text_input(
+                    name='search_player',
+                    input_type='search',
+                    label='',
+                    placeholder=_('Player'),
+                ) }}
+            </span>
             {% include '/admin/pairings/round_controls.html' %}
         {% endif %}
     </div>


### PR DESCRIPTION
inputting a result from the modal re-rendered the row and full header, including the search field, emptying it. The field is taken out of the pairing controls template to avoid re-rendering it 