### PR TITLE
chore: register SQLite date/datetime adapters explicitly

### DIFF
--- a/src/database/sqlite/adapters.py
+++ b/src/database/sqlite/adapters.py
@@ -1,0 +1,30 @@
+import sqlite3
+from datetime import date, datetime
+
+
+def adapt_date_iso(val: date) -> str:
+    """Adapt datetime.date to ISO 8601 date."""
+    return val.isoformat()
+
+
+def adapt_datetime_iso(val: datetime) -> str:
+    """Adapt datetime.datetime to timezone-naive ISO 8601 date."""
+    return val.isoformat(' ')
+
+
+def convert_date(val: bytes) -> date:
+    """Convert ISO 8601 date to datetime.date object."""
+    return date.fromisoformat(val.decode('utf-8'))
+
+
+def convert_datetime(val: bytes) -> datetime:
+    """Convert ISO 8601 datetime to datetime.datetime object."""
+    return datetime.fromisoformat(val.decode('utf-8'))
+
+
+def register_adapters() -> None:
+    """Register SQLite adapters and converters for date and datetime."""
+    sqlite3.register_adapter(date, adapt_date_iso)
+    sqlite3.register_adapter(datetime, adapt_datetime_iso)
+    sqlite3.register_converter('date', convert_date)
+    sqlite3.register_converter('timestamp', convert_datetime)

--- a/src/sharly_chess.py
+++ b/src/sharly_chess.py
@@ -6,6 +6,10 @@ from pathlib import Path
 
 from pathvalidate import validate_filepath, ValidationError
 
+from database.sqlite.adapters import register_adapters
+
+register_adapters()
+
 # Nuclear option: Override warnings.warn to block specific messages
 # warnings.filterwarnings simply would not work
 _original_warn = warnings.warn


### PR DESCRIPTION
Python 3.12 deprecated the default sqlite3 adapters/converters for date
and datetime; registering them explicitly future-proofs all platforms and
silences the DeprecationWarning.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
