### PR TITLE
Remove None type on last_update fields

### DIFF
--- a/src/data/family.py
+++ b/src/data/family.py
@@ -250,7 +250,7 @@ class Family:
         )
 
     @property
-    def last_update(self) -> datetime | None:
+    def last_update(self) -> datetime:
         return self.stored_family.last_update
 
     def _calculate_screens(self) -> bool:

--- a/src/data/screen.py
+++ b/src/data/screen.py
@@ -642,7 +642,7 @@ class Screen:
             for board in tournament.get_round_boards(tournament.current_round):
                 if board.last_result_update and board.last_result_update >= oldest:
                     boards.append(board)
-        boards.sort(key=lambda b: b.last_result_update, reverse=True)
+        boards.sort(key=lambda b: b.last_result_update or datetime.min, reverse=True)
         return boards
 
     def _clear_results_cache(self):

--- a/src/data/screen.py
+++ b/src/data/screen.py
@@ -642,7 +642,7 @@ class Screen:
             for board in tournament.get_round_boards(tournament.current_round):
                 if board.last_result_update and board.last_result_update >= oldest:
                     boards.append(board)
-        boards.sort(key=lambda b: b.last_result_update or datetime.min, reverse=True)
+        boards.sort(key=lambda b: b.last_result_update, reverse=True)
         return boards
 
     def _clear_results_cache(self):
@@ -709,7 +709,7 @@ class Screen:
                 raise ValueError(f'type=[{self.type}]')
 
     @property
-    def last_update(self) -> datetime | None:
+    def last_update(self) -> datetime:
         if self.stored_screen:
             return self.stored_screen.last_update
         if self.family is None:

--- a/src/data/screen_set.py
+++ b/src/data/screen_set.py
@@ -459,7 +459,7 @@ class ScreenSet:
         return self.last_item
 
     @property
-    def last_update(self) -> datetime | None:
+    def last_update(self) -> datetime:
         if self.stored_screen_set:
             return self.stored_screen_set.last_update
         else:

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -271,16 +271,16 @@ class Tournament:
             return self.stored_tournament.last_rounds_no_byes
 
     @property
-    def last_update(self) -> datetime | None:
+    def last_update(self) -> datetime:
         return self.stored_tournament.last_update
 
     @property
-    def last_player_update(self) -> datetime | None:
-        return self.stored_tournament.last_player_update
+    def last_player_update(self) -> datetime:
+        return self.stored_tournament.last_player_update or self.last_update
 
     @property
-    def last_pairing_update(self) -> datetime | None:
-        return self.stored_tournament.last_pairing_update
+    def last_pairing_update(self) -> datetime:
+        return self.stored_tournament.last_pairing_update or self.last_update
 
     @property
     def rounds(self) -> int:

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -610,9 +610,7 @@ class EventDatabase(MigrationDatabase):
             check_in_open=cls.load_bool_from_database_field(row['check_in_open']),
             rounds=row['rounds'],
             rating=row['rating'],
-            last_update=cls.load_optional_timestamp_from_database_field(
-                row['last_update']
-            ),
+            last_update=cls.load_datetime_from_database_field(row['last_update']),
             last_player_update=cls.load_optional_timestamp_from_database_field(
                 row['last_player_update']
             ),
@@ -1367,9 +1365,7 @@ class EventDatabase(MigrationDatabase):
             number=row['number'],
             message_default=cls.load_bool_from_database_field(row['message_default']),
             message_text=row['message_text'],
-            last_update=cls.load_optional_timestamp_from_database_field(
-                row['last_update']
-            ),
+            last_update=cls.load_datetime_from_database_field(row['last_update']),
         )
 
     def get_stored_family(self, family_id: int) -> StoredFamily | None:
@@ -1532,9 +1528,7 @@ class EventDatabase(MigrationDatabase):
             background_color=row['background_color'],
             message_default=cls.load_bool_from_database_field(row['message_default']),
             message_text=row['message_text'],
-            last_update=cls.load_optional_timestamp_from_database_field(
-                row['last_update']
-            ),
+            last_update=cls.load_datetime_from_database_field(row['last_update']),
         )
 
     def get_stored_screen(self, screen_id: int) -> StoredScreen | None:

--- a/src/database/sqlite/event/event_database.py
+++ b/src/database/sqlite/event/event_database.py
@@ -1695,9 +1695,7 @@ class EventDatabase(MigrationDatabase):
             fixed_boards_str=row['fixed_boards_str'],
             first=row['first'],
             last=row['last'],
-            last_update=cls.load_optional_timestamp_from_database_field(
-                row['last_update']
-            ),
+            last_update=cls.load_datetime_from_database_field(row['last_update']),
         )
 
     def get_stored_screen_set(self, screen_set_id: int) -> StoredScreenSet | None:

--- a/src/database/sqlite/event/event_store.py
+++ b/src/database/sqlite/event/event_store.py
@@ -172,7 +172,7 @@ class StoredTournament:
     rounds: int = 1
     rating: int = 1
     player_rating_type: int | None = None
-    last_update: datetime | None = None
+    last_update: datetime = field(default_factory=datetime.now)
     last_player_update: datetime | None = None
     last_pairing_update: datetime | None = None
     three_points_for_a_win: bool = False
@@ -247,7 +247,7 @@ class StoredScreen:
     stored_screen_sets: list[StoredScreenSet] = field(
         default_factory=list[StoredScreenSet]
     )
-    last_update: datetime | None = None
+    last_update: datetime = field(default_factory=datetime.now)
     public: bool = True
     message_default: bool = True
     message_text: str | None = None
@@ -284,7 +284,7 @@ class StoredFamily:
     public: bool = True
     message_default: bool = True
     message_text: str | None = None
-    last_update: datetime | None = None
+    last_update: datetime = field(default_factory=datetime.now)
     errors: dict[str, str] = field(default_factory=dict[str, str])
 
 

--- a/src/database/sqlite/event/event_store.py
+++ b/src/database/sqlite/event/event_store.py
@@ -214,7 +214,7 @@ class StoredScreenSet:
     fixed_boards_str: str | None
     first: int | None
     last: int | None
-    last_update: datetime | None = None
+    last_update: datetime = field(default_factory=datetime.now)
     errors: dict[str, str] = field(default_factory=dict[str, str])
 
 

--- a/src/plugins/chess_results/chess_results_background_uploader.py
+++ b/src/plugins/chess_results/chess_results_background_uploader.py
@@ -126,10 +126,11 @@ class ChessResultsBackgroundUploader:
     def chess_results_upload_needed(
         cls, tournament: Tournament | StoredTournament
     ) -> bool:
-        return (cls.chess_results_last_upload(tournament) or datetime.min) < max(
-            tournament.last_update or datetime.min,
-            tournament.last_player_update or datetime.min,
-            tournament.last_pairing_update or datetime.min,
+        last_upload = cls.chess_results_last_upload(tournament)
+        return not last_upload or last_upload < max(
+            tournament.last_update,
+            tournament.last_player_update,
+            tournament.last_pairing_update,
         )
 
     @classmethod

--- a/src/plugins/chess_results/chess_results_background_uploader.py
+++ b/src/plugins/chess_results/chess_results_background_uploader.py
@@ -20,6 +20,7 @@ from plugins.chess_results.utils import (
     ChessResultsUtils,
 )
 from plugins.utils import PluginUtils
+from utils import Utils
 from web.channels import channels_plugin
 
 logger = get_logger()
@@ -127,7 +128,7 @@ class ChessResultsBackgroundUploader:
         cls, tournament: Tournament | StoredTournament
     ) -> bool:
         last_upload = cls.chess_results_last_upload(tournament)
-        return not last_upload or PluginUtils.tournament_results_modified_since(
+        return not last_upload or Utils.tournament_results_modified_since(
             tournament, last_upload
         )
 

--- a/src/plugins/chess_results/chess_results_background_uploader.py
+++ b/src/plugins/chess_results/chess_results_background_uploader.py
@@ -127,10 +127,8 @@ class ChessResultsBackgroundUploader:
         cls, tournament: Tournament | StoredTournament
     ) -> bool:
         last_upload = cls.chess_results_last_upload(tournament)
-        return not last_upload or last_upload < max(
-            tournament.last_update,
-            tournament.last_player_update,
-            tournament.last_pairing_update,
+        return not last_upload or PluginUtils.tournament_results_modified_since(
+            tournament, last_upload
         )
 
     @classmethod

--- a/src/plugins/ffe/ffe_background_uploader.py
+++ b/src/plugins/ffe/ffe_background_uploader.py
@@ -133,10 +133,11 @@ class FfeBackgroundUploader:
 
     @classmethod
     def ffe_upload_needed(cls, tournament: Tournament | StoredTournament) -> bool:
-        return (cls.ffe_last_upload(tournament) or datetime.min) < max(
-            tournament.last_update or datetime.min,
-            tournament.last_player_update or datetime.min,
-            tournament.last_pairing_update or datetime.min,
+        last_upload = cls.ffe_last_upload(tournament)
+        return not last_upload or last_upload < max(
+            tournament.last_update,
+            tournament.last_player_update,
+            tournament.last_pairing_update,
         )
 
     @classmethod

--- a/src/plugins/ffe/ffe_background_uploader.py
+++ b/src/plugins/ffe/ffe_background_uploader.py
@@ -17,6 +17,7 @@ from plugins.ffe import PLUGIN_NAME
 from plugins.ffe.ffe_session import FFESession
 from plugins.ffe.utils import FFEUtils, FfeEventPluginData, FfeTournamentPluginData
 from plugins.utils import PluginUtils
+from utils import Utils
 from web.channels import channels_plugin
 
 logger = get_logger()
@@ -134,7 +135,7 @@ class FfeBackgroundUploader:
     @classmethod
     def ffe_upload_needed(cls, tournament: Tournament | StoredTournament) -> bool:
         last_upload = cls.ffe_last_upload(tournament)
-        return not last_upload or PluginUtils.tournament_results_modified_since(
+        return not last_upload or Utils.tournament_results_modified_since(
             tournament, last_upload
         )
 

--- a/src/plugins/ffe/ffe_background_uploader.py
+++ b/src/plugins/ffe/ffe_background_uploader.py
@@ -134,10 +134,8 @@ class FfeBackgroundUploader:
     @classmethod
     def ffe_upload_needed(cls, tournament: Tournament | StoredTournament) -> bool:
         last_upload = cls.ffe_last_upload(tournament)
-        return not last_upload or last_upload < max(
-            tournament.last_update,
-            tournament.last_player_update,
-            tournament.last_pairing_update,
+        return not last_upload or PluginUtils.tournament_results_modified_since(
+            tournament, last_upload
         )
 
     @classmethod

--- a/src/plugins/utils.py
+++ b/src/plugins/utils.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from datetime import datetime
 from functools import cached_property
 from pathlib import Path
 from types import ModuleType
@@ -15,6 +16,7 @@ from plugins import PLUGINS_DIR
 if TYPE_CHECKING:
     from data.event import Event
     from data.event_metadata import EventMetadata
+    from data.tournament import Tournament
     from database.sqlite.event.event_database import EventDatabase
     from database.sqlite.event.event_store import (
         StoredEvent,
@@ -113,6 +115,17 @@ class PluginUtils:
     ):
         cls._replace_on_condition(
             source_list, element, lambda elem: isinstance(elem, match_type)
+        )
+
+    @staticmethod
+    def tournament_results_modified_since(
+        tournament: 'Tournament | StoredTournament',
+        ref_datetime: datetime,
+    ) -> bool:
+        return ref_datetime < max(
+            tournament.last_update,
+            tournament.last_player_update or datetime.min,
+            tournament.last_pairing_update or datetime.min,
         )
 
 

--- a/src/plugins/utils.py
+++ b/src/plugins/utils.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from datetime import datetime
 from functools import cached_property
 from pathlib import Path
 from types import ModuleType
@@ -16,7 +15,6 @@ from plugins import PLUGINS_DIR
 if TYPE_CHECKING:
     from data.event import Event
     from data.event_metadata import EventMetadata
-    from data.tournament import Tournament
     from database.sqlite.event.event_database import EventDatabase
     from database.sqlite.event.event_store import (
         StoredEvent,
@@ -115,17 +113,6 @@ class PluginUtils:
     ):
         cls._replace_on_condition(
             source_list, element, lambda elem: isinstance(elem, match_type)
-        )
-
-    @staticmethod
-    def tournament_results_modified_since(
-        tournament: 'Tournament | StoredTournament',
-        ref_datetime: datetime,
-    ) -> bool:
-        return ref_datetime < max(
-            tournament.last_update,
-            tournament.last_player_update or datetime.min,
-            tournament.last_pairing_update or datetime.min,
         )
 
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -7,12 +7,16 @@ from decimal import Decimal
 from functools import lru_cache, cache
 from math import floor
 from subprocess import CompletedProcess
-from typing import Callable, Iterable, Protocol, Hashable, Collection
+from typing import Callable, Iterable, Protocol, Hashable, Collection, TYPE_CHECKING
 
 import iso4217parse
 import pycountry
 from babel.numbers import format_currency, format_decimal, get_decimal_symbol
 from text_unidecode import unidecode
+
+if TYPE_CHECKING:
+    from data.tournament import Tournament
+    from database.sqlite.event.event_store import StoredTournament
 
 
 class Utils:
@@ -305,6 +309,17 @@ class Utils:
         for property_name in property_names:
             if property_name in obj.__dict__:
                 del obj.__dict__[property_name]
+
+    @staticmethod
+    def tournament_results_modified_since(
+        tournament: 'Tournament | StoredTournament',
+        ref_datetime: datetime,
+    ) -> bool:
+        return ref_datetime < max(
+            tournament.last_update,
+            tournament.last_player_update or datetime.min,
+            tournament.last_pairing_update or datetime.min,
+        )
 
 
 class SupportsEquals(Protocol):

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -43,10 +43,7 @@ class ScreenUserController(BaseScreenUserController):
             return True
         match screen_set.type:
             case ScreenType.BOARDS | ScreenType.INPUT | ScreenType.RANKING:
-                if (
-                    tournament.last_pairing_update
-                    and tournament.last_pairing_update > date
-                ):
+                if tournament.last_pairing_update > date:
                     return True
             case ScreenType.PLAYERS:
                 pass
@@ -62,16 +59,14 @@ class ScreenUserController(BaseScreenUserController):
         date: float,
     ) -> bool:
         date_dt = datetime.fromtimestamp(date)
-        if web_context.screen:
-            assert web_context.screen.event is not None
-            if web_context.screen.event.last_update > date_dt:
+        screen = web_context.screen
+        if screen:
+            event = screen.event
+            if event.last_update > date_dt:
                 return True
-            if (
-                web_context.screen.last_update
-                and web_context.screen.last_update > date_dt
-            ):
+            if screen.last_update > date_dt:
                 return True
-            match web_context.screen.type:
+            match screen.type:
                 case ScreenType.IMAGE:
                     pass
                 case (
@@ -80,23 +75,18 @@ class ScreenUserController(BaseScreenUserController):
                     | ScreenType.PLAYERS
                     | ScreenType.RANKING
                 ):
-                    for screen_set in web_context.screen.screen_sets:
+                    for screen_set in screen.screen_sets:
                         if cls._user_screen_set_refresh_needed(screen_set, date_dt):
                             return True
                 case ScreenType.RESULTS:
-                    assert web_context.screen.event is not None
                     results_tournament_ids: list[int] = (
-                        web_context.screen.results_tournament_ids
-                        if web_context.screen.results_tournament_ids
-                        else list(web_context.screen.event.tournaments_by_id.keys())
+                        screen.results_tournament_ids
+                        if screen.results_tournament_ids
+                        else list(event.tournaments_by_id.keys())
                     )
                     for tournament_id in results_tournament_ids:
                         with suppress(KeyError):
-                            tournament: Tournament = (
-                                web_context.screen.event.tournaments_by_id[
-                                    tournament_id
-                                ]
-                            )
+                            tournament = event.tournaments_by_id[tournament_id]
                             if (
                                 max(
                                     tournament.last_update,
@@ -106,14 +96,14 @@ class ScreenUserController(BaseScreenUserController):
                             ):
                                 return True
                 case _:
-                    raise ValueError(f'type={web_context.screen.type}')
+                    raise ValueError(f'type={screen.type}')
         elif isinstance(web_context, BasicScreenOrFamilyUserWebContext):
-            assert web_context.family is not None
-            assert web_context.family.event is not None
+            family = web_context.family
+            assert family is not None
             if (
                 max(
-                    web_context.family.event.last_update,
-                    web_context.family.last_update,
+                    family.event.last_update,
+                    family.last_update,
                 )
                 > date_dt
             ):

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -35,8 +35,8 @@ class ScreenUserController(BaseScreenUserController):
         tournament: Tournament = screen_set.tournament
         if (
             max(
-                tournament.last_update or datetime.min,
-                tournament.last_player_update or datetime.min,
+                tournament.last_update,
+                tournament.last_player_update,
             )
             > date
         ):
@@ -99,8 +99,8 @@ class ScreenUserController(BaseScreenUserController):
                             )
                             if (
                                 max(
-                                    tournament.last_update or datetime.min,
-                                    tournament.last_pairing_update or datetime.min,
+                                    tournament.last_update,
+                                    tournament.last_pairing_update,
                                 )
                                 > date_dt
                             ):
@@ -113,7 +113,7 @@ class ScreenUserController(BaseScreenUserController):
             if (
                 max(
                     web_context.family.event.last_update,
-                    web_context.family.last_update or datetime.min,
+                    web_context.family.last_update,
                 )
                 > date_dt
             ):


### PR DESCRIPTION
`last_update` fields can't ever be None, This typing makes it much heavier to use for no reason. We can remove the usage of `{datetime | None} or datetime.min` which is rather heavy