### PR TITLE
Fix flashes on refresh on some browsers

### DIFF
--- a/src/web/templates/common/base.html
+++ b/src/web/templates/common/base.html
@@ -45,7 +45,6 @@
     <body
         hx-ext="multi-swap,morphdom-swap,remove-me"
         hx-swap="transition:true"
-        class="d-none"
     >
         {% set redirect_url = '' %}
         {% if sharly_chess_config.force_edit %}


### PR DESCRIPTION
closes #1836. The issue was reproduced on Firefox and Zen. With the fix, I haven't noticed a difference on any other browser. @timothyarmes considering you're the one that added that property would you mind checking it does not break anything on safari pls ?