### PR TITLE
Fix flashes on refresh with Firefox-based browsers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # _Sharly Chess_ release notes
 
+## Global
+
+- Fixed white flashes on refresh for Firefox-based browsers (3.6.8)
+
 ## Events
 
 - Import events from SCE files (3.6.0)

--- a/src/web/templates/common/base.html
+++ b/src/web/templates/common/base.html
@@ -45,7 +45,6 @@
     <body
         hx-ext="multi-swap,morphdom-swap,remove-me"
         hx-swap="transition:true"
-        class="d-none"
     >
         {% set redirect_url = '' %}
         {% if sharly_chess_config.force_edit %}


### PR DESCRIPTION
replaces #1890 (based on dev by mistake)  
closes #1836. The issue was reproduced on Firefox and Zen. With the fix, I haven't noticed a difference on any other browser. @timothyarmes considering you're the one that added that property would you mind checking it does not break anything on safari pls ?