### PR TITLE
Fix JS events not triggered when re-rendering a modal

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 - Fixed time pickers on Firefox-based browsers (3.6.8)
 - Fixed white flashes on refresh for Firefox-based browsers (3.6.8)
+- Fixed incoherent forms after an error (3.6.8)
 
 ## Events
 

--- a/src/web/templates/admin/event/event_modal.html
+++ b/src/web/templates/admin/event/event_modal.html
@@ -247,7 +247,7 @@
                         {% endfor %}
                     </div>
                     <script>
-                        $('.plugin-switch-input').trigger('change', [false]);
+                        triggerModalInitEvent('.plugin-switch-input', 'change', [false]);
                         $('#federation').change(function () {
                             const federation = $(this).val();
                             const pluginsToHide = $('.federation-plugin:not(.federation-plugin-' + federation + ')');
@@ -266,7 +266,7 @@
                             $('#plugins-container').show();
                             $('#plugins-container').toggle($('.plugin-container:visible').length > 0);
                         });
-                        $('#federation').trigger('change');
+                        triggerModalInitEvent('#federation');
                     </script>
                 </span>
             </form>
@@ -306,4 +306,6 @@
     </div>
 </div>
 
-<script>requestRefresh()</script>
+{% if action == 'update' %}
+    <script>requestRefresh()</script>
+{% endif %}

--- a/src/web/templates/admin/index/config_modal.html
+++ b/src/web/templates/admin/index/config_modal.html
@@ -134,7 +134,7 @@
                         </div>
                     {% endfor %}
                     <script>
-                        $('.plugin-switch-input').trigger('change', [false]);
+                        triggerModalInitEvent('.plugin-switch-input', 'change', [false]);
                     </script>
                 </div>
             </form>

--- a/src/web/templates/admin/prizes/prize_form_modal.html
+++ b/src/web/templates/admin/prizes/prize_form_modal.html
@@ -101,7 +101,7 @@
                                 }
                             {% endfor %}
                         });
-                        $('#type').trigger('change');
+                        triggerModalInitEvent('#type');
                     </script>
                 </div>
             </form>

--- a/src/web/templates/admin/tournaments/tournament_modal.html
+++ b/src/web/templates/admin/tournaments/tournament_modal.html
@@ -97,7 +97,7 @@
                                 $('#estimated-ratings').hide();
                             }
                         });
-                        $('#rating').trigger('change');
+                        triggerModalInitEvent('#rating');
                     </script>
                 </div>
 
@@ -177,7 +177,7 @@
                                 }
                             {% endfor %}
                         });
-                        $('#pairing-system').trigger('change');
+                        triggerModalInitEvent('#pairing-system');
                     </script>
                 </div>
                 <div class="row gy-2 gx-3">

--- a/src/web/templates/common/js/modals.js
+++ b/src/web/templates/common/js/modals.js
@@ -96,3 +96,10 @@ function preparePrintModal(print_document_id, tournament_id, print_round) {
         last_url = window.location.href;
     }
 }
+
+function triggerModalInitEvent(selector, event='change', params=[]) {
+    // When a modal is swapped, the JS events are triggered on previous elements
+    // Send the event again after the modal's been swapped to ensure triggering it on the correct element
+    $(selector).trigger(event, params);
+    setTimeout(() => $(selector).trigger(event, params), 100)
+}


### PR DESCRIPTION
<img width="1285" height="422" alt="image" src="https://github.com/user-attachments/assets/f4c74a59-ba79-4c94-b4a4-50af68c2b6ca" />  
Happens for example after triggering an error on some forms. ex: here, the `Use FIDE standard rating` switch should be hidden (rapid / blitz tournaments only) and the variaiton select of both pairing system is shown