### PR TITLE
fix/player-search-Issue

### DIFF
--- a/src/web/templates/admin/common/js/searchPlayerNavigation.js
+++ b/src/web/templates/admin/common/js/searchPlayerNavigation.js
@@ -21,7 +21,7 @@ function handleInitialQuery(event) {
                 if (resultList[selectedIndex]) {
                     resultList[selectedIndex].click();
                 }
-                event.stopPropagation();
+                return false;
             }
         });
     }

--- a/src/web/templates/admin/common/js/searchPlayerNavigation.js
+++ b/src/web/templates/admin/common/js/searchPlayerNavigation.js
@@ -20,8 +20,8 @@ function handleInitialQuery(event) {
             } else if (event.key === "Enter") {
                 if (resultList[selectedIndex]) {
                     resultList[selectedIndex].click();
+                    return false;
                 }
-                return false;
             }
         });
     }


### PR DESCRIPTION
I noticed an issue on my code, this is the fix for it

It turns out that event.stopPropagation() doesn't behave the way I thought

It's not a huge bug but it may be annoying:
If the arbiter uses the search player feature and the form on the modal is already filled, pressing "enter" would submit, instead of selecting another player.