### PR TITLE
Fix dates not selected by default on timepickers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,7 @@
 ## Tournaments
 
 - Added round schedule to tournaments (4.0.0)
+- Fixed schedule dates not selected by default (4.0.3)
 
 ## Prizes
 

--- a/src/web/templates/admin/common/macros.j2
+++ b/src/web/templates/admin/common/macros.j2
@@ -394,13 +394,14 @@
                         new Date(new Date().setHours(0, 0, 0, 0))
                     {% endif %}
                 ),
-                {# Prevent an odd behavior when selecting first using the time picker #}
-                onBeforeSelect: ({date, datepicker}) => {
-                    if (datepicker.selectedDates.length === 0) {
-                        return date.getHours() === 0 && date.getMinutes() === 0;
-                    }
-                    return true;
-                },
+                {% if min_date and max_date %}
+                    {# Selecting first using the time picker uses the current date, prevent selection if it's outside the time range #}
+                    onBeforeSelect: ({date, datepicker}) => {
+                        const minDate = ({{ formatter.value_to_date_js_function|safe }})(`{{ min_date }} 00:00`);
+                        const maxDate = ({{ formatter.value_to_date_js_function|safe }})(`{{ max_date }} 23:59`);
+                        return date >= minDate && date <= maxDate;
+                    },
+                {% endif %}
             {% endif %}
             {% if now_button %}
                 buttons: [


### PR DESCRIPTION
Before:  
<img width="418" height="363" alt="image" src="https://github.com/user-attachments/assets/e3add983-3008-4d2b-bf62-7ffd6248eb98" />

After:  
<img width="405" height="367" alt="image" src="https://github.com/user-attachments/assets/4db8834b-b14b-467c-ae4e-9d2fd5c219fa" />

timepicker current date selection behavior fix still maintained