### PR TITLE
Keep documents modal open

### DIFF
--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -1916,6 +1916,9 @@ msgstr ""
 msgid "Do you want to upgrade from [{old_version}] to [{new_version}]"
 msgstr ""
 
+msgid "Document [{document}] has been generated in another tab."
+msgstr ""
+
 msgid "Document:"
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -1916,6 +1916,9 @@ msgstr "Voulez-vous récupérer les données de la version [{version}]"
 msgid "Do you want to upgrade from [{old_version}] to [{new_version}]"
 msgstr "Voulez-vous faire la mise à jour de [{old_version}] à [{new_version}]"
 
+msgid "Document [{document}] has been generated in another tab."
+msgstr "Le document [{document}] a été généré dans un autre onglet."
+
 msgid "Document:"
 msgstr "Document :"
 

--- a/src/data/print_documents/documents.py
+++ b/src/data/print_documents/documents.py
@@ -156,6 +156,13 @@ class PrintDocument(OptionHandler[PrintOption], ABC):
         """Header of the print document."""
 
     @property
+    def tab_title(self) -> str:
+        title = self.name
+        if TournamentPrintOption in self.available_options():
+            title += f' - {self.tournament.name}'
+        return title
+
+    @property
     @abstractmethod
     def template_name(self) -> str:
         """Name of the template representing the printed document.

--- a/src/web/controllers/admin/event_documents_controller.py
+++ b/src/web/controllers/admin/event_documents_controller.py
@@ -178,6 +178,7 @@ class EventDocumentsController(BaseEventAdminController):
     ) -> Template:
         flat_data = WebContext.flatten_list_data(data)
         web_context = BaseEventAdminWebContext(request)
+        client = web_context.client
         event = web_context.get_admin_event()
 
         errors: dict[str, str] = {}
@@ -194,11 +195,11 @@ class EventDocumentsController(BaseEventAdminController):
 
         if document_type:
             options: list[PrintOption] = []
-            for option in document_type(web_context.client).default_options():
+            for option in document_type(client).default_options():
                 value = WebContext.form_data_to_value(flat_data, option.id, option.type)
                 options.append(type(option)(event, value))
             try:
-                document = document_type(web_context.client, options)
+                document = document_type(client, options)
                 document.validate_options()
             except OptionError as error:
                 errors[error.option.id] = str(error)

--- a/src/web/controllers/admin/event_documents_controller.py
+++ b/src/web/controllers/admin/event_documents_controller.py
@@ -183,6 +183,7 @@ class EventDocumentsController(BaseEventAdminController):
         errors: dict[str, str] = {}
 
         document_type: type[PrintDocument] | None = None
+        document: PrintDocument | None = None
         field = 'document'
         try:
             document_type = PrintDocumentManager(event).get_type(
@@ -210,8 +211,7 @@ class EventDocumentsController(BaseEventAdminController):
             return self._render_documents_modal(
                 web_context, data=flat_data, errors=errors
             )
-        assert document_type is not None
-        document = document_type(web_context.client)
+        assert document is not None
         # Clear the modal contents, and send an event
         return HTMXTemplate(
             template_name='common/alert.html',

--- a/src/web/controllers/admin/event_documents_controller.py
+++ b/src/web/controllers/admin/event_documents_controller.py
@@ -54,6 +54,7 @@ class EventDocumentsController(BaseEventAdminController):
         _round: int | None = None,
         data: dict[str, str] | None = None,
         errors: dict[str, str] | None = None,
+        success_message: str | None = None,
     ) -> HTMXTemplate:
         event = web_context.get_admin_event()
         print_options = PrintDocumentOptionManager(event).objects()
@@ -121,6 +122,7 @@ class EventDocumentsController(BaseEventAdminController):
             'print_options': print_options,
             'containers_by_document': containers_by_document,
             'data': data,
+            'success_message': success_message,
             'errors': errors or {},
         }
         return cls._admin_base_event_render(
@@ -209,10 +211,18 @@ class EventDocumentsController(BaseEventAdminController):
                 web_context, data=flat_data, errors=errors
             )
         assert document_type is not None
+        document = document_type(web_context.client)
         # Clear the modal contents, and send an event
         return HTMXTemplate(
-            template_name='common/empty_modal.html',
-            re_target='#modal-wrapper',
+            template_name='common/alert.html',
+            re_target='#document-success-message',
+            re_swap='innerHTML',
+            context={
+                'type': 'success',
+                'message': _(
+                    'Document [{document}] has been generated in another tab.'
+                ).format(document=document.tab_title),
+            },
             trigger_event='do_print',
             after='receive',
             params={
@@ -220,7 +230,7 @@ class EventDocumentsController(BaseEventAdminController):
                 'document': flat_data['document'],
                 'options': {
                     option.id: flat_data[option.id]
-                    for option in document_type(web_context.client).default_options()
+                    for option in document.default_options()
                     if option.id in data
                 },
             },

--- a/src/web/templates/admin/event/print_modal.html
+++ b/src/web/templates/admin/event/print_modal.html
@@ -9,6 +9,7 @@
             </h2>
         </div>
         <div class="modal-body">
+            <div id="document-success-message"></div>
             <form
                 id="modal-form"
                 hx-trigger="submit, enterKeypressFromModal"

--- a/src/web/templates/admin/print/base.html
+++ b/src/web/templates/admin/print/base.html
@@ -3,7 +3,7 @@
 <html translate="no">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title>{{ document.name }}{% if tournament %} - {{ tournament.name }}{% endif %}</title>
+        <title>{{ document.tab_title }}</title>
         <style>
             {% include 'print.css' %}
             {{ extra_css }}

--- a/src/web/templates/common/js/base.js
+++ b/src/web/templates/common/js/base.js
@@ -69,7 +69,6 @@ function scrollToFirstError() {
 }
 
 window.addEventListener("do_print", function(event) {
-    closeModal();
     const form = document.createElement('form');
     form.method = 'get';
     form.action = window.location.origin +


### PR DESCRIPTION
simplifies batch generation of documents  

<img width="716" height="636" alt="image" src="https://github.com/user-attachments/assets/a9b22a3f-9f30-4706-a201-272b46544145" />  
