### PR TITLE
Fix Round-Robin pairings round navigation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,7 @@
 - Added a reminder to update the players' ratings before pairings on round #1 and for tournaments lasting on multiple FIDE periods (4.0.0)
 - Clean display of pairing exceptions (4.0.2)
 - Fixed Koya tie-break calculation (4.0.3)
+- Fixed Round-Robin tournament round navigation (4.0.4)
 
 ## Prizes
 

--- a/src/web/controllers/admin/pairings_admin_controller.py
+++ b/src/web/controllers/admin/pairings_admin_controller.py
@@ -1269,8 +1269,9 @@ class PairingsAdminController(BaseEventAdminController):
             tournament_id=tournament_id,
             round_=current_round,
         )
-        web_context.get_admin_tournament().set_current_round(round_=current_round)
-
+        tournament = web_context.get_admin_tournament()
+        tournament.set_current_round(round_=current_round)
+        SessionPairingsSelectedRound(request, tournament).set(current_round)
         return self._admin_event_pairings_render(web_context)
 
     @put(


### PR DESCRIPTION
To reproduce: 
- Create an RR tournament
- pair it
- fill the results of the first round
- mark the round as finished (it moves to round 2)
- leave the pairings page, then come back 
--> You are on round 1 instead of round 2