### PR TITLE
Improve the tie-break sets UI

### DIFF
--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -664,7 +664,7 @@ msgstr ""
 msgid "Application"
 msgstr ""
 
-msgid "Apply set"
+msgid "Apply"
 msgstr ""
 
 msgid "Apply to all"
@@ -2272,6 +2272,9 @@ msgstr ""
 msgid "Event name"
 msgstr ""
 
+msgid "Event tournaments"
+msgstr ""
+
 msgid "Event unique ID has been renamed from [{old_uniq_id}] to [{new_uniq_id}]."
 msgstr ""
 
@@ -2371,6 +2374,12 @@ msgid "FIDE database"
 msgstr ""
 
 msgid "FIDE rating lost"
+msgstr ""
+
+msgid "FIDE recommendation (2019)"
+msgstr ""
+
+msgid "FIDE recommendation - Unrated (2019)"
 msgstr ""
 
 msgid "FM *** SHORT NAME FOR Fide Master"
@@ -2532,9 +2541,6 @@ msgid "Fr *** FRIDAY"
 msgstr "Fr"
 
 msgid "France"
-msgstr ""
-
-msgid "From tournament"
 msgstr ""
 
 msgid "From your server find the screen or rotator you want to display, and sent it to controller using the button with this icon:"
@@ -3200,9 +3206,6 @@ msgstr ""
 msgid "Manage prizes"
 msgstr ""
 
-msgid "Manage saved tie-break sets for this pairing system."
-msgstr ""
-
 msgid "Manage screens"
 msgstr ""
 
@@ -3678,7 +3681,7 @@ msgstr ""
 msgid "No such screens."
 msgstr ""
 
-msgid "No tie-breaks for [{tournament}]"
+msgid "No tie-breaks."
 msgstr ""
 
 msgid "No timers"
@@ -4913,9 +4916,6 @@ msgstr ""
 msgid "Rwanda"
 msgstr ""
 
-msgid "SC Recommendation"
-msgstr ""
-
 msgid "SCR"
 msgstr ""
 
@@ -5155,6 +5155,9 @@ msgid "Sharly Chess project"
 msgstr ""
 
 msgid "Sharly Chess reaches its full potential when used as a server, with other devices connected to the same network."
+msgstr ""
+
+msgid "Sharly Chess recommendation"
 msgstr ""
 
 msgid "Sharly Chess server"
@@ -5764,8 +5767,7 @@ msgstr ""
 msgid "These plugins can only be activated on events of their federation."
 msgstr ""
 
-#, python-format
-msgid "These sets are saved per pairing system and shared across events. Showing sets for [%(pairing_system)s]."
+msgid "These sets are saved per pairing system and shared across events."
 msgstr ""
 
 msgid "These tournaments are already included for this account by a higher access level."
@@ -5885,9 +5887,6 @@ msgstr ""
 msgid "This set contains [{name}] twice in a row."
 msgstr ""
 
-msgid "This set contains a duplicate tie-break ([{name}])."
-msgstr ""
-
 msgid "This tie-break can be used multiple times."
 msgstr ""
 
@@ -5947,9 +5946,6 @@ msgid "Tie-breaks"
 msgstr ""
 
 msgid "Tie-breaks determine the rankings for players that are tied with the same number of points."
-msgstr ""
-
-msgid "Tie-breaks for [{tournament}]"
 msgstr ""
 
 msgid "Time control"
@@ -7023,9 +7019,6 @@ msgstr ""
 msgid "{first_name} {last_name}"
 msgstr ""
 
-msgid "{name}: {message}"
-msgstr ""
-
 msgid "{player.first_name} {player.last_name} had won {previous_value} in the main group but was then given a prize of {next_value} in the category '{cat_name}' instead. By leaving the main group, the prize share for the place they were in is now worth {new_share}."
 msgstr ""
 
@@ -7069,4 +7062,37 @@ msgstr ""
 
 msgid "½ - ½ (U)"
 msgstr ""
+
+#~ msgid "Apply set"
+#~ msgstr ""
+
+#~ msgid "From tournament"
+#~ msgstr ""
+
+#~ msgid "Manage saved tie-break sets for this pairing system."
+#~ msgstr ""
+
+#~ msgid "No tie-breaks for [{tournament}]"
+#~ msgstr ""
+
+#~ msgid "SC Recommendation"
+#~ msgstr ""
+
+#~ msgid "These sets are saved per pairing system and shared across events. Showing sets for [%(pairing_system)s]."
+#~ msgstr ""
+
+#~ msgid "This set contains a duplicate tie-break ([{name}])."
+#~ msgstr ""
+
+#~ msgid "Tie-breaks for [{tournament}]"
+#~ msgstr ""
+
+#~ msgid "{name}: {message}"
+#~ msgstr ""
+
+#~ msgid "Fide recommendation (2019)"
+#~ msgstr ""
+
+#~ msgid "Fide recommendation - Unrated (2019)"
+#~ msgstr ""
 

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -7060,36 +7060,3 @@ msgstr ""
 msgid "½ - ½ (U)"
 msgstr ""
 
-#~ msgid "Apply set"
-#~ msgstr ""
-
-#~ msgid "From tournament"
-#~ msgstr ""
-
-#~ msgid "Manage saved tie-break sets for this pairing system."
-#~ msgstr ""
-
-#~ msgid "No tie-breaks for [{tournament}]"
-#~ msgstr ""
-
-#~ msgid "SC Recommendation"
-#~ msgstr ""
-
-#~ msgid "These sets are saved per pairing system and shared across events. Showing sets for [%(pairing_system)s]."
-#~ msgstr ""
-
-#~ msgid "This set contains a duplicate tie-break ([{name}])."
-#~ msgstr ""
-
-#~ msgid "Tie-breaks for [{tournament}]"
-#~ msgstr ""
-
-#~ msgid "{name}: {message}"
-#~ msgstr ""
-
-#~ msgid "Fide recommendation (2019)"
-#~ msgstr ""
-
-#~ msgid "Fide recommendation - Unrated (2019)"
-#~ msgstr ""
-

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -1165,9 +1165,6 @@ msgstr ""
 msgid "Choose families to add"
 msgstr ""
 
-msgid "Choose my own tie-breaks"
-msgstr ""
-
 msgid "Choose one, many or no players."
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -2377,7 +2377,7 @@ msgid "FIDE recommendation (2019)"
 msgstr "Recommendation FIDE (2019)"
 
 msgid "FIDE recommendation - Unrated (2019)"
-msgstr "Recommendation FIDE - Non-classé·es (2019)"
+msgstr "Recommendation FIDE - Non classé·es (2019)"
 
 msgid "FM *** SHORT NAME FOR Fide Master"
 msgstr "MF"

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -1165,9 +1165,6 @@ msgstr "Choisir au moins une valeur."
 msgid "Choose families to add"
 msgstr "Choisir des familles à ajouter"
 
-msgid "Choose my own tie-breaks"
-msgstr "Choisir mes départages"
-
 msgid "Choose one, many or no players."
 msgstr "Choisissez aucun·e, un·e ou plusieurs joueur·euses."
 

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -391,7 +391,7 @@ msgid "A positive value is expected."
 msgstr "Une valeur positive est attendue."
 
 msgid "A set named [{name}] already exists. Tick the overwrite option to replace it."
-msgstr "Un jeu nommé [{name}] existe déjà. Cochez l'option Remplacement pour le remplacer."
+msgstr "Un ensemble nommé [{name}] existe déjà. Cochez l'option Remplacement pour le remplacer."
 
 msgid "A set with this name already existe."
 msgstr "Un ensemble avec ce nom existe déjà."
@@ -664,8 +664,8 @@ msgstr "Un pilote d’afficheurs peut contrôler l’affichage de plusieurs affi
 msgid "Application"
 msgstr "Application"
 
-msgid "Apply set"
-msgstr "Appliquer le jeu"
+msgid "Apply"
+msgstr "Appliquer"
 
 msgid "Apply to all"
 msgstr "Appliquer à tout·es"
@@ -1157,7 +1157,7 @@ msgid "Choose a random player"
 msgstr "Choisir un·e joueur·euse au hasard"
 
 msgid "Choose a set…"
-msgstr "Choisir un jeu…"
+msgstr "Choisir un ensemble…"
 
 msgid "Choose at least one value."
 msgstr "Choisir au moins une valeur."
@@ -1553,10 +1553,10 @@ msgid "Custom"
 msgstr "Personnalisés"
 
 msgid "Custom sets"
-msgstr "Jeux personnalisés"
+msgstr "Ensembles personnalisés"
 
 msgid "Custom tie-break sets"
-msgstr "Jeux de départages personnalisés"
+msgstr "Ensembles de départages personnalisés"
 
 msgid "Cut values"
 msgstr "Élaguer des valeurs"
@@ -2272,6 +2272,9 @@ msgstr "Export d'évènement"
 msgid "Event name"
 msgstr "Nom de l'évènement"
 
+msgid "Event tournaments"
+msgstr "Tournois de l'évènement"
+
 msgid "Event unique ID has been renamed from [{old_uniq_id}] to [{new_uniq_id}]."
 msgstr "L'identifiant unique de l'évènement à été renommé de [{old_uniq_id}] à [{new_uniq_id}]."
 
@@ -2372,6 +2375,12 @@ msgstr "Base de données FIDE"
 
 msgid "FIDE rating lost"
 msgstr "classement FIDE perdu"
+
+msgid "FIDE recommendation (2019)"
+msgstr "Recommendation FIDE (2019)"
+
+msgid "FIDE recommendation - Unrated (2019)"
+msgstr "Recommendation FIDE - Non-classé·es (2019)"
 
 msgid "FM *** SHORT NAME FOR Fide Master"
 msgstr "MF"
@@ -2533,9 +2542,6 @@ msgstr "Ve"
 
 msgid "France"
 msgstr "France"
-
-msgid "From tournament"
-msgstr "D'un tournoi"
 
 msgid "From your server find the screen or rotator you want to display, and sent it to controller using the button with this icon:"
 msgstr "Depuis votre appareil principal, trouvez l’écran ou l’écran rotatif que vous souhaitez afficher, puis envoyez-le au pilote d’écran à l’aide du bouton portant cette icône :"
@@ -3192,16 +3198,13 @@ msgid "Manage archives"
 msgstr "Gestion des archives"
 
 msgid "Manage custom sets"
-msgstr "Gérer les jeux personnalisés"
+msgstr "Gérer les ensembles personnalisés"
 
 msgid "Manage events"
 msgstr "Gestion des évènements"
 
 msgid "Manage prizes"
 msgstr "Gestion des prix"
-
-msgid "Manage saved tie-break sets for this pairing system."
-msgstr "Gérer les jeux de départages enregistrés pour ce système d'appariement."
 
 msgid "Manage screens"
 msgstr "Gestion des écrans"
@@ -3661,7 +3664,7 @@ msgid "No rotators"
 msgstr "Aucun écran rotatif"
 
 msgid "No saved sets."
-msgstr "Aucun jeu enregistré."
+msgstr "Aucun ensemble enregistré."
 
 msgid "No screen families"
 msgstr "Aucune famille d'écrans"
@@ -3678,8 +3681,8 @@ msgstr "Aucun écran."
 msgid "No such screens."
 msgstr "Aucun écran de ce type."
 
-msgid "No tie-breaks for [{tournament}]"
-msgstr "Aucun départage pour [{tournament}]"
+msgid "No tie-breaks."
+msgstr "Aucun départage."
 
 msgid "No timers"
 msgstr "Aucun chronomètre"
@@ -4324,7 +4327,7 @@ msgid "Please choose a federation."
 msgstr "Veuillez choisir une fédération."
 
 msgid "Please choose a name for the set."
-msgstr "Veuillez choisir un nom pour le jeu."
+msgstr "Veuillez choisir un nom pour l'ensemble."
 
 msgid "Please choose a player."
 msgstr "Veuillez choisir un·e joueur·euse."
@@ -4543,7 +4546,7 @@ msgid "Qatar"
 msgstr "Qatar"
 
 msgid "Quick-apply a tie-break set"
-msgstr "Appliquer un jeu de départages"
+msgstr "Appliquer un ensemble de départages"
 
 #, python-format
 msgid "R %(round)d *** ROUND COLUMN HEADER"
@@ -4641,7 +4644,6 @@ msgstr "Ont reçu un bye point entier pour la ronde à venir"
 
 msgid "Received a Half-Point Bye for the next round"
 msgstr "Ont reçu un bye pour la ronde à venir"
-
 
 msgid "Received a Zero-Point Bye for all the remaining rounds"
 msgstr "A reçu un forfait pour toutes les rondes à venir"
@@ -4916,9 +4918,6 @@ msgstr "Russie"
 msgid "Rwanda"
 msgstr "Rwanda"
 
-msgid "SC Recommendation"
-msgstr "Recommandation SC"
-
 msgid "SCR"
 msgstr "ÉCR"
 
@@ -4953,7 +4952,7 @@ msgid "Save"
 msgstr "Enregistrer"
 
 msgid "Save current tie-breaks as custom set"
-msgstr "Enregistrer les départages actuels comme jeu personnalisé"
+msgstr "Enregistrer les départages actuels comme ensemble personnalisé"
 
 msgid "Save the set or cancel."
 msgstr "Enregistrez l'ensemble ou annulez."
@@ -5110,16 +5109,16 @@ msgid "Set Zero-Points Byes"
 msgstr "Allouer des forfaits"
 
 msgid "Set [{name}] has been saved."
-msgstr "Le jeu [{name}] a été enregistré."
+msgstr "L'ensemble [{name}] a été enregistré."
 
 msgid "Set [{name}] has been updated."
-msgstr "Le jeu [{name}] a été mis à jour."
+msgstr "L'ensemble [{name}] a été mis à jour."
 
 msgid "Set illegal moves"
 msgstr "Noter les coups illégaux"
 
 msgid "Set name"
-msgstr "Nom du jeu"
+msgstr "Nom de l'ensemble"
 
 msgid "Set special results"
 msgstr "Noter des résultats spéciaux"
@@ -5159,6 +5158,9 @@ msgstr "Projet Sharly Chess"
 
 msgid "Sharly Chess reaches its full potential when used as a server, with other devices connected to the same network."
 msgstr "Sharly Chess atteint son plein potentiel lorsqu'utilisé comme un serveur, avec d'autres appareils connectés au même réseau."
+
+msgid "Sharly Chess recommendation"
+msgstr "Recommendation Sharly Chess"
 
 msgid "Sharly Chess server"
 msgstr "Serveur Sharly Chess"
@@ -5708,7 +5710,7 @@ msgid "The timer displayed on the screens of the family."
 msgstr "Le chronomètre affiché sur les écrans de la famille."
 
 msgid "The tournament has invalid tie-breaks; please fix them before saving as a set."
-msgstr "Le tournoi contient des départages invalides ; corrigez-les avant d'enregistrer le jeu."
+msgstr "Le tournoi contient des départages invalides ; corrigez-les avant d'enregistrer l'ensemble."
 
 msgid "The tournament has no tie-breaks to save."
 msgstr "Le tournoi ne contient aucun départage à enregistrer."
@@ -5767,9 +5769,8 @@ msgstr "Il doit y avoir au moins un écran ou une famille d'écrans définie pou
 msgid "These plugins can only be activated on events of their federation."
 msgstr "Ces plug-ins ne peuvent-être activés que pour les évènements de leur fédération."
 
-#, python-format
-msgid "These sets are saved per pairing system and shared across events. Showing sets for [%(pairing_system)s]."
-msgstr "Ces jeux sont enregistrés par système d'appariement et partagés entre les événements. Affichage pour [%(pairing_system)s]."
+msgid "These sets are saved per pairing system and shared across events."
+msgstr "Ces ensembles sont enregistrés par système d'appariement et partagés entre les événements."
 
 msgid "These tournaments are already included for this account by a higher access level."
 msgstr "Ces tournois sont déjà inclus pour ce compte par un niveau d'accès plus élevé."
@@ -5886,10 +5887,7 @@ msgid "This screen is public (visible by the spectators)."
 msgstr "Cet écran est public (visible des spectateur·ices)."
 
 msgid "This set contains [{name}] twice in a row."
-msgstr "Ce jeu contient [{name}] deux fois consécutivement."
-
-msgid "This set contains a duplicate tie-break ([{name}])."
-msgstr "Ce jeu contient un départage en doublon ([{name}])."
+msgstr "Cet ensemble contient [{name}] deux fois de suite."
 
 msgid "This tie-break can be used multiple times."
 msgstr "Ce départage peut-être utilisé plusieurs fois."
@@ -5944,16 +5942,13 @@ msgid "Tie-break favoring players which have won against the players they are ti
 msgstr "Départage favorisant les joueur·euses ayant gagné contre les joueur·euses ex aequo (consulter le règlement FIDE pour plus d'informations)."
 
 msgid "Tie-break sets are saved from the Tie-breaks modal."
-msgstr "Les jeux de départages sont enregistrés depuis la fenêtre Départages."
+msgstr "Les ensembles de départages sont enregistrés depuis la fenêtre Départages."
 
 msgid "Tie-breaks"
 msgstr "Départages"
 
 msgid "Tie-breaks determine the rankings for players that are tied with the same number of points."
 msgstr "Les départages déterminent le classement des joueur·euses ayant le même nombre de points."
-
-msgid "Tie-breaks for [{tournament}]"
-msgstr "Départages de [{tournament}]"
 
 msgid "Time control"
 msgstr "Cadence"
@@ -7025,9 +7020,6 @@ msgstr "ecran-{family_type}"
 
 msgid "{first_name} {last_name}"
 msgstr "{last_name} {first_name}"
-
-msgid "{name}: {message}"
-msgstr "{name} : {message}"
 
 msgid "{player.first_name} {player.last_name} had won {previous_value} in the main group but was then given a prize of {next_value} in the category '{cat_name}' instead. By leaving the main group, the prize share for the place they were in is now worth {new_share}."
 msgstr "{player.last_name} {player.first_name} avait remporté {previous_value} dans le groupe principal, mais a ensuite reçu un prix de {next_value} dans la catégorie « {cat_name} ». En quittant le groupe principal, la part du prix à sa place vaut désormais {new_share}."

--- a/src/data/pairings/systems.py
+++ b/src/data/pairings/systems.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
         SwissVariation,
         RoundRobinVariation,
     )
-    from data.tie_breaks import TieBreak
     from data.tournament import Tournament
     from data.event import Event
 
@@ -102,11 +101,6 @@ class PairingSystem[PV: PairingVariation](IdentifiableEntity, ABC):
         """ID of the html element containing the tie-break help in the tournament form."""
         return f'{self.id}_tie_break_help_container'
 
-    @property
-    @abstractmethod
-    def recommended_tie_breaks(self) -> list['TieBreak']:
-        """List of tie-breaks recommended by the FIDE."""
-
 
 class SwissPairingSystem(PairingSystem['SwissVariation']):
     @staticmethod
@@ -186,22 +180,6 @@ class SwissPairingSystem(PairingSystem['SwissVariation']):
 
     def default_current_round(self, tournament: 'Tournament') -> int:
         return tournament.last_paired_round
-
-    @property
-    def recommended_tie_breaks(self) -> list['TieBreak']:
-        from data.tie_breaks import tie_breaks
-        from data.tie_breaks.options import CutterWithMedianTieBreakOption
-        from data.tie_breaks.cutters import Cut1TieBreakCutter
-
-        return [
-            tie_breaks.StandardBuchholzTieBreak(
-                [CutterWithMedianTieBreakOption(Cut1TieBreakCutter().id)]
-            ),
-            tie_breaks.DirectEncounterTieBreak(),
-            tie_breaks.StandardBuchholzTieBreak(),
-            tie_breaks.SonnebornBergerTieBreak(),
-            tie_breaks.WinsTieBreak(),
-        ]
 
 
 class RoundRobinPairingSystem(PairingSystem['RoundRobinVariation']):
@@ -285,14 +263,3 @@ class RoundRobinPairingSystem(PairingSystem['RoundRobinVariation']):
             ),
             1 if tournament.has_pairings else 0,
         )
-
-    @property
-    def recommended_tie_breaks(self) -> list['TieBreak']:
-        from data.tie_breaks import tie_breaks
-
-        return [
-            tie_breaks.DirectEncounterTieBreak(),
-            tie_breaks.WinsTieBreak(),
-            tie_breaks.SonnebornBergerTieBreak(),
-            tie_breaks.KoyaTieBreak(),
-        ]

--- a/src/data/tie_breaks/sets.py
+++ b/src/data/tie_breaks/sets.py
@@ -2,8 +2,7 @@
 parameters) that can be applied to a tournament that has no tie-breaks yet.
 
 Sets come from four sources:
-  - SYSTEM: code constants (SC recommendation, FIDE 2019…)
-  - PLUGIN: provided by plugins via the `insert_tie_break_sets` hook
+  - SYSTEM: SC recommendation, FIDE 2019, plugins
   - CUSTOM: stored in the global `.scc` config DB, shared by all users of
     the server instance
   - TOURNAMENT: snapshot of another tournament in the same event
@@ -13,7 +12,7 @@ import copy
 from dataclasses import dataclass, field
 from enum import StrEnum
 from logging import Logger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from common.i18n import _
 from common.logger import get_logger
@@ -29,18 +28,21 @@ logger: Logger = get_logger()
 
 
 class TieBreakSetSource(StrEnum):
-    SYSTEM = 'system'
-    PLUGIN = 'plugin'
-    CUSTOM = 'custom'
     TOURNAMENT = 'tournament'
+    CUSTOM = 'custom'
+    SYSTEM = 'system'
 
-
-SOURCE_LABELS: dict[TieBreakSetSource, str] = {
-    TieBreakSetSource.SYSTEM: _('System'),
-    TieBreakSetSource.PLUGIN: _('Plugins'),
-    TieBreakSetSource.CUSTOM: _('Custom'),
-    TieBreakSetSource.TOURNAMENT: _('From tournament'),
-}
+    @property
+    def label(self) -> str:
+        match self:
+            case self.SYSTEM:
+                return _('System')
+            case self.CUSTOM:
+                return _('Custom')
+            case self.TOURNAMENT:
+                return _('Event tournaments')
+            case _:
+                raise ValueError(self)
 
 
 @dataclass
@@ -57,16 +59,30 @@ class TieBreakSet:
     custom_set_id: int | None = None
     tie_break_acronyms: list[str] = field(default_factory=list)
 
-    def instantiate_tie_breaks(self, event: 'Event') -> list['TieBreak | None']:
+    def instantiate_tie_breaks(
+        self, event: Optional['Event']
+    ) -> list['TieBreak | None']:
         """Materialize fresh TieBreak instances from the stored payload."""
         return [
             instantiate_tie_break(stored_tb, event)
             for stored_tb in self.stored_tie_breaks
         ]
 
+    def tooltip_message(self, event: Optional['Event'] = None) -> str:
+        return ''.join(
+            [
+                f'<div class="text-start">{index}. {tie_break.full_name}</div>'
+                for index, tie_break in enumerate(
+                    self.instantiate_tie_breaks(event),
+                    start=1,
+                )
+                if tie_break is not None
+            ]
+        )
+
 
 def instantiate_tie_break(
-    stored_tie_break: StoredTieBreak, event: 'Event'
+    stored_tie_break: StoredTieBreak, event: Optional['Event']
 ) -> 'TieBreak | None':
     """Materialize a single TieBreak from its stored value.
     Returns None if the type is unknown for this event (e.g. plugin disabled)."""
@@ -144,28 +160,24 @@ def evaluate_set_against_tournament(
                 name=friendly_name_for_tie_break_type(stored_tb.type)
             )
         if message := tournament.tie_break_invalid_message(tie_break):
-            return True, _('{name}: {message}').format(
-                name=tie_break.full_name, message=message
+            tooltip = (
+                f'<div class="fw-bold">'
+                f'  {tie_break.full_name} ({tie_break.acronym})'
+                f'</div>{message}'
             )
-
-    seen: list['TieBreak'] = []
+            return True, tooltip
     last_id: str | None = None
     for tie_break in tie_breaks:
         assert tie_break is not None
-        if not tie_break.allow_multiple and tie_break in seen:
-            return True, _(
-                'This set contains a duplicate tie-break ([{name}]).'
-            ).format(name=tie_break.full_name)
         if tie_break.allow_multiple and tie_break.id == last_id:
             return True, _('This set contains [{name}] twice in a row.').format(
                 name=tie_break.full_name
             )
-        seen.append(tie_break)
         last_id = tie_break.id
     return False, None
 
 
-def fill_acronyms(tie_break_set: TieBreakSet, event: 'Event') -> None:
+def fill_acronyms(tie_break_set: TieBreakSet, event: 'Event | None') -> None:
     """Populate `tie_break_acronyms` on the set for UI display."""
     acronyms: list[str] = []
     for tie_break in tie_break_set.instantiate_tie_breaks(event):
@@ -219,28 +231,13 @@ def available_tie_break_sets(
     Each set's `disabled` and `disabled_reason` are evaluated against the tournament."""
     from common.sharly_chess_config import SharlyChessConfig
     from data.tie_breaks.system_sets import build_system_tie_break_sets
-    from plugins.manager import plugin_manager
 
     pairing_system_id = tournament.pairing_system.id
     grouped: dict[TieBreakSetSource, list[TieBreakSet]] = {
-        TieBreakSetSource.SYSTEM: [],
-        TieBreakSetSource.PLUGIN: [],
-        TieBreakSetSource.CUSTOM: [],
-        TieBreakSetSource.TOURNAMENT: [],
+        source: [] for source in TieBreakSetSource
     }
 
-    for tie_break_set in build_system_tie_break_sets(tournament.event):
-        if tie_break_set.pairing_system_id == pairing_system_id:
-            grouped[TieBreakSetSource.SYSTEM].append(tie_break_set)
-
-    plugin_sets: list[TieBreakSet] = []
-    plugin_manager.hook_for_event(tournament.event, 'insert_tie_break_sets')(
-        tie_break_sets=plugin_sets, event=tournament.event
-    )
-    for tie_break_set in plugin_sets:
-        tie_break_set.source = TieBreakSetSource.PLUGIN
-        if tie_break_set.pairing_system_id == pairing_system_id:
-            grouped[TieBreakSetSource.PLUGIN].append(tie_break_set)
+    grouped[TieBreakSetSource.SYSTEM] = build_system_tie_break_sets(tournament)
 
     for tie_break_set in SharlyChessConfig().custom_tie_break_sets:
         if tie_break_set.pairing_system_id == pairing_system_id:

--- a/src/data/tie_breaks/system_sets.py
+++ b/src/data/tie_breaks/system_sets.py
@@ -6,9 +6,18 @@ system the set targets.
 """
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from common.i18n import _
+from data.pairings.systems import SwissPairingSystem, RoundRobinPairingSystem
+from data.tie_breaks import tie_breaks
+from data.tie_breaks.cutters import Cut1TieBreakCutter
+from data.tie_breaks.options import (
+    CutterWithMedianTieBreakOption,
+    EstimatedRatingsTieBreakOption,
+)
+from data.tournament import Tournament
+from plugins.manager import plugin_manager
 
 if TYPE_CHECKING:
     from data.event import Event
@@ -17,55 +26,103 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class SystemTieBreakSetDefinition:
+class SystemTieBreakSet:
     key: str
-    name_factory: Callable[[], str]
-    pairing_system_id: str
-    tie_break_factory: Callable[[], list['TieBreak']]
+    name: str
+    tie_breaks: list['TieBreak']
 
 
-def _sc_recommendation_swiss() -> list['TieBreak']:
-    from data.pairings.systems import SwissPairingSystem
+def _swiss_system_sets(event: 'Event') -> list['SystemTieBreakSet']:
+    system_sets: list[SystemTieBreakSet] = [
+        SystemTieBreakSet(
+            key='swiss-sc-recommendation',
+            name=_('Sharly Chess recommendation'),
+            tie_breaks=[
+                tie_breaks.StandardBuchholzTieBreak(
+                    [CutterWithMedianTieBreakOption(Cut1TieBreakCutter().id)]
+                ),
+                tie_breaks.DirectEncounterTieBreak(),
+                tie_breaks.StandardBuchholzTieBreak(),
+                tie_breaks.SonnebornBergerTieBreak(),
+                tie_breaks.WinsTieBreak(),
+            ],
+        ),
+        SystemTieBreakSet(
+            key='swiss-fide-recommendation-2019',
+            name=_('FIDE recommendation (2019)'),
+            tie_breaks=[
+                tie_breaks.StandardBuchholzTieBreak(
+                    [CutterWithMedianTieBreakOption(Cut1TieBreakCutter().id)]
+                ),
+                tie_breaks.StandardBuchholzTieBreak(),
+                tie_breaks.SonnebornBergerTieBreak(),
+                tie_breaks.ProgressiveScoresTieBreak(),
+                tie_breaks.DirectEncounterTieBreak(),
+                tie_breaks.WinsTieBreak(),
+                tie_breaks.GamesWonWithBlackTieBreak(),
+            ],
+        ),
+        SystemTieBreakSet(
+            key='swiss-fide-recommendation-2019-unrated',
+            name=_('FIDE recommendation - Unrated (2019)'),
+            tie_breaks=[
+                tie_breaks.StandardBuchholzTieBreak(
+                    [CutterWithMedianTieBreakOption(Cut1TieBreakCutter().id)]
+                ),
+                tie_breaks.StandardBuchholzTieBreak(),
+                tie_breaks.DirectEncounterTieBreak(),
+                tie_breaks.AverageRatingOpponentsTieBreak(
+                    [EstimatedRatingsTieBreakOption(True)]
+                ),
+                tie_breaks.WinsTieBreak(),
+                tie_breaks.GamesWonWithBlackTieBreak(),
+                tie_breaks.GamesPlayedWithBlackTieBreak(),
+                tie_breaks.SonnebornBergerTieBreak(),
+            ],
+        ),
+    ]
+    plugin_manager.hook_for_event(event, 'insert_swiss_system_tie_break_sets')(
+        system_sets=system_sets
+    )
+    return system_sets
 
-    return SwissPairingSystem().recommended_tie_breaks
+
+def _round_robin_system_sets() -> list['SystemTieBreakSet']:
+    system_sets: list[SystemTieBreakSet] = [
+        SystemTieBreakSet(
+            key='rr-fide-recommendation-2019',
+            name=_('FIDE recommendation (2019)'),
+            tie_breaks=[
+                tie_breaks.DirectEncounterTieBreak(),
+                tie_breaks.WinsTieBreak(),
+                tie_breaks.SonnebornBergerTieBreak(),
+                tie_breaks.KoyaTieBreak(),
+            ],
+        ),
+    ]
+    return system_sets
 
 
-def _sc_recommendation_round_robin() -> list['TieBreak']:
-    from data.pairings.systems import RoundRobinPairingSystem
-
-    return RoundRobinPairingSystem().recommended_tie_breaks
-
-
-SYSTEM_TIE_BREAK_SETS: list[SystemTieBreakSetDefinition] = [
-    SystemTieBreakSetDefinition(
-        key='sc-recommendation-swiss',
-        name_factory=lambda: _('SC Recommendation'),
-        pairing_system_id='SWISS',
-        tie_break_factory=_sc_recommendation_swiss,
-    ),
-    SystemTieBreakSetDefinition(
-        key='sc-recommendation-round-robin',
-        name_factory=lambda: _('SC Recommendation'),
-        pairing_system_id='ROUND_ROBIN',
-        tie_break_factory=_sc_recommendation_round_robin,
-    ),
-]
-
-
-def build_system_tie_break_sets(event: 'Event') -> list['TieBreakSet']:
+def build_system_tie_break_sets(tournament: 'Tournament') -> list['TieBreakSet']:
     """Materialize all system tie-break set definitions into TieBreakSet objects."""
     from data.tie_breaks.sets import TieBreakSet, TieBreakSetSource
 
-    sets: list['TieBreakSet'] = []
-    for definition in SYSTEM_TIE_BREAK_SETS:
-        tie_breaks = definition.tie_break_factory()
-        sets.append(
-            TieBreakSet(
-                key=definition.key,
-                name=definition.name_factory(),
-                source=TieBreakSetSource.SYSTEM,
-                pairing_system_id=definition.pairing_system_id,
-                stored_tie_breaks=[tb.to_stored_value() for tb in tie_breaks],
-            )
+    event = tournament.event
+    system_sets: list[SystemTieBreakSet] = []
+    system_id = tournament.pairing_system.id
+    if system_id == SwissPairingSystem().id:
+        system_sets = _swiss_system_sets(event)
+    elif system_id == RoundRobinPairingSystem().id:
+        system_sets = _round_robin_system_sets()
+    return [
+        TieBreakSet(
+            key=system_set.key,
+            name=system_set.name,
+            source=TieBreakSetSource.SYSTEM,
+            pairing_system_id=system_id,
+            stored_tie_breaks=[
+                tie_break.to_stored_value() for tie_break in system_set.tie_breaks
+            ],
         )
-    return sets
+        for system_set in system_sets
+    ]

--- a/src/plugins/ffe/ffe.py
+++ b/src/plugins/ffe/ffe.py
@@ -36,6 +36,8 @@ from data.print_documents.place_cards.data import PlaceCardPlayer
 from data.print_documents.player_splitters import ClubPlayerSplitter
 from data.print_documents.qrcode_types import QRCodeType
 from data.tie_breaks import TieBreak, TieBreakOption
+from data.tie_breaks.system_sets import SystemTieBreakSet
+from data.tie_breaks.tie_breaks import ProgressiveScoresTieBreak
 from database.sqlite.event.event_database import EventDatabase
 from database.sqlite.event.event_store import StoredPlayer
 from database.sqlite.fide.fide_database import FideDatabase
@@ -789,6 +791,48 @@ class FfePlugin(Plugin):
         self, tie_break_option_types: list[type[TieBreakOption]]
     ):
         tie_break_option_types.append(PapiBuchholzTypeOption)
+
+    @hookimpl
+    def insert_swiss_system_tie_break_sets(
+        self, system_sets: list['SystemTieBreakSet']
+    ):
+        from plugins.ffe import ffe_tie_breaks
+        from plugins.ffe.ffe_tie_breaks import (
+            PapiBuchholzTypeOption,
+            StandardPapiBuchholzType,
+            CutPapiBuchholzType,
+        )
+
+        system_sets.append(
+            SystemTieBreakSet(
+                key=f'{PLUGIN_NAME}:youth-championship-swiss',
+                name=_('"France jeunes" and qualifiers'),
+                tie_breaks=[
+                    ffe_tie_breaks.PapiBuchholzTieBreak(
+                        [PapiBuchholzTypeOption(CutPapiBuchholzType().id)]
+                    ),
+                    ffe_tie_breaks.PapiBuchholzTieBreak(
+                        [PapiBuchholzTypeOption(StandardPapiBuchholzType().id)]
+                    ),
+                    ffe_tie_breaks.PapiPerformanceTieBreak(),
+                ],
+            )
+        )
+        system_sets.append(
+            SystemTieBreakSet(
+                key=f'{PLUGIN_NAME}:youth-championship-swiss-unrated',
+                name=_('"France jeunes" and qualifiers - Unrated'),
+                tie_breaks=[
+                    ffe_tie_breaks.PapiBuchholzTieBreak(
+                        [PapiBuchholzTypeOption(CutPapiBuchholzType().id)]
+                    ),
+                    ffe_tie_breaks.PapiBuchholzTieBreak(
+                        [PapiBuchholzTypeOption(StandardPapiBuchholzType().id)]
+                    ),
+                    ProgressiveScoresTieBreak(),
+                ],
+            )
+        )
 
     # ---------------------------------------------------------------------------------
     # Pairings

--- a/src/plugins/ffe/locale/en/LC_MESSAGES/ffe.po
+++ b/src/plugins/ffe/locale/en/LC_MESSAGES/ffe.po
@@ -1,3 +1,9 @@
+msgid "\"France jeunes\" and qualifiers"
+msgstr ""
+
+msgid "\"France jeunes\" and qualifiers - Unrated"
+msgstr ""
+
 msgid "\"Niçois\" accelerated system"
 msgstr ""
 

--- a/src/plugins/ffe/locale/fr/LC_MESSAGES/ffe.po
+++ b/src/plugins/ffe/locale/fr/LC_MESSAGES/ffe.po
@@ -2,7 +2,7 @@ msgid "\"France jeunes\" and qualifiers"
 msgstr "France jeunes et qualif."
 
 msgid "\"France jeunes\" and qualifiers - Unrated"
-msgstr "France jeunes et qualif. - Non-classé·es"
+msgstr "France jeunes et qualif. - Non classé·es"
 
 msgid "\"Niçois\" accelerated system"
 msgstr "Système accéléré niçois"

--- a/src/plugins/ffe/locale/fr/LC_MESSAGES/ffe.po
+++ b/src/plugins/ffe/locale/fr/LC_MESSAGES/ffe.po
@@ -1,3 +1,9 @@
+msgid "\"France jeunes\" and qualifiers"
+msgstr "France jeunes et qualif."
+
+msgid "\"France jeunes\" and qualifiers - Unrated"
+msgstr "France jeunes et qualif. - Non-classé·es"
+
 msgid "\"Niçois\" accelerated system"
 msgstr "Système accéléré niçois"
 

--- a/src/plugins/fra_schools/fra_schools.py
+++ b/src/plugins/fra_schools/fra_schools.py
@@ -25,6 +25,7 @@ from data.print_documents.documents import (
     StatisticsPrintDocument,
 )
 from data.print_documents.player_splitters import ClubPlayerSplitter
+from data.tie_breaks.system_sets import SystemTieBreakSet
 from database.sqlite.event.event_store import (
     StoredEvent,
     StoredTournament,
@@ -78,7 +79,6 @@ from web.controllers.base_controller import BaseController
 if TYPE_CHECKING:
     from database.sqlite.event.event_store import StoredTournament
     from data.tournament import Tournament
-    from data.tie_breaks.sets import TieBreakSet
 
 logger = get_logger()
 
@@ -347,6 +347,39 @@ class FRASchoolsPlugin(Plugin):
         PluginUtils.insert_on_equals(player_filter_option_types, school, club, False)
 
     # ---------------------------------------------------------------------------------
+    # Tie-breaks
+    # ---------------------------------------------------------------------------------
+
+    @hookimpl(trylast=True)
+    def insert_swiss_system_tie_break_sets(
+        self, system_sets: list['SystemTieBreakSet']
+    ):
+        from data.tie_breaks import tie_breaks
+        from plugins.ffe import ffe_tie_breaks
+        from plugins.ffe.ffe_tie_breaks import (
+            PapiBuchholzTypeOption,
+            StandardPapiBuchholzType,
+            CutPapiBuchholzType,
+        )
+
+        system_sets.insert(
+            0,
+            SystemTieBreakSet(
+                key=f'{PLUGIN_NAME}:fra-schools-championship',
+                name=_('French schools championship'),
+                tie_breaks=[
+                    ffe_tie_breaks.PapiBuchholzTieBreak(
+                        [PapiBuchholzTypeOption(CutPapiBuchholzType().id)]
+                    ),
+                    ffe_tie_breaks.PapiBuchholzTieBreak(
+                        [PapiBuchholzTypeOption(StandardPapiBuchholzType().id)]
+                    ),
+                    tie_breaks.ProgressiveScoresTieBreak(),
+                ],
+            ),
+        )
+
+    # ---------------------------------------------------------------------------------
     # Plugin hooks
     # ---------------------------------------------------------------------------------
 
@@ -449,10 +482,6 @@ class FRASchoolsPlugin(Plugin):
             school_id
         ).to_stored_value()
 
-    # ---------------------------------------------------------------------------------
-    # Plugin hooks
-    # ---------------------------------------------------------------------------------
-
     @hookimpl
     def add_sce_upload_player_custom_fields(
         self, custom_fields: dict[str, Any], player: TournamentPlayer
@@ -480,33 +509,3 @@ class FRASchoolsPlugin(Plugin):
     @hookimpl(trylast=True)
     def alter_sce_upload_ranking_columns(self, columns: list[SCEUploadColumn]):
         self._replace_sce_upload_origin_columns(columns)
-
-    @hookimpl
-    def insert_tie_break_sets(self, tie_break_sets: list['TieBreakSet'], event: Event):
-        from data.tie_breaks import tie_breaks
-        from data.tie_breaks.sets import TieBreakSet, TieBreakSetSource
-        from plugins.ffe import ffe_tie_breaks
-        from plugins.ffe.ffe_tie_breaks import (
-            PapiBuchholzTypeOption,
-            StandardPapiBuchholzType,
-            CutPapiBuchholzType,
-        )
-
-        ordered = [
-            ffe_tie_breaks.PapiBuchholzTieBreak(
-                [PapiBuchholzTypeOption(CutPapiBuchholzType().id)]
-            ),
-            ffe_tie_breaks.PapiBuchholzTieBreak(
-                [PapiBuchholzTypeOption(StandardPapiBuchholzType().id)]
-            ),
-            tie_breaks.ProgressiveScoresTieBreak(),
-        ]
-        tie_break_sets.append(
-            TieBreakSet(
-                key=f'plugin:{PLUGIN_NAME}:fra-schools-championship',
-                name=_('Championnat de France des écoles et collèges'),
-                source=TieBreakSetSource.PLUGIN,
-                pairing_system_id='SWISS',
-                stored_tie_breaks=[tb.to_stored_value() for tb in ordered],
-            )
-        )

--- a/src/plugins/fra_schools/locale/en/LC_MESSAGES/fra_schools.po
+++ b/src/plugins/fra_schools/locale/en/LC_MESSAGES/fra_schools.po
@@ -27,9 +27,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-msgid "Championnat de France des écoles et collèges"
-msgstr ""
-
 msgid "Choose at least one school."
 msgstr ""
 
@@ -58,6 +55,9 @@ msgid "French Schools"
 msgstr ""
 
 msgid "French school"
+msgstr ""
+
+msgid "French schools championship"
 msgstr ""
 
 msgid "Hide the UAI codes for the FFE upload"
@@ -188,4 +188,7 @@ msgid "{count} school represented"
 msgid_plural "{count} schools represented"
 msgstr[0] ""
 msgstr[1] ""
+
+#~ msgid "Championnat de France des écoles et collèges"
+#~ msgstr ""
 

--- a/src/plugins/fra_schools/locale/fr/LC_MESSAGES/fra_schools.po
+++ b/src/plugins/fra_schools/locale/fr/LC_MESSAGES/fra_schools.po
@@ -27,9 +27,6 @@ msgstr "Âge moyen : %(years)s ans"
 msgid "Cancel"
 msgstr "Annuler"
 
-msgid "Championnat de France des écoles et collèges"
-msgstr "Championnat de France des écoles et collèges"
-
 msgid "Choose at least one school."
 msgstr "Choisir au moins un établissement."
 
@@ -59,6 +56,9 @@ msgstr "Établissements Scolaires"
 
 msgid "French school"
 msgstr "Établissement scolaire"
+
+msgid "French schools championship"
+msgstr "Championnat de France des écoles et collèges"
 
 msgid "Hide the UAI codes for the FFE upload"
 msgstr "Cacher les codes UAI lors de la mise en ligne FFE"

--- a/src/plugins/hookspec.py
+++ b/src/plugins/hookspec.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from data.criteria.player_filter_options import PlayerFilterOption
     from data.criteria.player_filters import PlayerFilter
     from data.tie_breaks import TieBreak, TieBreakOption
-    from data.tie_breaks.sets import TieBreakSet
+    from data.tie_breaks.system_sets import SystemTieBreakSet
     from data.tournament import Tournament
     from data.event import Event
     from database.sqlite.event.event_store import StoredPlayer
@@ -397,10 +397,10 @@ class AppHookSpecs:
         """Provide extra tournament tie-break options."""
 
     @hookspec
-    def insert_tie_break_sets(
-        self, tie_break_sets: list['TieBreakSet'], event: 'Event'
+    def insert_swiss_system_tie_break_sets(
+        self, system_sets: list['SystemTieBreakSet']
     ):
-        """Provide extra named tie-break sets, scoped per pairing system."""
+        """Provide extra system tie-break sets for the swiss pairing system."""
 
     # ---------------------------------------------------------------------------------
     # Pairings

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -34,12 +34,12 @@ from data.pairings.systems import SwissPairingSystem
 from data.player import TournamentPlayer
 from data.tie_breaks import TieBreakManager, TieBreak, TieBreakOptionManager
 from data.tie_breaks.sets import (
-    SOURCE_LABELS,
     TieBreakSetSource,
     available_tie_break_sets,
     get_tie_break_set,
     instantiate_tie_break,
     stored_tie_break_to_dict,
+    TieBreakSet,
 )
 from database.sqlite.config.config_database import ConfigDatabase
 from database.sqlite.config.config_store import StoredTieBreakSet
@@ -1290,39 +1290,23 @@ class TournamentAdminController(BaseEventAdminController):
         grouped = available_tie_break_sets(tournament)
 
         select_options: dict[str, dict[str, SelectOption]] = {}
-        for source in (
-            TieBreakSetSource.SYSTEM,
-            TieBreakSetSource.PLUGIN,
-            TieBreakSetSource.CUSTOM,
-            TieBreakSetSource.TOURNAMENT,
-        ):
+        for source in TieBreakSetSource:
             sets = grouped.get(source, [])
             if not sets:
                 continue
             options: dict[str, SelectOption] = {}
             for tie_break_set in sets:
-                preview = (
-                    '<br/>'.join(
-                        [
-                            f'{index}. {tie_break.acronym} - {tie_break.name}'
-                            for index, tie_break in enumerate(
-                                tie_break_set.instantiate_tie_breaks(tournament.event),
-                                start=1,
-                            )
-                            if tie_break is not None
-                        ]
-                    )
-                    or '—'
-                )
-                tooltip = (
-                    tie_break_set.disabled_reason if tie_break_set.disabled else preview
-                )
                 options[f'{source.value}|{tie_break_set.key}'] = SelectOption(
-                    name=f'{tie_break_set.name} ({" - ".join(tie_break_set.tie_break_acronyms) or "-"})',
-                    tooltip=tooltip,
+                    name=tie_break_set.name,
+                    tooltip=(
+                        tie_break_set.disabled_reason
+                        if tie_break_set.disabled
+                        else tie_break_set.tooltip_message(tournament.event)
+                    ),
                     disabled=tie_break_set.disabled,
+                    subtitle=' - '.join(tie_break_set.tie_break_acronyms),
                 )
-            select_options[SOURCE_LABELS[source]] = options
+            select_options[source.label] = options
 
         existing_custom_set_names = [
             tie_break_set.name
@@ -1635,18 +1619,24 @@ class TournamentAdminController(BaseEventAdminController):
     def _tie_break_sets_modal_context(tournament: Tournament) -> dict[str, Any]:
         """Context for the custom TB-set management modal: lists all custom
         sets for the current pairing system."""
-        custom_sets = [
-            tie_break_set
-            for tie_break_set in SharlyChessConfig().custom_tie_break_sets
-            if tie_break_set.pairing_system_id == tournament.pairing_system.id
-        ]
-        for tie_break_set in custom_sets:
+        system_name_by_id = PairingSystemManager(None).options()
+        custom_sets_by_pairing_system_name: dict[str, list[TieBreakSet]] = {
+            system_name: [] for system_name in system_name_by_id.values()
+        }
+        for tie_break_set in SharlyChessConfig().custom_tie_break_sets:
             from data.tie_breaks.sets import fill_acronyms
 
-            fill_acronyms(tie_break_set, tournament.event)
+            fill_acronyms(tie_break_set, event=None)
+            system_name = system_name_by_id[tie_break_set.pairing_system_id]
+            custom_sets_by_pairing_system_name[system_name].append(tie_break_set)
+
         return {
             'modal': 'tie_break_sets',
-            'tie_break_custom_sets': custom_sets,
+            'custom_sets_by_pairing_system_name': {
+                name: sets
+                for name, sets in custom_sets_by_pairing_system_name.items()
+                if sets
+            },
         }
 
     @get(

--- a/src/web/controllers/admin/tournament_admin_controller.py
+++ b/src/web/controllers/admin/tournament_admin_controller.py
@@ -1616,7 +1616,7 @@ class TournamentAdminController(BaseEventAdminController):
         )
 
     @staticmethod
-    def _tie_break_sets_modal_context(tournament: Tournament) -> dict[str, Any]:
+    def _tie_break_sets_modal_context() -> dict[str, Any]:
         """Context for the custom TB-set management modal: lists all custom
         sets for the current pairing system."""
         system_name_by_id = PairingSystemManager(None).options()
@@ -1652,10 +1652,8 @@ class TournamentAdminController(BaseEventAdminController):
         tournament_id: int,
     ) -> Template:
         web_context = TournamentAdminWebContext(request, tournament_id)
-        tournament = web_context.get_admin_tournament()
         return self._admin_base_event_render(
-            web_context.template_context
-            | self._tie_break_sets_modal_context(tournament)
+            web_context.template_context | self._tie_break_sets_modal_context()
         )
 
     @delete(
@@ -1674,13 +1672,11 @@ class TournamentAdminController(BaseEventAdminController):
         tie_break_set_id: int,
     ) -> Template:
         web_context = TournamentAdminWebContext(request, tournament_id)
-        tournament = web_context.get_admin_tournament()
         with ConfigDatabase(True) as database:
             database.delete_stored_tie_break_set(tie_break_set_id)
         SharlyChessConfig().load_and_set_env()
         return self._admin_base_event_render(
-            web_context.template_context
-            | self._tie_break_sets_modal_context(tournament)
+            web_context.template_context | self._tie_break_sets_modal_context()
         )
 
     @get(

--- a/src/web/templates/admin/common/macros.j2
+++ b/src/web/templates/admin/common/macros.j2
@@ -167,6 +167,9 @@
             {% if option.search %}
                 data-search="{{ option.search }}"
             {% endif %}
+            {% if option.subtitle %}
+                data-subtitle="{{ option.subtitle }}"
+            {% endif %}
             {% if option.disabled %}disabled{% endif %}
             {% if selected %}selected{% endif %}
         >
@@ -262,6 +265,12 @@
                 const $result = $('<span>' + data.text + '</span>');
                 const tooltip = $(data.element).attr('data-bs-title');
                 if (tooltip) $result.attr('data-bs-title', tooltip);
+                const subtitle = $(data.element).attr('data-subtitle');
+                if (subtitle) {
+                    $result.append($(
+                        '<div class="fst-italic" style="font-size: 70%">' + subtitle + '</div>'
+                    ));
+                }
                 const optionClass = $(data.element).data('class');
                 if (optionClass) $result.addClass(optionClass);
                 const search = $(data.element).data('search');

--- a/src/web/templates/admin/tournaments/tie_break_sets_modal.html
+++ b/src/web/templates/admin/tournaments/tie_break_sets_modal.html
@@ -7,49 +7,56 @@
         <div class="modal-header">
             <h2 class="modal-title">
                 {{ _('Custom tie-break sets') }}
+                <i
+                    class="bi-info-circle-fill"
+                    style="font-size: 70%"
+                    {{ macros.tooltip_attributes('', _(
+                        'These sets are saved per pairing system and shared across events.'
+                    )) }}
+                ></i>
             </h2>
         </div>
         <div class="modal-body">
-            <p>
-                {{ _(
-                    'These sets are saved per pairing system and shared across events. '
-                    'Showing sets for [%(pairing_system)s].',
-                    pairing_system=admin_tournament.pairing_system.name
-                ) }}
-            </p>
-            {% if not tie_break_custom_sets %}
+            {% if not custom_sets_by_pairing_system_name %}
                 <h5 class="text-center my-3">{{ _('No saved sets.') }}</h5>
-                <p>
+                <p class="text-center">
                     {{ _('Tie-break sets are saved from the Tie-breaks modal.') }}
                 </p>
             {% else %}
                 <div class="d-flex flex-column gap-2">
-                    {% for tie_break_set in tie_break_custom_sets %}
-                        <div class="border border-secondary bg-body-tertiary">
-                            <div class="p-2 d-flex align-items-center gap-4">
-                                <div class="text-start flex-grow-1">
-                                    <b>{{ tie_break_set.name }}</b>
-                                    (<i>{{ tie_break_set.tie_break_acronyms|join(' - ') }}</i>)
-                                </div>
-                                <div class="flex-shrink-0 d-flex gap-2 align-items-center">
-                                    <button
-                                        class="btn btn-sm btn-outline-danger text-nowrap"
-                                        type="button"
-                                        hx-delete="{{ url_for(
-                                            'admin-tie-break-set-delete',
-                                            event_uniq_id=admin_event.uniq_id,
-                                            tournament_id=admin_tournament.id,
-                                            tie_break_set_id=tie_break_set.custom_set_id,
-                                        ) }}"
-                                        hx-target="body"
-                                        hx-indicator="#please-wait"
-                                        data-bs-target="#modal-wrapper"
-                                    >
-                                        <i class="bi-trash-fill"></i>
-                                    </button>
+                    {% for system_name, custom_sets in custom_sets_by_pairing_system_name.items() %}
+                        <h4>{{ system_name }}</h4>
+                        {% for tie_break_set in custom_sets %}
+                            <div class="border border-secondary bg-body-tertiary">
+                                <div class="p-2 d-flex align-items-center gap-4">
+                                    <div class="text-start flex-grow-1">
+                                        <b>{{ tie_break_set.name }}</b>
+                                        (<i>{{ tie_break_set.tie_break_acronyms|join(' - ') }}</i>)
+                                    </div>
+                                    <div class="flex-shrink-0 d-flex gap-2 align-items-center">
+                                        <i
+                                            class="bi-info-circle-fill"
+                                            {{ macros.tooltip_attributes('', tie_break_set.tooltip_message(admin_event)) }}
+                                        ></i>
+                                        <button
+                                            class="btn btn-sm btn-outline-danger text-nowrap"
+                                            type="button"
+                                            hx-delete="{{ url_for(
+                                                'admin-tie-break-set-delete',
+                                                event_uniq_id=admin_event.uniq_id,
+                                                tournament_id=admin_tournament.id,
+                                                tie_break_set_id=tie_break_set.custom_set_id,
+                                            ) }}"
+                                            hx-target="body"
+                                            hx-indicator="#please-wait"
+                                            data-bs-target="#modal-wrapper"
+                                        >
+                                            <i class="bi-trash-fill"></i>
+                                        </button>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
+                        {% endfor %}
                     {% endfor %}
                 </div>
             {% endif %}

--- a/src/web/templates/admin/tournaments/tie_breaks_modal.html
+++ b/src/web/templates/admin/tournaments/tie_breaks_modal.html
@@ -1,31 +1,33 @@
+{% set has_tie_breaks = admin_tournament.tie_breaks_by_id|length > 0 %}
 <div
     id="tie-breaks-modal"
     class="modal-dialog modal-dialog-scrollable"
-    style="--bs-modal-width: fit-content; min-width: min(90vw, 450px);"
+    style="--bs-modal-width: fit-content; min-width: min(90vw, {% if has_tie_breaks %}450px{% else %}550px{% endif %});"
 >
     <div class="modal-content">
         <div class="modal-header">
             <h2 class="modal-title">
                 {{ _('Tie-breaks') }}
+                <i
+                    class="bi-info-circle-fill"
+                    style="font-size: 70%"
+                    {{ macros.tooltip_attributes('', _(
+                        'Tie-breaks determine the rankings for players '
+                        'that are tied with the same number of points.'
+                    )) }}
+                ></i>
             </h2>
         </div>
+        {% set has_custom_sets = tie_break_set_custom_names|length > 0 %}
         <div class="modal-body">
             {% if success_message %}
                 {% with type='success', message=success_message %}
                     {% include '/common/alert.html' %}
                 {% endwith %}
             {% endif %}
-
             <h4 class="mb-3">
-                {% if admin_tournament.tie_breaks_by_id %}
-                    {{ _('Tie-breaks for [{tournament}]').format(
-                        tournament=admin_tournament.name
-                    ) }}
-                {% else %}
-                    {{ _('No tie-breaks for [{tournament}]').format(
-                        tournament=admin_tournament.name
-                    ) }}
-                {% endif %}
+                {{ _('%(string)s:', string=_('Tournament')) }}
+                {{ admin_tournament.name }}
                 {% set warning_message = admin_tournament.tie_breaks_warning_message %}
                 {% if warning_message %}
                     <i
@@ -35,13 +37,8 @@
                 {% endif %}
             </h4>
             {% if not admin_tournament.tie_breaks_by_id %}
-                <div>
-                    <p>
-                        {{ _(
-                            'Tie-breaks determine the rankings for players '
-                            'that are tied with the same number of points.'
-                        ) }}
-                    </p>
+                <div class="text-danger">{{ _('No tie-breaks.') }}</div>
+                <div class="pt-2">
                     {% if tie_break_set_select_options %}
                         <form
                             id="tie-break-set-apply-form"
@@ -74,9 +71,28 @@
                                 disabled
                             >
                                 <i class="bi-check-circle-fill pe-1"></i>
-                                {{ _('Apply set') }}
+                                {{ _('Apply') }}
                             </button>
                         </form>
+                        {% if has_custom_sets %}
+                            <div class="text-end {% if not save_as_invalid %}mt-3{% endif %}">
+                                <button
+                                    type="button"
+                                    class="btn btn-outline-primary btn-sm text-nowrap"
+                                    hx-get="{{ url_for(
+                                        'admin-tie-break-sets-modal',
+                                        event_uniq_id=admin_event.uniq_id,
+                                        tournament_id=admin_tournament.id,
+                                    ) }}"
+                                    hx-target="body"
+                                    hx-indicator="#please-wait"
+                                    data-bs-target="#modal-wrapper"
+                                >
+                                    <i class="bi-gear-fill pe-1"></i>
+                                    {{ _('Manage custom sets') }}
+                                </button>
+                            </div>
+                        {% endif %}
                         <script>
                             (function () {
                                 var $sel = $('#tie-break-set');
@@ -224,113 +240,113 @@
                         </button>
                         <div id="custom-sets-collapse" class="collapse">
                             <div class="pt-2">
-                                    {% if not save_as_invalid %}
-                                        {% if tie_break_set_save_as_error %}
-                                            {% with type='warning', message=tie_break_set_save_as_error %}
-                                                {% include '/common/alert.html' %}
-                                            {% endwith %}
-                                        {% endif %}
-                                        <form
-                                            id="tie-break-set-save-form"
-                                            hx-post="{{ url_for(
-                                                'admin-save-tie-break-set',
+                                {% if not save_as_invalid %}
+                                    {% if tie_break_set_save_as_error %}
+                                        {% with type='warning', message=tie_break_set_save_as_error %}
+                                            {% include '/common/alert.html' %}
+                                        {% endwith %}
+                                    {% endif %}
+                                    <form
+                                        id="tie-break-set-save-form"
+                                        hx-post="{{ url_for(
+                                            'admin-save-tie-break-set',
+                                            event_uniq_id=admin_event.uniq_id,
+                                            tournament_id=admin_tournament.id,
+                                        ) }}"
+                                        hx-target="body"
+                                        hx-indicator="#please-wait"
+                                        class="d-flex gap-2 align-items-end"
+                                    >
+                                        <div class="flex-grow-1">
+                                            <style>
+                                                #save-as-name-wrapper { flex-direction: column; }
+                                            </style>
+                                            {{ admin_macros.text_input(
+                                                name='save_as_name',
+                                                label=_('Save current tie-breaks as custom set'),
+                                                placeholder=_('Set name'),
+                                                data={'save_as_name': tie_break_set_save_as_name_value},
+                                                errors={}
+                                            ) }}
+                                        </div>
+                                        <input type="hidden" name="name" id="save-as-name-hidden"/>
+                                        <button
+                                            type="submit"
+                                            class="btn btn-outline-primary text-nowrap"
+                                            id="save-as-submit"
+                                            disabled
+                                        >
+                                            <i class="bi-floppy-fill pe-1"></i>
+                                            {{ _('Save') }}
+                                        </button>
+                                    </form>
+                                    {% set _show_overwrite_initial = (
+                                        tie_break_set_save_as_name_value
+                                        and tie_break_set_save_as_name_value in tie_break_set_custom_names
+                                    ) %}
+                                    <div
+                                        class="justify-content-end align-items-center gap-2 mt-1"
+                                        id="save-as-overwrite-wrapper"
+                                        style="display:{{ 'flex' if _show_overwrite_initial else 'none' }}"
+                                    >
+                                        <label class="form-check-label" for="save-as-overwrite">
+                                            {{ _('Overwrite') }}
+                                        </label>
+                                        <input
+                                            class="form-check-input m-0"
+                                            type="checkbox"
+                                            name="overwrite"
+                                            id="save-as-overwrite"
+                                            value="true"
+                                            form="tie-break-set-save-form"
+                                        />
+                                    </div>
+                                    <script>
+                                        (function () {
+                                            var nameInput = $('#save-as-name');
+                                            var hidden = $('#save-as-name-hidden');
+                                            var btn = $('#save-as-submit');
+                                            var existing = {{ tie_break_set_custom_names|tojson }};
+                                            function refresh() {
+                                                var v = nameInput.val();
+                                                hidden.val(v);
+                                                btn.prop('disabled', !v);
+                                                var collides = existing.indexOf(v) !== -1;
+                                                var wrap = document.getElementById(
+                                                    'save-as-overwrite-wrapper'
+                                                );
+                                                if (!wrap) return;
+                                                if (collides) {
+                                                    wrap.style.display = 'flex';
+                                                } else {
+                                                    wrap.style.display = 'none';
+                                                    $('#save-as-overwrite').prop('checked', false);
+                                                }
+                                            }
+                                            nameInput.on('input keyup', refresh);
+                                            refresh();
+                                        })();
+                                    </script>
+                                {% endif %}
+                                {% if has_custom_sets %}
+                                    <div class="text-end {% if not save_as_invalid %}mt-3{% endif %}">
+                                        <button
+                                            type="button"
+                                            class="btn btn-outline-primary btn-sm text-nowrap"
+                                            hx-get="{{ url_for(
+                                                'admin-tie-break-sets-modal',
                                                 event_uniq_id=admin_event.uniq_id,
                                                 tournament_id=admin_tournament.id,
                                             ) }}"
                                             hx-target="body"
                                             hx-indicator="#please-wait"
-                                            class="d-flex gap-2 align-items-end"
+                                            data-bs-target="#modal-wrapper"
                                         >
-                                            <div class="flex-grow-1">
-                                                <style>
-                                                    #save-as-name-wrapper { flex-direction: column; }
-                                                </style>
-                                                {{ admin_macros.text_input(
-                                                    name='save_as_name',
-                                                    label=_('Save current tie-breaks as custom set'),
-                                                    placeholder=_('Set name'),
-                                                    data={'save_as_name': tie_break_set_save_as_name_value},
-                                                    errors={}
-                                                ) }}
-                                            </div>
-                                            <input type="hidden" name="name" id="save-as-name-hidden"/>
-                                            <button
-                                                type="submit"
-                                                class="btn btn-outline-primary text-nowrap"
-                                                id="save-as-submit"
-                                                disabled
-                                            >
-                                                <i class="bi-floppy-fill pe-1"></i>
-                                                {{ _('Save') }}
-                                            </button>
-                                        </form>
-                                        {% set _show_overwrite_initial = (
-                                            tie_break_set_save_as_name_value
-                                            and tie_break_set_save_as_name_value in tie_break_set_custom_names
-                                        ) %}
-                                        <div
-                                            class="justify-content-end align-items-center gap-2 mt-1"
-                                            id="save-as-overwrite-wrapper"
-                                            style="display:{{ 'flex' if _show_overwrite_initial else 'none' }}"
-                                        >
-                                            <label class="form-check-label" for="save-as-overwrite">
-                                                {{ _('Overwrite') }}
-                                            </label>
-                                            <input
-                                                class="form-check-input m-0"
-                                                type="checkbox"
-                                                name="overwrite"
-                                                id="save-as-overwrite"
-                                                value="true"
-                                                form="tie-break-set-save-form"
-                                            />
-                                        </div>
-                                        <script>
-                                            (function () {
-                                                var nameInput = $('#save-as-name');
-                                                var hidden = $('#save-as-name-hidden');
-                                                var btn = $('#save-as-submit');
-                                                var existing = {{ tie_break_set_custom_names|tojson }};
-                                                function refresh() {
-                                                    var v = nameInput.val();
-                                                    hidden.val(v);
-                                                    btn.prop('disabled', !v);
-                                                    var collides = existing.indexOf(v) !== -1;
-                                                    var wrap = document.getElementById(
-                                                        'save-as-overwrite-wrapper'
-                                                    );
-                                                    if (!wrap) return;
-                                                    if (collides) {
-                                                        wrap.style.display = 'flex';
-                                                    } else {
-                                                        wrap.style.display = 'none';
-                                                        $('#save-as-overwrite').prop('checked', false);
-                                                    }
-                                                }
-                                                nameInput.on('input keyup', refresh);
-                                                refresh();
-                                            })();
-                                        </script>
-                                    {% endif %}
-                                    {% if has_custom_sets %}
-                                        <div class="text-end {% if not save_as_invalid %}mt-3{% endif %}">
-                                            <button
-                                                type="button"
-                                                class="btn btn-outline-primary btn-sm text-nowrap"
-                                                hx-get="{{ url_for(
-                                                    'admin-tie-break-sets-modal',
-                                                    event_uniq_id=admin_event.uniq_id,
-                                                    tournament_id=admin_tournament.id,
-                                                ) }}"
-                                                hx-target="body"
-                                                hx-indicator="#please-wait"
-                                                data-bs-target="#modal-wrapper"
-                                            >
-                                                <i class="bi-gear-fill pe-1"></i>
-                                                {{ _('Manage custom sets') }}
-                                            </button>
-                                        </div>
-                                    {% endif %}
+                                            <i class="bi-gear-fill pe-1"></i>
+                                            {{ _('Manage custom sets') }}
+                                        </button>
+                                    </div>
+                                {% endif %}
                             </div>
                         </div>
                     </div>
@@ -346,28 +362,6 @@
                 <i class="bi-x-circle-fill pe-1"></i>
                 {{ _('Close') }}
             </button>
-            {% if not admin_tournament.tie_breaks_by_id and tie_break_set_custom_names %}
-                <button
-                    type="button"
-                    class="btn btn-outline-primary text-nowrap"
-                    hx-get="{{ url_for(
-                        'admin-tie-break-sets-modal',
-                        event_uniq_id=admin_event.uniq_id,
-                        tournament_id=admin_tournament.id,
-                    ) }}"
-                    hx-target="body"
-                    hx-indicator="#please-wait"
-                    data-bs-target="#modal-wrapper"
-                    {{ macros.tooltip_attributes(
-                        'info',
-                        _('Manage saved tie-break sets for this pairing system.'),
-                        'top'
-                    ) }}
-                >
-                    <i class="bi-gear-fill pe-1"></i>
-                    {{ _('Manage custom sets') }}
-                </button>
-            {% endif %}
             <button
                 class="btn btn-primary text-nowrap"
                 hx-get="{{ url_for(

--- a/src/web/templates/admin/tournaments/tie_breaks_modal.html
+++ b/src/web/templates/admin/tournaments/tie_breaks_modal.html
@@ -372,11 +372,7 @@
                 hx-indicator="#please-wait"
             >
                 <i class="bi-plus-square-fill pe-1"></i>
-                {% if admin_tournament.tie_breaks %}
-                    {{ _('Add tie-break') }}
-                {% else %}
-                    {{ _('Choose my own tie-breaks') }}
-                {% endif %}
+                {{ _('Add tie-break') }}
             </button>
         </div>
     </div>

--- a/src/web/utils.py
+++ b/src/web/utils.py
@@ -313,6 +313,7 @@ class SelectOption:
     disabled: bool = False
     classes: str = ''
     search: str | None = None
+    subtitle: str | None = None
 
 
 class PKCEUtils:

--- a/tests/e2e/test_tournaments.py
+++ b/tests/e2e/test_tournaments.py
@@ -26,10 +26,8 @@ class TestTournamentFunctionality:
         expect(success_alert).to_be_visible()
         select_container = modal.locator('#tie-break-set').locator('..')
         select_container.locator('.select2-selection').click()
-        page.locator(
-            '.select2-results__option', has_text='SC Recommendation'
-        ).first.click()
-        TestUtils.button_by_text(modal, 'Apply set').click()
+        page.locator('.select2-results__option[id$="swiss-sc-recommendation"]').click()
+        TestUtils.button_by_text(modal, 'Apply').click()
 
         expect(modal.locator('.tie-break-row')).to_have_count(5)
         page.wait_for_timeout(500)


### PR DESCRIPTION
- Deleted Plugin source type (same as sytem from a user POV)
- added FIDE 2019 recommendations  
- added FRA youth recos 
- Display acronyms as subtitles in the select options  
- changed the source orders to something most likely to be picked by the user: 
  - Event tournaments
  - Custom
  - System
- Added all pairing systems to the custom sets modal
<img width="650" height="544" alt="image" src="https://github.com/user-attachments/assets/ca4f17d3-b94c-4c9d-969c-f52639cdad2e" />

<img width="731" height="520" alt="image" src="https://github.com/user-attachments/assets/1344714d-8ce5-4816-8a2d-bb4b60abf9de" />
