### PR TITLE
Improve SC.com duplicates management

### DIFF
--- a/src/data/event.py
+++ b/src/data/event.py
@@ -437,9 +437,12 @@ class Event:
                 tournament.add_player_to_tournament(stored_player, database)
         return stored_player.id
 
-    def delete_player(self, player_id: int):
+    def delete_player(self, player: Player):
         with EventDatabase(self.uniq_id, True) as database:
-            database.delete_stored_player(player_id)
+            database.delete_stored_player(player.id)
+        del self.players_by_id[player.id]
+        del player.single_tournament.tournament_players_by_id[player.id]
+        plugin_manager.hook_for_event(self, 'on_player_deleted')(player=player)
 
     def update_player(self, player: Player, new_stored_player: StoredPlayer):
         new_stored_player.id = player.id
@@ -472,21 +475,25 @@ class Event:
             return True
         return False
 
-    def check_player_unicity(
+    def get_player_duplicate(
         self,
         stored_player: StoredPlayer,
         tournament: Tournament,
         player_id: int | None = None,
-    ) -> bool:
+    ) -> Player | None:
         players = (
             tournament.tournament_players
             if self.allow_multi_tournament_players
             else self.players
         )
-        return all(
-            not self._are_player_duplicates(stored_player, player)
-            for player in players
-            if player.id != player_id
+        return next(
+            (
+                player
+                for player in players
+                if player.id != player_id
+                and self._are_player_duplicates(stored_player, player)
+            ),
+            None,
         )
 
     @cached_property

--- a/src/plugins/sce/sce.py
+++ b/src/plugins/sce/sce.py
@@ -218,6 +218,19 @@ class SCEPlugin(Plugin):
 
     @hookimpl
     def on_player_deleted(self, player: 'Player'):
+        for tournament in player.event.tournaments:
+            t_plugin_data = SCEUtils.get_tournament_plugin_data(tournament)
+            if not t_plugin_data.id:
+                continue
+            old_duplicates = t_plugin_data.duplicated_players_by_id
+            new_duplicates = {
+                sce_id: dup_player
+                for sce_id, dup_player in old_duplicates.items()
+                if dup_player.duplicate_player_id != player.id
+            }
+            if len(old_duplicates) != len(new_duplicates):
+                t_plugin_data.duplicated_players_by_id = new_duplicates
+                SCEUtils.update_tournament_plugin_data(tournament, t_plugin_data)
         sce_player_id = SCEUtils.get_player_plugin_data(player).id
         if not sce_player_id:
             return

--- a/src/plugins/sce/sce_admin_controller.py
+++ b/src/plugins/sce/sce_admin_controller.py
@@ -914,7 +914,7 @@ class SCEAdminController(BaseAdminController):
         player = web_context.get_player()
         if player.has_real_pairings:
             raise ClientException(f'Player [{player.full_name}] is not deletable')
-        event.delete_player(player.id)
+        event.delete_player(player)
         web_context = SCEWebContext(request, reload_event=True)
         return self._render_player_duplicate_modal(
             web_context, _('Player [{player}] deleted.').format(player=player.full_name)
@@ -945,6 +945,11 @@ class SCEAdminController(BaseAdminController):
                 SCESession(event).delete_sce_player(plugin_data.id, sce_player_id)
                 del plugin_data.duplicated_players_by_id[sce_player_id]
                 SCEUtils.update_tournament_plugin_data(tournament, plugin_data)
+                for player in event.players:
+                    p_plugin_data = SCEUtils.get_player_plugin_data(player)
+                    if p_plugin_data.duplicated_registration_id == sce_player_id:
+                        p_plugin_data.duplicated_registration_id = None
+                        SCEUtils.update_player_plugin_data(player, p_plugin_data)
                 message = _('Player [{player}] deleted.')
             except SharlyChessException as e:
                 logger.exception(e)

--- a/src/plugins/sce/sce_batch.py
+++ b/src/plugins/sce/sce_batch.py
@@ -1,0 +1,138 @@
+"""Batch op builder for Sharly-Chess.com registration sync.
+
+The events platform exposes
+`POST /api/v1/events/{eventId}/registrations/batch` which applies many
+registration ops (create/update/delete) atomically or best-effort. THP
+collects ops here while walking the local model, then flushes the whole
+batch in one HTTP round-trip per chunk.
+
+Each pending op carries the callbacks needed to apply its server response
+back to local plugin_data. The session does not need to know per-op
+semantics — it just dispatches by status.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Generator
+
+
+# Server cap is 200. Stay under it to leave headroom for retries / future
+# server-side schema growth.
+BATCH_CHUNK_SIZE = 100
+
+
+@dataclass
+class _PendingOp:
+    """An op queued for batch dispatch plus the callbacks that apply its result.
+
+    `on_success(result)` is invoked with the per-op result dict from the
+    server (`{index, status: 'ok', registration_id?, promoted?}`). Used to
+    set `plugin_data.id`, `plugin_data.last_sync_data`, etc.
+
+    `on_error(result)` is invoked with the per-op error dict
+    (`{index, status: 'error', error: {code, message}}`). Lets the caller
+    distinguish 409 (duplicate) from other failures.
+
+    `log_label` is a short identifier (typically the player's display name)
+    used when logging batch outcomes.
+    """
+
+    op_dict: dict[str, Any]
+    on_success: Callable[[dict[str, Any]], None]
+    on_error: Callable[[dict[str, Any]], None]
+    log_label: str
+
+
+@dataclass
+class SCEBatchBuilder:
+    """Collects registration ops to flush as a single batch request."""
+
+    pending: list[_PendingOp] = field(default_factory=list)
+
+    def __len__(self) -> int:
+        return len(self.pending)
+
+    def is_empty(self) -> bool:
+        return not self.pending
+
+    def add_create(
+        self,
+        tournament_id: str,
+        data: dict[str, Any],
+        on_success: Callable[[dict[str, Any]], None],
+        on_error: Callable[[dict[str, Any]], None],
+        log_label: str,
+    ) -> None:
+        op_data = {k: v for k, v in data.items() if k != 'tournament_id'}
+        self.pending.append(
+            _PendingOp(
+                op_dict={
+                    'op': 'create',
+                    'tournament_id': tournament_id,
+                    'data': op_data,
+                },
+                on_success=on_success,
+                on_error=on_error,
+                log_label=log_label,
+            )
+        )
+
+    def add_update(
+        self,
+        registration_id: str,
+        tournament_id: str,
+        data: dict[str, Any],
+        on_success: Callable[[dict[str, Any]], None],
+        on_error: Callable[[dict[str, Any]], None],
+        log_label: str,
+    ) -> None:
+        op_data = {k: v for k, v in data.items() if k != 'tournament_id'}
+        self.pending.append(
+            _PendingOp(
+                op_dict={
+                    'op': 'update',
+                    'registration_id': registration_id,
+                    'tournament_id': tournament_id,
+                    'data': op_data,
+                },
+                on_success=on_success,
+                on_error=on_error,
+                log_label=log_label,
+            )
+        )
+
+    def add_delete(
+        self,
+        registration_id: str,
+        on_success: Callable[[dict[str, Any]], None],
+        on_error: Callable[[dict[str, Any]], None],
+        log_label: str,
+    ) -> None:
+        self.pending.append(
+            _PendingOp(
+                op_dict={'op': 'delete', 'registration_id': registration_id},
+                on_success=on_success,
+                on_error=on_error,
+                log_label=log_label,
+            )
+        )
+
+    def chunks(
+        self, chunk_size: int = BATCH_CHUNK_SIZE
+    ) -> Generator[list[_PendingOp], None, None]:
+        for i in range(0, len(self.pending), chunk_size):
+            yield self.pending[i : i + chunk_size]
+
+    def apply_results(
+        self, ops: list[_PendingOp], results: list[dict[str, Any]]
+    ) -> None:
+        """Dispatch each per-op result to its on_success / on_error callback.
+
+        Aligned by position — the server returns one result per op in the
+        order they were sent (each result also carries `index`, which we
+        cross-check defensively).
+        """
+        for op, result in zip(ops, results):
+            if result.get('status') == 'ok':
+                op.on_success(result)
+            else:
+                op.on_error(result)

--- a/src/plugins/sce/sce_data.py
+++ b/src/plugins/sce/sce_data.py
@@ -34,6 +34,7 @@ class SCETokens:
 class SCEDuplicatedPlayer:
     last_name: str
     first_name: str | None
+    duplicate_player_id: int | None = None
 
     @property
     def full_name(self) -> str:
@@ -44,6 +45,7 @@ class SCEDuplicatedPlayer:
         return cls(
             last_name=value['last_name'],
             first_name=value['first_name'],
+            duplicate_player_id=value.get('duplicate_player_id'),
         )
 
     def to_stored_value(self) -> dict[str, Any]:
@@ -400,7 +402,7 @@ class SCEPlayerSyncData:
             rating_type=player.rating_type if player.rating else None,
             phone=player.phone,
             gender=player.gender,
-            comment=player.comment,
+            comment=player.comment or None,
             check_in=player.check_in,
         )
         plugin_manager.hook_for_event(
@@ -789,7 +791,12 @@ class SCEPlayerPluginData(PluginData):
     deleted_id: str | None = None
     last_sync_data: SCEPlayerSyncData | None = None
     conflict_sync_data: SCEPlayerSyncData | None = None
-    is_duplicated: bool = False
+    duplicated_registration_id: str | None = None
+    _legacy_is_duplicated: bool = False
+
+    @property
+    def is_duplicated(self) -> bool:
+        return self._legacy_is_duplicated or bool(self.duplicated_registration_id)
 
     @classmethod
     def from_stored_value(cls, stored_value: dict[str, Any]) -> Self:
@@ -808,7 +815,8 @@ class SCEPlayerPluginData(PluginData):
                 if stored_conflict_sync_data
                 else None
             ),
-            is_duplicated=stored_value.get('is_duplicated', False),
+            duplicated_registration_id=stored_value.get('duplicated_registration_id'),
+            _legacy_is_duplicated=stored_value.get('is_duplicated', False),
         )
 
     def to_stored_value(self) -> dict[str, Any]:
@@ -823,7 +831,8 @@ class SCEPlayerPluginData(PluginData):
                 if self.conflict_sync_data
                 else None
             ),
-            'is_duplicated': self.is_duplicated,
+            'duplicated_registration_id': self.duplicated_registration_id,
+            'is_duplicated': self._legacy_is_duplicated,
         }
 
     @classmethod

--- a/src/plugins/sce/sce_session.py
+++ b/src/plugins/sce/sce_session.py
@@ -1,7 +1,6 @@
 import copy
 import json
 from datetime import datetime, timedelta
-from enum import Enum, auto
 from functools import partial
 from json import JSONDecodeError
 from logging import Logger
@@ -36,6 +35,7 @@ from database.sqlite.event.event_store import (
 from plugins.fra_schools.fra_schools import FRASchoolsPlugin
 from plugins.manager import plugin_manager
 from plugins.sce import PLUGIN_NAME, SCE_BASE_URL, SCE_CLIENT_ID
+from plugins.sce.sce_batch import SCEBatchBuilder
 from plugins.sce.sce_event_status import (
     NotFoundSCEEventStatus,
     UnexpectedHttpSCEEventStatus,
@@ -94,10 +94,17 @@ REQUIRED_SCOPES = [
 ]
 
 
-class PlayerStatus(Enum):
-    SUCCESS = auto()
-    CONFLICT = auto()
-    DUPLICATE = auto()
+class _BatchSyncCounters:
+    """Mutable counter object updated by batch-op result callbacks.
+
+    `_plan_player_sync` registers callbacks against the builder; those
+    callbacks fire later when the batch response comes back and need
+    somewhere to record conflict / duplicate outcomes.
+    """
+
+    def __init__(self) -> None:
+        self.conflict_count: int = 0
+        self.duplicate_count: int = 0
 
 
 class SCESession(Session):
@@ -136,6 +143,10 @@ class SCESession(Session):
 
     def registration_url(self, tournament_id: str, registration_id: str) -> str:
         return self.tournament_url(tournament_id) + '/registrations/' + registration_id
+
+    @property
+    def registrations_batch_url(self) -> str:
+        return self.base_event_url + '/registrations/batch'
 
     def _log_sync_operation(self, message: str, is_info: bool = False):
         full_message = (
@@ -391,6 +402,40 @@ class SCESession(Session):
             )
         )
 
+    # -------------------------------------------------------------------------
+    # Batch
+    # -------------------------------------------------------------------------
+
+    def _send_batch_request(self, ops: list[dict[str, Any]]) -> Response:
+        return requests.post(
+            self.registrations_batch_url,
+            headers=self.api_headers,
+            json={'mode': 'best_effort', 'ops': ops},
+        )
+
+    def send_batch(self, builder: SCEBatchBuilder) -> None:
+        """Flush a batch builder to SC.com in chunks, invoking each op's
+        on_success / on_error callback with its server result.
+
+        Uses best_effort mode so that one bad row (e.g., duplicate FIDE ID)
+        does not roll back the rest of the sync.
+        """
+        for chunk in builder.chunks():
+            ops_payload = [op.op_dict for op in chunk]
+            response = self._run_with_token_validation(
+                partial(self._send_batch_request, ops=ops_payload),
+                skip_validation=True,
+            )
+            # 200 = all ok; 207 = mixed. Anything else is a server-level error.
+            if response.status_code not in (HTTP_200_OK, 207):
+                self.validate_api_response(response)
+            try:
+                results = response.json().get('results', [])
+            except JSONDecodeError:
+                self.validate_api_response(response)
+                return
+            builder.apply_results(chunk, results)
+
     def _create_local_player(
         self,
         sce_id: str,
@@ -448,29 +493,71 @@ class SCESession(Session):
             )
             self.event.move_player_to_tournament(player, new_tournament)
 
-    def _sync_player(
-        self, player: TournamentPlayer, sce_sync_data: SCEPlayerSyncData | None
-    ) -> PlayerStatus:
-        def log_operation(message: str):
+    def _plan_player_sync(
+        self,
+        player: TournamentPlayer,
+        sce_sync_data: SCEPlayerSyncData | None,
+        builder: SCEBatchBuilder,
+        counters: _BatchSyncCounters,
+    ) -> None:
+        """Emits create/update/delete ops into `builder` and registers
+        callbacks that mutate plugin_data + counters after the server
+        response arrives. Local-only effects (soft-delete, hard-delete,
+        update_local_player) run inline since they don't touch SC.com."""
+
+        def log_operation(message: str) -> None:
             log_name = player.last_name
             if player.first_name:
                 log_name += f' {player.first_name}'
             self._log_sync_operation(f'Player [{log_name}] - {message}')
 
+        log_name = player.last_name + (
+            f' {player.first_name}' if player.first_name else ''
+        )
+
         plugin_data = SCEUtils.get_player_plugin_data(player)
         sce_id = plugin_data.id
+
+        # Branch A: no sce_id → either create or stay idle for soft-deleted.
         if not sce_id:
-            if not plugin_data.deleted_id:
-                if self.create_sce_player(player):
-                    log_operation('Creation (SC.com)')
-                else:
+            if plugin_data.deleted_id:
+                return
+            sync_data = SCEPlayerSyncData.from_player(player)
+
+            def on_create_success(result: dict[str, Any]) -> None:
+                pd = SCEUtils.get_player_plugin_data(player)
+                pd.id = result.get('registration_id')
+                pd.last_sync_data = sync_data
+                SCEUtils.update_player_plugin_data(player, pd, write_stored_object=True)
+                log_operation('Creation (SC.com)')
+
+            def on_create_error(result: dict[str, Any]) -> None:
+                err = result.get('error') or {}
+                if err.get('code') == 'conflict':
+                    pd = SCEUtils.get_player_plugin_data(player)
+                    pd.is_duplicated = True
+                    SCEUtils.update_player_plugin_data(player, pd)
+                    counters.duplicate_count += 1
                     log_operation('SC.com creation failed, already exists in SC.com')
-                    return PlayerStatus.DUPLICATE
-            return PlayerStatus.SUCCESS
+                else:
+                    log_operation(
+                        f'SC.com creation failed: {err.get("message", "unknown error")}'
+                    )
+
+            builder.add_create(
+                tournament_id=sync_data.tournament_id,
+                data=sync_data.to_sce_data(),
+                on_success=on_create_success,
+                on_error=on_create_error,
+                log_label=log_name,
+            )
+            return
+
         tournament = player.tournament
+
+        # Branch B: remote-gone → local-only soft- or hard-delete.
         if not sce_sync_data:
             if player.has_real_pairings:
-                # Soft delete
                 plugin_data.deleted_id = sce_id
                 plugin_data.id = None
                 SCEUtils.update_player_plugin_data(player, plugin_data)
@@ -488,75 +575,124 @@ class SCESession(Session):
                 with EventDatabase(self.event.uniq_id, True) as database:
                     database.delete_stored_player(player.id)
                     log_operation('Deletion (local)')
-            return PlayerStatus.SUCCESS
+            return
 
-        has_conflict = False
-
+        # Branch C: both ends present → tournament force + 3-way merge.
         local_sync_data = SCEPlayerSyncData.from_player(player)
+
         if (
             local_sync_data.tournament_id != sce_sync_data.tournament_id
             and player.has_real_pairings
         ):
-            # Paired player + different tournaments --> Force to local tournament
-            sce_tournament_id = sce_sync_data.tournament_id
-            sce_sync_data.tournament_id = local_sync_data.tournament_id
-            self.update_sce_player(sce_sync_data, sce_tournament_id, sce_id)
-            log_operation(
-                f'Tournament forced to [{local_sync_data.tournament_id}] (SC.com)'
+            forced_sync_data = copy.deepcopy(sce_sync_data)
+            forced_sync_data.tournament_id = local_sync_data.tournament_id
+
+            def on_force_success(result: dict[str, Any]) -> None:
+                log_operation(
+                    f'Tournament forced to [{local_sync_data.tournament_id}] (SC.com)'
+                )
+
+            def on_force_error(result: dict[str, Any]) -> None:
+                err = result.get('error') or {}
+                log_operation(
+                    f'Tournament force failed: {err.get("message", "unknown error")}'
+                )
+
+            builder.add_update(
+                registration_id=sce_id,
+                tournament_id=local_sync_data.tournament_id,
+                data=forced_sync_data.to_sce_data(),
+                on_success=on_force_success,
+                on_error=on_force_error,
+                log_label=log_name,
             )
-        needs_saving = True
+            sce_sync_data.tournament_id = local_sync_data.tournament_id
+
         last_sync_data = plugin_data.last_sync_data
         local_check_in_updated = (
             last_sync_data
             and local_sync_data.check_in != sce_sync_data.check_in
             and local_sync_data.check_in == last_sync_data.check_in
         )
+
+        def finalise_save(new_last_sync_data: SCEPlayerSyncData) -> None:
+            pd = SCEUtils.get_player_plugin_data(player)
+            pd.last_sync_data = new_last_sync_data
+            SCEUtils.update_player_plugin_data(player, pd, write_stored_object=True)
+            if local_check_in_updated:
+                tid = getattr(pd.last_sync_data, 'tournament_id', None)
+                if tid:
+                    self.new_check_ins_tournament_sce_ids.add(tid)
+
         if local_sync_data == sce_sync_data:
-            # Already synced
-            if local_sync_data == plugin_data.last_sync_data:
-                needs_saving = False
-            else:
-                plugin_data.last_sync_data = local_sync_data
-        elif sce_sync_data == plugin_data.last_sync_data:
-            # Modified locally --> update SC.com value
-            self.update_sce_player(local_sync_data, sce_sync_data.tournament_id, sce_id)
-            plugin_data.last_sync_data = local_sync_data
-            log_operation('Local changes uploaded (SC.com)')
-        elif local_sync_data == plugin_data.last_sync_data:
-            # Modified on SC.com --> update locally
-            self.update_local_player(player, sce_sync_data)
-            plugin_data.last_sync_data = sce_sync_data
-            log_operation('SC.com changes imported (local)')
-        else:
-            # Modified on both ends
-            try:
-                assert plugin_data.last_sync_data is not None
-                merged_sync_data = local_sync_data.merge_with_other_sync_data(
-                    sce_sync_data, plugin_data.last_sync_data
-                )
-                # Mergeable --> Update locally and on SC.com
-                self.update_sce_player(
-                    merged_sync_data, sce_sync_data.tournament_id, sce_id
-                )
-                self.update_local_player(player, merged_sync_data)
-                plugin_data.last_sync_data = merged_sync_data
-                log_operation('Dual changes merged (SC.com + local)')
-            except SharlyChessException as e:
-                # Not mergeable --> Create a conflict
-                plugin_data.conflict_sync_data = sce_sync_data
-                has_conflict = True
+            if local_sync_data != last_sync_data:
+                finalise_save(local_sync_data)
+            return
+
+        if sce_sync_data == last_sync_data:
+            # Modified locally → push local to SC.com
+            def on_local_push_success(result: dict[str, Any]) -> None:
+                finalise_save(local_sync_data)
+                log_operation('Local changes uploaded (SC.com)')
+
+            def on_local_push_error(result: dict[str, Any]) -> None:
+                err = result.get('error') or {}
                 log_operation(
-                    f'Not mergeable dual changes, conflict created (details: {e})'
+                    f'SC.com update failed: {err.get("message", "unknown error")}'
                 )
-        if needs_saving:
+
+            builder.add_update(
+                registration_id=sce_id,
+                tournament_id=local_sync_data.tournament_id,
+                data=local_sync_data.to_sce_data(),
+                on_success=on_local_push_success,
+                on_error=on_local_push_error,
+                log_label=log_name,
+            )
+            return
+
+        if local_sync_data == last_sync_data:
+            # Modified on SC.com → pull to local (no HTTP needed)
+            self.update_local_player(player, sce_sync_data)
+            finalise_save(sce_sync_data)
+            log_operation('SC.com changes imported (local)')
+            return
+
+        # Modified on both ends.
+        try:
+            assert last_sync_data is not None
+            merged_sync_data = local_sync_data.merge_with_other_sync_data(
+                sce_sync_data, last_sync_data
+            )
+
+            def on_merge_success(result: dict[str, Any]) -> None:
+                self.update_local_player(player, merged_sync_data)
+                finalise_save(merged_sync_data)
+                log_operation('Dual changes merged (SC.com + local)')
+
+            def on_merge_error(result: dict[str, Any]) -> None:
+                err = result.get('error') or {}
+                log_operation(
+                    f'Dual-change merge update failed: {err.get("message", "unknown error")}'
+                )
+
+            builder.add_update(
+                registration_id=sce_id,
+                tournament_id=merged_sync_data.tournament_id,
+                data=merged_sync_data.to_sce_data(),
+                on_success=on_merge_success,
+                on_error=on_merge_error,
+                log_label=log_name,
+            )
+        except SharlyChessException as e:
+            plugin_data.conflict_sync_data = sce_sync_data
             SCEUtils.update_player_plugin_data(
                 player, plugin_data, write_stored_object=True
             )
-            if local_check_in_updated:
-                self.new_check_ins_tournament_sce_ids.add(
-                    getattr(plugin_data.last_sync_data, 'tournament_id')
-                )
-        return PlayerStatus.CONFLICT if has_conflict else PlayerStatus.SUCCESS
+            counters.conflict_count += 1
+            log_operation(
+                f'Not mergeable dual changes, conflict created (details: {e})'
+            )
 
     # -------------------------------------------------------------------------
     # Tournament
@@ -952,6 +1088,8 @@ class SCESession(Session):
         """Synchronize the event with its SC.com equivalent.
         Raises a SharlyChessException if it fails."""
         self._log_sync_operation('Sync started', is_info=True)
+        builder = SCEBatchBuilder()
+        batch_counters = _BatchSyncCounters()
         data = self._get_event_data(with_active_registrations=True)
         tournament_data_by_id = {
             tournament_data['id']: tournament_data
@@ -1003,14 +1141,48 @@ class SCESession(Session):
                     soft_deleted_players_by_id[plugin_data.deleted_id] = player
 
         event_plugin_data = SCEUtils.get_event_plugin_data(self.event)
+        # Track SC.com deletes that succeeded so failed ones stay queued for retry.
+        succeeded_delete_ids: set[str] = set()
         for sce_player_id, sce_sync_data in sce_player_sync_data_by_id.items():
             if sce_player_id in local_sce_player_ids:
                 continue
             message = ''
             if sce_player_id in event_plugin_data.deleted_player_ids:
                 # Delete locally --> delete on SC.com
-                sce_tournament_id = sce_sync_data.tournament_id
-                self.delete_sce_player(sce_tournament_id, sce_player_id)
+                label = sce_sync_data.last_name + (
+                    f' {sce_sync_data.first_name}' if sce_sync_data.first_name else ''
+                )
+
+                def on_delete_success(
+                    _r: dict[str, Any], pid: str = sce_player_id
+                ) -> None:
+                    succeeded_delete_ids.add(pid)
+
+                def on_delete_error(
+                    r: dict[str, Any],
+                    pid: str = sce_player_id,
+                    lbl: str = label,
+                ) -> None:
+                    err = r.get('error') or {}
+                    # 404 = already gone on SC.com → treat as success so we
+                    # don't keep retrying forever.
+                    if err.get('code') == 'not_found':
+                        succeeded_delete_ids.add(pid)
+                        self._log_sync_operation(
+                            f'Player [{lbl}] - Already deleted on SC.com (treated as success)'
+                        )
+                    else:
+                        self._log_sync_operation(
+                            f'Player [{lbl}] - SC.com delete failed: '
+                            f'{err.get("message", "unknown error")} (will retry next sync)'
+                        )
+
+                builder.add_delete(
+                    registration_id=sce_player_id,
+                    on_success=on_delete_success,
+                    on_error=on_delete_error,
+                    log_label=label,
+                )
                 message = 'Deletion (SC.com)'
             else:
                 # New player --> create locally
@@ -1047,21 +1219,26 @@ class SCESession(Session):
             sce_sync_data.mail = None
 
         for tournament in sce_tournaments:
-            players = tournament.tournament_players
+            # Snapshot the view: planning may move/delete players in the
+            # underlying tournament_players_by_id dict.
+            players = list(tournament.tournament_players)
             for player in players:
                 player_sce_id = SCEUtils.get_player_plugin_data(player).id
-                status = self._sync_player(
-                    player, sce_player_sync_data_by_id.get(player_sce_id or '')
-                )
-                if status == PlayerStatus.CONFLICT:
-                    conflict_count += 1
-                elif status == PlayerStatus.DUPLICATE:
-                    duplicate_count += 1
+                sync_data = sce_player_sync_data_by_id.get(player_sce_id or '')
+                self._plan_player_sync(player, sync_data, builder, batch_counters)
+        if not builder.is_empty():
+            self.send_batch(builder)
+        conflict_count += batch_counters.conflict_count
+        duplicate_count += batch_counters.duplicate_count
         for sce_id in self.new_check_ins_tournament_sce_ids:
             tournament = SCEUtils.get_tournament_by_sce_id(self.event, sce_id)
             PlayerAdminController.publish_new_checkin(channels_plugin, tournament)
 
-        event_plugin_data.deleted_player_ids = []
+        event_plugin_data.deleted_player_ids = [
+            pid
+            for pid in event_plugin_data.deleted_player_ids
+            if pid not in succeeded_delete_ids
+        ]
         event_plugin_data.last_sync_at = datetime.now()
         SCEUtils.update_event_plugin_data(self.event, event_plugin_data)
         message = 'Sync completed'

--- a/src/plugins/sce/sce_session.py
+++ b/src/plugins/sce/sce_session.py
@@ -495,6 +495,7 @@ class SCESession(Session):
                 pd = SCEUtils.get_player_plugin_data(player)
                 pd.id = result.get('registration_id')
                 pd.last_sync_data = sync_data
+                pd.is_duplicated = False
                 SCEUtils.update_player_plugin_data(player, pd, write_stored_object=True)
                 log_operation('Creation (SC.com)')
 

--- a/src/plugins/sce/sce_session.py
+++ b/src/plugins/sce/sce_session.py
@@ -14,7 +14,6 @@ from litestar.status_codes import (
     HTTP_403_FORBIDDEN,
     HTTP_200_OK,
     HTTP_404_NOT_FOUND,
-    HTTP_409_CONFLICT,
 )
 from requests import Session, HTTPError, Response
 
@@ -323,38 +322,6 @@ class SCESession(Session):
     # -------------------------------------------------------------------------
     # Player
     # -------------------------------------------------------------------------
-
-    def _create_registration_request(
-        self,
-        data: SCEPlayerSyncData,
-    ):
-        payload = data.to_sce_data()
-        return requests.post(
-            self.tournament_url(data.tournament_id) + '/registrations',
-            headers=self.api_headers,
-            json=payload,
-        )
-
-    def create_sce_player(self, player: TournamentPlayer) -> bool:
-        """Create a player on SC.com, returns False if it already exists, True if it succeeds."""
-        plugin_data = SCEUtils.get_player_plugin_data(player)
-        sync_data = SCEPlayerSyncData.from_player(player)
-        response = self._run_with_token_validation(
-            partial(self._create_registration_request, data=sync_data),
-            skip_validation=True,
-        )
-        try:
-            self.validate_api_response(response)
-        except SharlyChessException as e:
-            if response.status_code != HTTP_409_CONFLICT:
-                raise e
-            plugin_data.is_duplicated = True
-            SCEUtils.update_player_plugin_data(player, plugin_data)
-            return False
-        plugin_data.id = response.json()['data']['id']
-        plugin_data.last_sync_data = sync_data
-        SCEUtils.update_player_plugin_data(player, plugin_data)
-        return True
 
     def _update_registration_request(
         self,
@@ -760,17 +727,16 @@ class SCESession(Session):
         event_plugin_data = SCEUtils.get_event_plugin_data(event)
         event_plugin_data.tournament_names_by_id[sce_id] = tournament.name
         SCEUtils.update_event_plugin_data(event, event_plugin_data)
-        duplicate_count = 0
+        builder = SCEBatchBuilder()
+        counters = _BatchSyncCounters()
         for player in tournament.tournament_players:
-            if self.create_sce_player(player):
-                logger.debug(log_prefix + 'Player [%s] created', player.full_name)
-            else:
-                duplicate_count += 1
-                logger.error(
-                    log_prefix + 'Player [%s] already exists, skipped',
-                    player.full_name,
-                )
-        return duplicate_count
+            self._plan_player_sync(
+                player,
+                sce_sync_data=None,
+                builder=builder,
+                counters=counters,
+            )
+        return counters.duplicate_count
 
     def _update_tournament_request(
         self, data: SCETournamentSyncData, sce_tournament_id: str

--- a/src/plugins/sce/sce_session.py
+++ b/src/plugins/sce/sce_session.py
@@ -156,6 +156,12 @@ class SCESession(Session):
         else:
             logger.debug(full_message)
 
+    def _log_player_sync_operation(self, player: TournamentPlayer, message: str):
+        log_name = player.last_name
+        if player.first_name:
+            log_name += f' {player.first_name}'
+        self._log_sync_operation(f'Player [{log_name}] - {message}')
+
     # -------------------------------------------------------------------------
     # Auth
     # -------------------------------------------------------------------------
@@ -369,6 +375,28 @@ class SCESession(Session):
             )
         )
 
+    def _delete_local_player(self, player: TournamentPlayer):
+        tournament = player.tournament
+        plugin_data = SCEUtils.get_player_plugin_data(player)
+        sce_id = plugin_data.id
+        plugin_data.id = None
+        if player.has_real_pairings:
+            plugin_data.deleted_id = sce_id
+            SCEUtils.update_player_plugin_data(player, plugin_data)
+            new_byes = {
+                round_: Result.ZERO_POINT_BYE
+                for round_ in range(
+                    tournament.current_round or 1,
+                    tournament.rounds + 1,
+                )
+                if player.pairings[round_].unpaired
+            }
+            tournament.set_player_byes(player.single_tournament_player, new_byes)
+            self._log_player_sync_operation(player, 'Soft-deletion (local)')
+        else:
+            self.event.delete_player(player)
+            self._log_player_sync_operation(player, 'Deletion (local)')
+
     # -------------------------------------------------------------------------
     # Batch
     # -------------------------------------------------------------------------
@@ -413,6 +441,9 @@ class SCESession(Session):
         """Create a local player from SC.com data.
         Return False if it already exists, True if it succeeds."""
 
+        def log_operation(message):
+            self._log_player_data_operation(sync_data, message)
+
         sce_tournament_id = SCEUtils.get_tournament_plugin_data(tournament).id
         assert sce_tournament_id is not None
         stored_player = StoredPlayer(
@@ -424,26 +455,44 @@ class SCESession(Session):
             },
         )
         sync_data.augment_stored_player(stored_player, tournament)
-        if not self.event.check_player_unicity(stored_player, tournament):
-            plugin_data = SCEUtils.get_tournament_plugin_data(tournament)
-            plugin_data.duplicated_players_by_id[sce_id] = SCEDuplicatedPlayer(
+        duplicate_player = self.event.get_player_duplicate(stored_player, tournament)
+        if not duplicate_player:
+            stored_player.id = database.add_stored_player(stored_player)
+            database.add_stored_tournament_player(
+                StoredTournamentPlayer(
+                    player_id=stored_player.id,
+                    tournament_id=tournament.id,
+                )
+            )
+            log_operation('Creation (local)')
+            return True
+        duplicate_tournament_player = duplicate_player.single_tournament_player
+        local_sync_data = SCEPlayerSyncData.from_player(duplicate_tournament_player)
+        sce_sync_data = copy.copy(sync_data)
+        sce_sync_data.mail = None
+        p_plugin_data = SCEUtils.get_player_plugin_data(duplicate_tournament_player)
+        if not p_plugin_data.id and local_sync_data == sce_sync_data:
+            # Match players if they are the same (handles same creation on both sides)
+            p_plugin_data.id = sce_id
+            p_plugin_data.deleted_id = None
+            p_plugin_data.last_sync_data = sce_sync_data
+            SCEUtils.update_player_plugin_data_from_database(
+                duplicate_tournament_player, p_plugin_data, database
+            )
+            log_operation('Already existed on both ends, connection created')
+            return True
+        else:
+            t_plugin_data = SCEUtils.get_tournament_plugin_data(tournament)
+            t_plugin_data.duplicated_players_by_id[sce_id] = SCEDuplicatedPlayer(
                 last_name=stored_player.last_name,
                 first_name=stored_player.first_name,
+                duplicate_player_id=duplicate_player.id,
             )
-            database.execute(
-                'UPDATE tournament SET plugin_data = '
-                "json_set(plugin_data,'$.sce', json(?)) WHERE id = ?",
-                (json.dumps(plugin_data.to_stored_value()), tournament.id),
+            SCEUtils.update_tournament_plugin_data_from_database(
+                tournament, t_plugin_data, database
             )
-            return False
-        stored_player.id = database.add_stored_player(stored_player)
-        database.add_stored_tournament_player(
-            StoredTournamentPlayer(
-                player_id=stored_player.id,
-                tournament_id=tournament.id,
-            )
-        )
-        return True
+            log_operation('Local creation failed, already exists locally')
+        return False
 
     def update_local_player(self, player: TournamentPlayer, data: SCEPlayerSyncData):
         data.augment_stored_player(
@@ -473,10 +522,7 @@ class SCESession(Session):
         update_local_player) run inline since they don't touch SC.com."""
 
         def log_operation(message: str) -> None:
-            log_name = player.last_name
-            if player.first_name:
-                log_name += f' {player.first_name}'
-            self._log_sync_operation(f'Player [{log_name}] - {message}')
+            self._log_player_sync_operation(player, message)
 
         log_name = player.last_name + (
             f' {player.first_name}' if player.first_name else ''
@@ -495,7 +541,7 @@ class SCESession(Session):
                 pd = SCEUtils.get_player_plugin_data(player)
                 pd.id = result.get('registration_id')
                 pd.last_sync_data = sync_data
-                pd.is_duplicated = False
+                pd.duplicated_registration_id = None
                 SCEUtils.update_player_plugin_data(player, pd, write_stored_object=True)
                 log_operation('Creation (SC.com)')
 
@@ -503,7 +549,9 @@ class SCESession(Session):
                 err = result.get('error') or {}
                 if err.get('code') == 'conflict':
                     pd = SCEUtils.get_player_plugin_data(player)
-                    pd.is_duplicated = True
+                    pd.duplicated_registration_id = (
+                        err.get('existing_registration_id') or 'missing_id'
+                    )
                     SCEUtils.update_player_plugin_data(player, pd)
                     counters.duplicate_count += 1
                     log_operation('SC.com creation failed, already exists in SC.com')
@@ -521,28 +569,9 @@ class SCESession(Session):
             )
             return
 
-        tournament = player.tournament
-
         # Branch B: remote-gone → local-only soft- or hard-delete.
         if not sce_sync_data:
-            if player.has_real_pairings:
-                plugin_data.deleted_id = sce_id
-                plugin_data.id = None
-                SCEUtils.update_player_plugin_data(player, plugin_data)
-                new_byes = {
-                    round_: Result.ZERO_POINT_BYE
-                    for round_ in range(
-                        tournament.current_round or 1,
-                        tournament.rounds + 1,
-                    )
-                    if player.pairings[round_].unpaired
-                }
-                tournament.set_player_byes(player.single_tournament_player, new_byes)
-                log_operation('Soft-deletion (local)')
-            else:
-                with EventDatabase(self.event.uniq_id, True) as database:
-                    database.delete_stored_player(player.id)
-                    log_operation('Deletion (local)')
+            self._delete_local_player(player)
             return
 
         # Branch C: both ends present → tournament force + 3-way merge.
@@ -1095,6 +1124,14 @@ class SCESession(Session):
         soft_deleted_players_by_id: dict[str, TournamentPlayer] = {}
         duplicate_count = 0
 
+        # Deleted on SC.com --> delete locally
+        # Execute first to avoid duplicates on SC.com creations
+        for tournament in sce_tournaments:
+            for player in list(tournament.tournament_players):
+                p_sce_id = SCEUtils.get_player_plugin_data(player).id
+                if p_sce_id and p_sce_id not in sce_player_sync_data_by_id:
+                    self._delete_local_player(player)
+
         for tournament in sce_tournaments:
             t_plugin_data = SCEUtils.get_tournament_plugin_data(tournament)
             if t_plugin_data.duplicated_players_by_id:
@@ -1113,9 +1150,8 @@ class SCESession(Session):
         for sce_player_id, sce_sync_data in sce_player_sync_data_by_id.items():
             if sce_player_id in local_sce_player_ids:
                 continue
-            message = ''
             if sce_player_id in event_plugin_data.deleted_player_ids:
-                # Delete locally --> delete on SC.com
+                # Deleted locally --> delete on SC.com
                 label = sce_sync_data.last_name + (
                     f' {sce_sync_data.first_name}' if sce_sync_data.first_name else ''
                 )
@@ -1150,24 +1186,20 @@ class SCESession(Session):
                     on_error=on_delete_error,
                     log_label=label,
                 )
-                message = 'Deletion (SC.com)'
+                self._log_player_data_operation(sce_sync_data, 'Deletion (SC.com)')
             else:
                 # New player --> create locally
                 tournament = SCEUtils.get_tournament_by_sce_id(
                     self.event, sce_sync_data.tournament_id
                 )
                 with EventDatabase(self.event.uniq_id, True) as database:
-                    if self._create_local_player(
+                    if not self._create_local_player(
                         sce_player_id,
                         sce_sync_data,
                         tournament,
                         database,
                     ):
-                        message = 'Creation (local)'
-                    else:
                         duplicate_count += 1
-                        message = 'Local creation failed, already exists locally'
-            self._log_player_data_operation(sce_sync_data, message)
 
             if sce_player_id in soft_deleted_players_by_id:
                 player = soft_deleted_players_by_id[sce_player_id]

--- a/src/plugins/sce/utils.py
+++ b/src/plugins/sce/utils.py
@@ -86,8 +86,9 @@ class SCEUtils:
                         (json.dumps(plugin_data.to_stored_value()),),
                     )
 
-    @staticmethod
+    @classmethod
     def update_tournament_plugin_data(
+        cls,
         tournament: Tournament,
         plugin_data: SCETournamentPluginData,
         write: bool = True,
@@ -102,14 +103,26 @@ class SCEUtils:
                 if write_stored_object:
                     database.update_stored_tournament(tournament.stored_tournament)
                 else:
-                    database.execute(
-                        'UPDATE tournament SET plugin_data = '
-                        "json_set(plugin_data,'$.sce', json(?)) WHERE id = ?",
-                        (json.dumps(plugin_data.to_stored_value()), tournament.id),
+                    cls.update_tournament_plugin_data_from_database(
+                        tournament, plugin_data, database
                     )
 
-    @staticmethod
+    @classmethod
+    def update_tournament_plugin_data_from_database(
+        cls,
+        tournament: Tournament,
+        plugin_data: SCETournamentPluginData,
+        database: EventDatabase,
+    ):
+        database.execute(
+            'UPDATE tournament SET plugin_data = '
+            "json_set(plugin_data,'$.sce', json(?)) WHERE id = ?",
+            (json.dumps(plugin_data.to_stored_value()), tournament.id),
+        )
+
+    @classmethod
     def update_player_plugin_data(
+        cls,
         player: Player,
         plugin_data: SCEPlayerPluginData,
         write: bool = True,
@@ -122,11 +135,22 @@ class SCEUtils:
                 if write_stored_object:
                     database.update_stored_player(player.stored_player)
                 else:
-                    database.execute(
-                        'UPDATE player SET plugin_data = '
-                        "json_set(plugin_data,'$.sce', json(?)) WHERE id = ?",
-                        (json.dumps(plugin_data.to_stored_value()), player.id),
+                    cls.update_player_plugin_data_from_database(
+                        player, plugin_data, database
                     )
+
+    @classmethod
+    def update_player_plugin_data_from_database(
+        cls,
+        player: Player,
+        plugin_data: SCEPlayerPluginData,
+        database: EventDatabase,
+    ):
+        database.execute(
+            'UPDATE player SET plugin_data = '
+            "json_set(plugin_data,'$.sce', json(?)) WHERE id = ?",
+            (json.dumps(plugin_data.to_stored_value()), player.id),
+        )
 
     @classmethod
     def get_event_sce_tournaments(cls, event: Event) -> list[Tournament]:

--- a/src/web/controllers/admin/player_admin_controller.py
+++ b/src/web/controllers/admin/player_admin_controller.py
@@ -966,7 +966,7 @@ class PlayerAdminController(BaseEventAdminController):
             return None, errors
         tournament = event.tournaments_by_id[int(data['tournament_id'])]
         stored_player = cls._stored_player_from_data(data, tournament, player)
-        if not event.check_player_unicity(
+        if event.get_player_duplicate(
             stored_player, tournament, player.id if player else None
         ):
             errors['alert'] = (
@@ -1304,9 +1304,8 @@ class PlayerAdminController(BaseEventAdminController):
                 ),
             )
         else:
-            event.delete_player(player.id)
+            event.delete_player(player)
             deleted_player_id = player.id
-            plugin_manager.hook_for_event(event, 'on_player_deleted')(player=player)
         return self._render_player_table_row(
             web_context, deleted_player_id=deleted_player_id
         )

--- a/tests/integration/test_sce_sync_event.py
+++ b/tests/integration/test_sce_sync_event.py
@@ -1,0 +1,380 @@
+"""Integration tests for `SCESession.sync_event`.
+
+Real Event/Tournament/Player in a SQLite DB under `tests/tmp/`. SC.com
+HTTP boundary is mocked at the `requests.post` / `_get_event_data` level
+so we exercise the full sync_event orchestration: tournament-data loop,
+remote-only delete step, per-player planning, batch flush, and the
+event-level `deleted_player_ids` retry filter.
+"""
+
+import json
+from datetime import datetime, timedelta
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+import pytest
+
+from data.loader import EventLoader
+from database.sqlite.event.event_database import EventDatabase
+from database.sqlite.event.event_store import (
+    StoredPlayer,
+    StoredTournamentPlayer,
+)
+from plugins.sce import PLUGIN_NAME
+from plugins.sce.sce_data import (
+    SCEEventPluginData,
+    SCEPlayerPluginData,
+    SCETokens,
+    SCETournamentPluginData,
+)
+from plugins.sce.sce_session import SCESession
+from plugins.sce.utils import SCEUtils
+
+from tests.test_config import TestUtils
+
+
+SCE_EVENT_ID = 'SCE-EVT'
+SCE_TOURNAMENT_ID = 'SCE-T1'
+EVENT_UNIQ_ID = 'test-sce-sync-event'
+
+
+def _install_event_plugin_data(
+    uniq_id: str,
+    deleted_player_ids: list[str] | None = None,
+) -> None:
+    """Stamp SCEEventPluginData (with tokens + id) onto the StoredEvent."""
+    epd = SCEEventPluginData(
+        id=SCE_EVENT_ID,
+        slug='test-event',
+        organiser_slug='test-org',
+        tokens=SCETokens(
+            access_token='TEST-ACCESS',
+            refresh_token='TEST-REFRESH',
+            expires_at=datetime.now() + timedelta(hours=1),
+        ),
+        deleted_player_ids=deleted_player_ids or [],
+    )
+    with EventDatabase(uniq_id, write=True) as db:
+        stored = db.load_stored_event()
+        stored.plugin_data[PLUGIN_NAME] = epd.to_stored_value()
+        db.update_stored_event(stored)
+
+
+def _install_tournament_plugin_data(uniq_id: str, tournament_name: str) -> int:
+    """Stamp SCETournamentPluginData onto the tournament and return its id."""
+    tpd = SCETournamentPluginData(id=SCE_TOURNAMENT_ID)
+    with EventDatabase(uniq_id, write=True) as db:
+        stored_tournaments = db.load_stored_tournaments()
+        stored_t = next(t for t in stored_tournaments if t.name == tournament_name)
+        stored_t.plugin_data[PLUGIN_NAME] = tpd.to_stored_value()
+        # Re-issue the update via raw execute since we just modify plugin_data.
+        db.execute(
+            'UPDATE `tournament` SET `plugin_data` = ? WHERE `id` = ?',
+            (json.dumps(stored_t.plugin_data), stored_t.id),
+        )
+        return stored_t.id
+
+
+def _add_local_player_with_sce_id(
+    uniq_id: str,
+    tournament_id: int,
+    sce_player_id: str,
+    last_name: str = 'Local',
+    first_name: str = 'Player',
+) -> int:
+    """Insert a StoredPlayer + StoredTournamentPlayer carrying an SCE
+    plugin_data.id so the player is treated as synced from SC.com's side."""
+    ppd = SCEPlayerPluginData(id=sce_player_id)
+    with EventDatabase(uniq_id, write=True) as db:
+        stored_player = StoredPlayer(
+            id=None,
+            last_name=last_name,
+            first_name=first_name,
+            federation='FRA',
+            plugin_data={PLUGIN_NAME: ppd.to_stored_value()},
+        )
+        player_id = db.add_stored_player(stored_player)
+        db.add_stored_tournament_player(
+            StoredTournamentPlayer(player_id=player_id, tournament_id=tournament_id)
+        )
+        return player_id
+
+
+def _canned_registration(sce_player_id: str) -> dict:
+    """Shape of one registration in the SC.com `data['tournaments']`
+    payload. Includes all keys the FFE + FRA-schools augment hooks read
+    so they don't KeyError on canned data."""
+    return {
+        'id': sce_player_id,
+        'last_name': 'Local',
+        'first_name': 'Player',
+        'year_of_birth': 1990,
+        'fide_id': None,
+        'national_id': None,
+        'federation': 'FRA',
+        'title': None,
+        'club': None,
+        'rating': None,
+        'rating_type': None,
+        'phone_number': None,
+        'comment': None,
+        'gender': None,
+        'checked_in': False,
+        # FFE plugin
+        'ffe_licence_type': None,
+        'ffe_league': None,
+        # FRA-schools plugin
+        'fra_school': None,
+    }
+
+
+def _canned_event_data(sce_player_id: str | None = None) -> dict:
+    """Mimic the shape returned by `SCESession._get_event_data`."""
+    registrations: list[dict] = []
+    if sce_player_id:
+        registrations.append(_canned_registration(sce_player_id))
+    return {
+        'id': SCE_EVENT_ID,
+        'slug': 'test-event',
+        'organiser_slug': 'test-org',
+        'status': 'open',
+        'age_categories': [],
+        'age_category_base_date': None,
+        'age_category_change_month': 1,
+        'allow_multiple_tournament_registrations': True,
+        'tournaments': [
+            {
+                'id': SCE_TOURNAMENT_ID,
+                'name': 'T1',
+                'registrations': registrations,
+            }
+        ],
+    }
+
+
+@pytest.mark.integration
+class TestSyncEventDeleteRetry(TestCase):
+    """Failed batch deletes must keep their entry in
+    `deleted_player_ids` so the next sync retries. Successful deletes
+    (or 404 = already-gone) must clear the entry."""
+
+    def setUp(self):
+        super().setUp()
+        TestUtils.create_event(EVENT_UNIQ_ID)
+        TestUtils.create_tournament(EVENT_UNIQ_ID, 'T1')
+        _install_tournament_plugin_data(EVENT_UNIQ_ID, 'T1')
+
+    def tearDown(self):
+        TestUtils.delete_event(EVENT_UNIQ_ID)
+        super().tearDown()
+
+    def _build_session_with_canned_batch(
+        self, sce_player_id: str, batch_response: dict
+    ) -> SCESession:
+        """Load the event, install canned plugin_data, and wire mocks so
+        sync_event sees `sce_player_id` as remote-only and to-be-deleted."""
+        _install_event_plugin_data(EVENT_UNIQ_ID, deleted_player_ids=[sce_player_id])
+        event = EventLoader().load_event(EVENT_UNIQ_ID)
+        session = SCESession(event)
+
+        # Skip tournament sync — focus on player flow.
+        session._sync_tournament = MagicMock(return_value=True)  # type: ignore[method-assign]
+        session._get_event_data = MagicMock(  # type: ignore[method-assign]
+            return_value=_canned_event_data(sce_player_id=sce_player_id)
+        )
+
+        # Stub the HTTP send path: token validation just calls the request
+        # function directly with our canned response.
+        canned_resp = MagicMock()
+        canned_resp.status_code = 207
+        canned_resp.json.return_value = batch_response
+        session._run_with_token_validation = MagicMock(  # type: ignore[method-assign]
+            return_value=canned_resp
+        )
+        # PublishNewCheckin would call into web channels; stub it out.
+        session.new_check_ins_tournament_sce_ids = set()
+        return session
+
+    def _reload_event_plugin_data(self) -> SCEEventPluginData:
+        event = EventLoader().load_event(EVENT_UNIQ_ID)
+        return SCEUtils.get_event_plugin_data(event)
+
+    def test_failed_delete_preserves_id_in_deleted_player_ids(self):
+        session = self._build_session_with_canned_batch(
+            sce_player_id='SCE-DEAD',
+            batch_response={
+                'results': [
+                    {
+                        'index': 0,
+                        'status': 'error',
+                        'error': {'code': 'internal_error', 'message': 'boom'},
+                    }
+                ]
+            },
+        )
+
+        session.sync_event()
+
+        epd = self._reload_event_plugin_data()
+        self.assertIn(
+            'SCE-DEAD',
+            epd.deleted_player_ids,
+            'Failed SC.com delete must be retried on next sync',
+        )
+
+    def test_404_delete_treated_as_success_and_cleared(self):
+        session = self._build_session_with_canned_batch(
+            sce_player_id='SCE-GHOST',
+            batch_response={
+                'results': [
+                    {
+                        'index': 0,
+                        'status': 'error',
+                        'error': {'code': 'not_found', 'message': 'gone'},
+                    }
+                ]
+            },
+        )
+
+        session.sync_event()
+
+        epd = self._reload_event_plugin_data()
+        self.assertNotIn(
+            'SCE-GHOST',
+            epd.deleted_player_ids,
+            'Already-deleted-on-SC.com (404) should not be retried',
+        )
+
+    def test_successful_delete_clears_from_deleted_player_ids(self):
+        session = self._build_session_with_canned_batch(
+            sce_player_id='SCE-OK',
+            batch_response={'results': [{'index': 0, 'status': 'ok'}]},
+        )
+
+        session.sync_event()
+
+        epd = self._reload_event_plugin_data()
+        self.assertNotIn('SCE-OK', epd.deleted_player_ids)
+
+
+MOVE_EVENT_UNIQ_ID = 'test-sce-sync-event-move'
+
+
+@pytest.mark.integration
+class TestSyncEventLocalMove(TestCase):
+    """Local-only move (player moved between local tournaments) should
+    push an UPDATE op with op-level `tournament_id` = target so the
+    server triggers the move."""
+
+    def setUp(self):
+        super().setUp()
+        TestUtils.create_event(MOVE_EVENT_UNIQ_ID)
+
+    def tearDown(self):
+        TestUtils.delete_event(MOVE_EVENT_UNIQ_ID)
+        super().tearDown()
+
+    def test_batch_payload_carries_target_tournament_id(self):
+        from plugins.sce.sce_data import SCEPlayerSyncData
+        from utils.enum import PlayerGender
+
+        # Two tournaments: SCE-T1 (source), SCE-T2 (target).
+        TestUtils.create_tournament(MOVE_EVENT_UNIQ_ID, 'T1')
+        TestUtils.create_tournament(MOVE_EVENT_UNIQ_ID, 'T2')
+
+        # Tag tournaments with their SCE IDs.
+        with EventDatabase(MOVE_EVENT_UNIQ_ID, write=True) as db:
+            stored_ts = db.load_stored_tournaments()
+            for stored_t in stored_ts:
+                sce_tid = 'SCE-T1' if stored_t.name == 'T1' else 'SCE-T2'
+                stored_t.plugin_data[PLUGIN_NAME] = SCETournamentPluginData(
+                    id=sce_tid
+                ).to_stored_value()
+                db.execute(
+                    'UPDATE `tournament` SET `plugin_data` = ? WHERE `id` = ?',
+                    (json.dumps(stored_t.plugin_data), stored_t.id),
+                )
+            t2_id = next(t.id for t in stored_ts if t.name == 'T2')
+
+        _install_event_plugin_data(MOVE_EVENT_UNIQ_ID)
+
+        # Player currently in T2 locally (already "moved"), known to SC as
+        # being in T1 still. last_sync_data captures the pre-move state.
+        last_sync = SCEPlayerSyncData(
+            tournament_id='SCE-T1',
+            last_name='LOCAL',
+            first_name='Player',
+            federation='FRA',
+            year_of_birth=1990,
+            gender=PlayerGender.NONE,
+        )
+        ppd = SCEPlayerPluginData(id='SCE-MOVER', last_sync_data=last_sync)
+        with EventDatabase(MOVE_EVENT_UNIQ_ID, write=True) as db:
+            stored_player = StoredPlayer(
+                id=None,
+                last_name='Local',
+                first_name='Player',
+                year_of_birth=1990,
+                federation='FRA',
+                plugin_data={PLUGIN_NAME: ppd.to_stored_value()},
+            )
+            player_id = db.add_stored_player(stored_player)
+            db.add_stored_tournament_player(
+                StoredTournamentPlayer(player_id=player_id, tournament_id=t2_id)
+            )
+
+        event = EventLoader().load_event(MOVE_EVENT_UNIQ_ID)
+        session = SCESession(event)
+
+        session._sync_tournament = MagicMock(return_value=True)  # type: ignore[method-assign]
+        # SC says player is still in SCE-T1.
+        sc_event_data = _canned_event_data(sce_player_id=None)
+        sc_event_data['tournaments'] = [
+            {
+                'id': 'SCE-T1',
+                'name': 'T1',
+                'registrations': [_canned_registration('SCE-MOVER')],
+            },
+            {'id': 'SCE-T2', 'name': 'T2', 'registrations': []},
+        ]
+        session._get_event_data = MagicMock(return_value=sc_event_data)  # type: ignore[method-assign]
+
+        # Capture the batch POST body without actually hitting HTTP.
+        captured_bodies: list[dict] = []
+
+        def fake_runner(fn, skip_validation=False):
+            # fn is a partial wrapping _send_batch_request(ops=...)
+            ops = fn.keywords['ops']
+            captured_bodies.append({'ops': ops})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {
+                'results': [
+                    {
+                        'index': i,
+                        'status': 'ok',
+                        'registration_id': op.get('registration_id'),
+                    }
+                    for i, op in enumerate(ops)
+                ]
+            }
+            return resp
+
+        session._run_with_token_validation = MagicMock(side_effect=fake_runner)  # type: ignore[method-assign]
+
+        session.sync_event()
+
+        # Find the UPDATE op for our player. Op-level tournament_id must be
+        # the local target (SCE-T2), not the source (SCE-T1).
+        all_ops = [op for body in captured_bodies for op in body['ops']]
+        update_ops = [
+            op
+            for op in all_ops
+            if op['op'] == 'update' and op.get('registration_id') == 'SCE-MOVER'
+        ]
+        self.assertTrue(update_ops, 'Expected at least one UPDATE op for SCE-MOVER')
+        self.assertEqual(
+            update_ops[0]['tournament_id'],
+            'SCE-T2',
+            'op-level tournament_id must be the move target',
+        )

--- a/tests/unit/test_sce_batch.py
+++ b/tests/unit/test_sce_batch.py
@@ -1,0 +1,120 @@
+"""Unit tests for `plugins.sce.sce_batch.SCEBatchBuilder`.
+
+Focused on the builder's pure behaviour — op construction, chunking, and
+callback dispatch. Higher-level coverage (HTTP wiring, plugin_data
+mutations) lives in integration tests against a running events platform.
+"""
+
+import pytest
+
+from plugins.sce.sce_batch import SCEBatchBuilder
+
+
+@pytest.mark.unit
+class TestSCEBatchBuilder:
+    def test_empty_builder(self):
+        b = SCEBatchBuilder()
+        assert b.is_empty()
+        assert len(b) == 0
+        assert list(b.chunks()) == []
+
+    def test_add_create_strips_tournament_id_from_data(self):
+        b = SCEBatchBuilder()
+        called = {}
+
+        def on_success(r):
+            called['success'] = r
+
+        def on_error(r):
+            called['error'] = r
+
+        b.add_create(
+            tournament_id='T1',
+            data={'tournament_id': 'T1', 'last_name': 'Carlsen', 'year_of_birth': 1990},
+            on_success=on_success,
+            on_error=on_error,
+            log_label='Carlsen',
+        )
+
+        assert len(b) == 1
+        op = b.pending[0]
+        assert op.op_dict['op'] == 'create'
+        assert op.op_dict['tournament_id'] == 'T1'
+        assert 'tournament_id' not in op.op_dict['data']
+        assert op.op_dict['data']['last_name'] == 'Carlsen'
+        assert op.log_label == 'Carlsen'
+
+    def test_add_update_strips_tournament_id_from_data(self):
+        b = SCEBatchBuilder()
+        b.add_update(
+            registration_id='R1',
+            tournament_id='T2',
+            data={'tournament_id': 'T2', 'last_name': 'Smith', 'year_of_birth': 1985},
+            on_success=lambda r: None,
+            on_error=lambda r: None,
+            log_label='Smith',
+        )
+        op = b.pending[0]
+        assert op.op_dict == {
+            'op': 'update',
+            'registration_id': 'R1',
+            'tournament_id': 'T2',
+            'data': {'last_name': 'Smith', 'year_of_birth': 1985},
+        }
+
+    def test_add_delete(self):
+        b = SCEBatchBuilder()
+        b.add_delete(
+            registration_id='R7',
+            on_success=lambda r: None,
+            on_error=lambda r: None,
+            log_label='Doe',
+        )
+        op = b.pending[0]
+        assert op.op_dict == {'op': 'delete', 'registration_id': 'R7'}
+
+    def test_chunks_splits_at_chunk_size(self):
+        b = SCEBatchBuilder()
+        for i in range(25):
+            b.add_delete(
+                registration_id=f'R{i}',
+                on_success=lambda r: None,
+                on_error=lambda r: None,
+                log_label=f'P{i}',
+            )
+        chunks = list(b.chunks(chunk_size=10))
+        assert len(chunks) == 3
+        assert len(chunks[0]) == 10
+        assert len(chunks[1]) == 10
+        assert len(chunks[2]) == 5
+
+    def test_apply_results_dispatches_per_op(self):
+        b = SCEBatchBuilder()
+        outcomes: list[tuple[str, dict]] = []
+
+        for i in range(3):
+            b.add_create(
+                tournament_id='T1',
+                data={'last_name': f'L{i}', 'year_of_birth': 1990},
+                on_success=lambda r, idx=i: outcomes.append((f'ok-{idx}', r)),
+                on_error=lambda r, idx=i: outcomes.append((f'err-{idx}', r)),
+                log_label=f'P{i}',
+            )
+
+        chunk = b.pending
+        results = [
+            {'index': 0, 'status': 'ok', 'registration_id': 'X0'},
+            {
+                'index': 1,
+                'status': 'error',
+                'error': {'code': 'conflict', 'message': 'dup'},
+            },
+            {'index': 2, 'status': 'ok', 'registration_id': 'X2', 'promoted': True},
+        ]
+        b.apply_results(chunk, results)
+
+        assert outcomes == [
+            ('ok-0', results[0]),
+            ('err-1', results[1]),
+            ('ok-2', results[2]),
+        ]

--- a/tests/unit/test_sce_plan_player_sync.py
+++ b/tests/unit/test_sce_plan_player_sync.py
@@ -1,0 +1,361 @@
+"""Unit tests for `SCESession._plan_player_sync`.
+
+These tests exercise the 3-way merge decision tree without touching the
+DB or the network. Player + plugin_data are lightweight stubs; the few
+SCEUtils helpers that touch the DB are monkey-patched to operate on the
+in-memory `player.plugin_data` dict.
+
+Coverage targets the four recent bugs:
+  * move target tournament_id wrong (op-level vs body)
+  * dict-iter mutation during planning
+  * conflict not registered when both ends modify same field
+  * failed deletes silently retired from `deleted_player_ids`
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.sce import PLUGIN_NAME
+from plugins.sce.sce_batch import SCEBatchBuilder
+from plugins.sce.sce_data import SCEPlayerPluginData, SCEPlayerSyncData
+from plugins.sce.sce_session import SCESession, _BatchSyncCounters
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def make_sync_data(
+    tid: str = 'T1',
+    last_name: str = 'Doe',
+    first_name: str | None = 'John',
+    yob: int | None = 1990,
+    fide_id: int | None = None,
+    club: str = '',
+) -> SCEPlayerSyncData:
+    return SCEPlayerSyncData(
+        tournament_id=tid,
+        last_name=last_name,
+        first_name=first_name,
+        year_of_birth=yob,
+        fide_id=fide_id,
+        club=club,
+    )
+
+
+def make_player(
+    plugin_data: SCEPlayerPluginData | None = None,
+    last_name: str = 'Doe',
+    first_name: str | None = 'John',
+    has_real_pairings: bool = False,
+) -> MagicMock:
+    pd = plugin_data if plugin_data is not None else SCEPlayerPluginData()
+    p = MagicMock()
+    p.plugin_data = {PLUGIN_NAME: pd}
+    p.stored_player.plugin_data = {PLUGIN_NAME: pd.to_stored_value()}
+    p.last_name = last_name
+    p.first_name = first_name
+    p.has_real_pairings = has_real_pairings
+    return p
+
+
+def make_session() -> SCESession:
+    session = SCESession.__new__(SCESession)
+    session.event = MagicMock()
+    session.event.uniq_id = 'test-event'
+    session.new_check_ins_tournament_sce_ids = set()
+    return session
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def stub_db_writes(monkeypatch):
+    """update_player_plugin_data normally writes to SQLite. Stub it to mutate
+    in-memory player state only so tests can inspect outcomes."""
+
+    def fake_update(player, plugin_data, write=True, write_stored_object=False):
+        player.stored_player.plugin_data[PLUGIN_NAME] = plugin_data.to_stored_value()
+        player.plugin_data[PLUGIN_NAME] = plugin_data
+
+    monkeypatch.setattr(
+        'plugins.sce.utils.SCEUtils.update_player_plugin_data', fake_update
+    )
+
+
+@pytest.fixture
+def session():
+    s = make_session()
+    # update_local_player would call augment_stored_player + DB; stub it.
+    s.update_local_player = MagicMock()  # type: ignore[method-assign]
+    return s
+
+
+@pytest.fixture
+def builder():
+    return SCEBatchBuilder()
+
+
+@pytest.fixture
+def counters():
+    return _BatchSyncCounters()
+
+
+def _patch_from_player(monkeypatch, sync_data: SCEPlayerSyncData):
+    monkeypatch.setattr(
+        'plugins.sce.sce_data.SCEPlayerSyncData.from_player',
+        classmethod(lambda cls, player: sync_data),
+    )
+
+
+# ── Branch A: no sce_id (create) ────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestCreateBranch:
+    def test_no_sce_id_queues_create_op(self, session, builder, counters, monkeypatch):
+        local = make_sync_data(tid='T1', last_name='Carlsen', fide_id=1503014)
+        _patch_from_player(monkeypatch, local)
+        player = make_player()
+
+        session._plan_player_sync(player, None, builder, counters)
+
+        assert len(builder) == 1
+        op = builder.pending[0]
+        assert op.op_dict['op'] == 'create'
+        assert op.op_dict['tournament_id'] == 'T1'
+        assert op.op_dict['data']['last_name'] == 'Carlsen'
+        assert 'tournament_id' not in op.op_dict['data']
+
+    def test_create_success_sets_id_and_last_sync_data(
+        self, session, builder, counters, monkeypatch
+    ):
+        local = make_sync_data(tid='T1')
+        _patch_from_player(monkeypatch, local)
+        player = make_player()
+
+        session._plan_player_sync(player, None, builder, counters)
+        builder.pending[0].on_success(
+            {'index': 0, 'status': 'ok', 'registration_id': 'SCE-REG-42'}
+        )
+
+        pd = player.plugin_data[PLUGIN_NAME]
+        assert pd.id == 'SCE-REG-42'
+        assert pd.last_sync_data == local
+        assert pd.is_duplicated is False
+
+    def test_create_conflict_marks_duplicated(
+        self, session, builder, counters, monkeypatch
+    ):
+        local = make_sync_data(tid='T1')
+        _patch_from_player(monkeypatch, local)
+        player = make_player()
+
+        session._plan_player_sync(player, None, builder, counters)
+        builder.pending[0].on_error(
+            {
+                'index': 0,
+                'status': 'error',
+                'error': {'code': 'conflict', 'message': 'dup'},
+            }
+        )
+
+        pd = player.plugin_data[PLUGIN_NAME]
+        assert pd.is_duplicated is True
+        assert pd.id is None
+        assert counters.duplicate_count == 1
+
+    def test_create_other_error_leaves_state_untouched_for_retry(
+        self, session, builder, counters, monkeypatch
+    ):
+        local = make_sync_data(tid='T1')
+        _patch_from_player(monkeypatch, local)
+        player = make_player()
+
+        session._plan_player_sync(player, None, builder, counters)
+        builder.pending[0].on_error(
+            {
+                'index': 0,
+                'status': 'error',
+                'error': {'code': 'bad_request', 'message': 'oops'},
+            }
+        )
+
+        pd = player.plugin_data[PLUGIN_NAME]
+        assert pd.id is None
+        assert pd.is_duplicated is False
+        assert counters.duplicate_count == 0
+
+    def test_soft_deleted_player_skipped(self, session, builder, counters):
+        pd = SCEPlayerPluginData(id=None, deleted_id='SCE-OLD')
+        player = make_player(plugin_data=pd)
+
+        session._plan_player_sync(player, None, builder, counters)
+
+        assert len(builder) == 0
+
+
+# ── Branch C: 3-way merge ───────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestMergeBranch:
+    def test_already_synced_no_op_no_save(
+        self, session, builder, counters, monkeypatch
+    ):
+        last = make_sync_data(tid='T1', last_name='Doe')
+        pd = SCEPlayerPluginData(id='SCE-1', last_sync_data=last)
+        player = make_player(plugin_data=pd)
+        local = make_sync_data(tid='T1', last_name='Doe')
+        sce = make_sync_data(tid='T1', last_name='Doe')
+        _patch_from_player(monkeypatch, local)
+
+        session._plan_player_sync(player, sce, builder, counters)
+
+        assert len(builder) == 0
+        # last_sync_data unchanged
+        assert player.plugin_data[PLUGIN_NAME].last_sync_data == last
+
+    def test_modified_locally_queues_update_with_local_tournament_target(
+        self, session, builder, counters, monkeypatch
+    ):
+        """op-level tournament_id must be TARGET (local), not
+        source (sce). The batch endpoint reads tournament_id from op level —
+        if equal to current, no move fires."""
+        last = make_sync_data(tid='T1', last_name='Doe')
+        pd = SCEPlayerPluginData(id='SCE-1', last_sync_data=last)
+        player = make_player(plugin_data=pd)
+        local = make_sync_data(tid='T2', last_name='Doe')  # MOVED locally
+        sce = make_sync_data(tid='T1', last_name='Doe')  # unchanged on SC
+        _patch_from_player(monkeypatch, local)
+
+        session._plan_player_sync(player, sce, builder, counters)
+
+        assert len(builder) == 1
+        op = builder.pending[0]
+        assert op.op_dict['op'] == 'update'
+        assert op.op_dict['registration_id'] == 'SCE-1'
+        # Target = local, not source. Triggers move on the server.
+        assert op.op_dict['tournament_id'] == 'T2'
+
+    def test_modified_locally_success_updates_last_sync(
+        self, session, builder, counters, monkeypatch
+    ):
+        last = make_sync_data(tid='T1', last_name='Doe')
+        pd = SCEPlayerPluginData(id='SCE-1', last_sync_data=last)
+        player = make_player(plugin_data=pd)
+        local = make_sync_data(tid='T1', last_name='Smith')
+        sce = make_sync_data(tid='T1', last_name='Doe')
+        _patch_from_player(monkeypatch, local)
+
+        session._plan_player_sync(player, sce, builder, counters)
+        builder.pending[0].on_success({'index': 0, 'status': 'ok'})
+
+        assert player.plugin_data[PLUGIN_NAME].last_sync_data == local
+
+    def test_modified_on_sc_pulls_locally_no_op_queued(
+        self, session, builder, counters, monkeypatch
+    ):
+        last = make_sync_data(tid='T1', last_name='Doe')
+        pd = SCEPlayerPluginData(id='SCE-1', last_sync_data=last)
+        player = make_player(plugin_data=pd)
+        local = make_sync_data(tid='T1', last_name='Doe')
+        sce = make_sync_data(tid='T1', last_name='Smith')  # SC changed
+        _patch_from_player(monkeypatch, local)
+
+        session._plan_player_sync(player, sce, builder, counters)
+
+        assert len(builder) == 0
+        session.update_local_player.assert_called_once_with(player, sce)
+        assert player.plugin_data[PLUGIN_NAME].last_sync_data == sce
+
+    def test_both_mergeable_queues_update_with_merged_tournament_target(
+        self, session, builder, counters, monkeypatch
+    ):
+        """Regression: when merge handles a tournament change, op-level
+        tournament_id must come from MERGED data (which carries the local
+        tournament_id since SC matched ref on that field)."""
+        last = make_sync_data(tid='T1', last_name='Doe', club='Old')
+        pd = SCEPlayerPluginData(id='SCE-1', last_sync_data=last)
+        player = make_player(plugin_data=pd)
+        # Local moved to T2, SC changed club. Mergeable.
+        local = make_sync_data(tid='T2', last_name='Doe', club='Old')
+        sce = make_sync_data(tid='T1', last_name='Doe', club='New')
+        _patch_from_player(monkeypatch, local)
+
+        session._plan_player_sync(player, sce, builder, counters)
+
+        assert len(builder) == 1
+        op = builder.pending[0]
+        assert op.op_dict['op'] == 'update'
+        # Merged carries local tournament_id (T2) + sc club (New).
+        assert op.op_dict['tournament_id'] == 'T2'
+        assert op.op_dict['data']['club'] == 'New'
+        assert op.op_dict['data']['last_name'] == 'Doe'
+
+    def test_both_unmergeable_sets_conflict_no_op_queued(
+        self, session, builder, counters, monkeypatch
+    ):
+        """Regression: same field changed on both ends must register
+        conflict, not silently overwrite local."""
+        last = make_sync_data(tid='T1', last_name='Doe')
+        pd = SCEPlayerPluginData(id='SCE-1', last_sync_data=last)
+        player = make_player(plugin_data=pd)
+        local = make_sync_data(tid='T1', last_name='Smith')  # local edit
+        sce = make_sync_data(tid='T1', last_name='Jones')  # different SC edit
+        _patch_from_player(monkeypatch, local)
+
+        session._plan_player_sync(player, sce, builder, counters)
+
+        assert len(builder) == 0  # No op queued — conflict only.
+        assert counters.conflict_count == 1
+        result_pd = player.plugin_data[PLUGIN_NAME]
+        assert result_pd.conflict_sync_data == sce
+        # Local user changes preserved (stored_player not mutated).
+        session.update_local_player.assert_not_called()
+
+    def test_merge_success_updates_local_and_last_sync(
+        self, session, builder, counters, monkeypatch
+    ):
+        last = make_sync_data(tid='T1', last_name='Doe', club='Old')
+        pd = SCEPlayerPluginData(id='SCE-1', last_sync_data=last)
+        player = make_player(plugin_data=pd)
+        local = make_sync_data(tid='T1', last_name='Smith', club='Old')
+        sce = make_sync_data(tid='T1', last_name='Doe', club='New')
+        _patch_from_player(monkeypatch, local)
+
+        session._plan_player_sync(player, sce, builder, counters)
+        builder.pending[0].on_success({'index': 0, 'status': 'ok'})
+
+        # update_local_player called with merged data.
+        assert session.update_local_player.call_count == 1
+        merged = session.update_local_player.call_args[0][1]
+        assert merged.last_name == 'Smith'
+        assert merged.club == 'New'
+        assert player.plugin_data[PLUGIN_NAME].last_sync_data == merged
+
+
+# ── Tournament-force branch ─────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestTournamentForce:
+    def test_paired_player_in_different_tournament_queues_force_update(
+        self, session, builder, counters, monkeypatch
+    ):
+        last = make_sync_data(tid='T1', last_name='Doe')
+        pd = SCEPlayerPluginData(id='SCE-1', last_sync_data=last)
+        player = make_player(plugin_data=pd, has_real_pairings=True)
+        local = make_sync_data(tid='T1', last_name='Doe')  # local stayed in T1
+        sce = make_sync_data(tid='T2', last_name='Doe')  # SC moved to T2
+        _patch_from_player(monkeypatch, local)
+
+        session._plan_player_sync(player, sce, builder, counters)
+
+        # Force update queued with target = local (T1).
+        assert len(builder) >= 1
+        force_op = builder.pending[0]
+        assert force_op.op_dict['op'] == 'update'
+        assert force_op.op_dict['registration_id'] == 'SCE-1'
+        assert force_op.op_dict['tournament_id'] == 'T1'

--- a/tests/unit/test_sce_send_batch.py
+++ b/tests/unit/test_sce_send_batch.py
@@ -1,0 +1,210 @@
+"""Unit tests for `SCESession.send_batch`.
+
+Covers HTTP-level wiring: URL, method, payload shape, chunking, and how
+batch responses are dispatched back to per-op callbacks.
+`_run_with_token_validation` is stubbed so the token-refresh dance is
+out of scope here (tested separately if needed).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from litestar.status_codes import HTTP_200_OK
+
+from common import SharlyChessException
+from plugins.sce.sce_batch import SCEBatchBuilder
+from plugins.sce.sce_session import SCESession
+
+
+def make_session_for_batch(monkeypatch) -> SCESession:
+    """Build an SCESession that returns a known batch URL without needing
+    real event tokens/plugin_data."""
+    session = SCESession.__new__(SCESession)
+    session.event = MagicMock()
+    session.event.uniq_id = 'test-event'
+    session.new_check_ins_tournament_sce_ids = set()
+
+    # Override the property that would otherwise read plugin_data.tokens.
+    monkeypatch.setattr(
+        SCESession,
+        'registrations_batch_url',
+        property(lambda self: 'https://test/api/v1/events/E1/registrations/batch'),
+    )
+    monkeypatch.setattr(
+        SCESession,
+        'api_headers',
+        property(
+            lambda self: {
+                'Authorization': 'Bearer T',
+                'Content-Type': 'application/json',
+            }
+        ),
+    )
+    return session
+
+
+def _fake_response(status: int, body: dict | None = None) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = body or {}
+    return r
+
+
+@pytest.mark.unit
+class TestSendBatch:
+    def test_empty_builder_is_a_noop(self, monkeypatch):
+        session = make_session_for_batch(monkeypatch)
+        called = {'count': 0}
+
+        def fake_runner(fn, skip_validation=False):
+            called['count'] += 1
+            return _fake_response(200, {'results': []})
+
+        monkeypatch.setattr(session, '_run_with_token_validation', fake_runner)
+
+        session.send_batch(SCEBatchBuilder())
+        assert called['count'] == 0
+
+    def test_single_chunk_dispatches_results_to_callbacks(self, monkeypatch):
+        session = make_session_for_batch(monkeypatch)
+        builder = SCEBatchBuilder()
+        outcomes: list[tuple[str, dict]] = []
+
+        for i in range(3):
+            builder.add_delete(
+                registration_id=f'R{i}',
+                on_success=lambda r, idx=i: outcomes.append((f'ok-{idx}', r)),
+                on_error=lambda r, idx=i: outcomes.append((f'err-{idx}', r)),
+                log_label=f'P{i}',
+            )
+
+        results = [
+            {'index': 0, 'status': 'ok', 'registration_id': 'R0'},
+            {
+                'index': 1,
+                'status': 'error',
+                'error': {'code': 'not_found', 'message': '!'},
+            },
+            {'index': 2, 'status': 'ok', 'registration_id': 'R2'},
+        ]
+        monkeypatch.setattr(
+            session,
+            '_run_with_token_validation',
+            lambda fn, skip_validation=False: _fake_response(207, {'results': results}),
+        )
+
+        session.send_batch(builder)
+
+        assert outcomes == [
+            ('ok-0', results[0]),
+            ('err-1', results[1]),
+            ('ok-2', results[2]),
+        ]
+
+    def test_chunks_send_separate_requests(self, monkeypatch):
+        session = make_session_for_batch(monkeypatch)
+        builder = SCEBatchBuilder()
+        for i in range(7):
+            builder.add_delete(
+                registration_id=f'R{i}',
+                on_success=lambda r: None,
+                on_error=lambda r: None,
+                log_label=f'P{i}',
+            )
+
+        request_count = {'n': 0}
+
+        def fake_runner(fn, skip_validation=False):
+            request_count['n'] += 1
+            # Inspect what the closed-over partial would post by calling it.
+            # The fn is partial(_send_batch_request, ops=...) — we ignore
+            # actually sending and craft a matching results list.
+            ops = fn.keywords['ops']
+            return _fake_response(
+                200,
+                {
+                    'results': [
+                        {
+                            'index': i,
+                            'status': 'ok',
+                            'registration_id': op['registration_id'],
+                        }
+                        for i, op in enumerate(ops)
+                    ]
+                },
+            )
+
+        monkeypatch.setattr(session, '_run_with_token_validation', fake_runner)
+
+        # Force tiny chunks via internal chunks() arg by monkeypatching.
+        original_chunks = SCEBatchBuilder.chunks
+        monkeypatch.setattr(
+            SCEBatchBuilder,
+            'chunks',
+            lambda self, chunk_size=2: original_chunks(self, chunk_size=2),
+        )
+
+        session.send_batch(builder)
+        # 7 ops in chunks of 2 → 4 requests (2, 2, 2, 1).
+        assert request_count['n'] == 4
+
+    def test_http_failure_raises_sharly_chess_exception(self, monkeypatch):
+        session = make_session_for_batch(monkeypatch)
+        builder = SCEBatchBuilder()
+        builder.add_delete(
+            registration_id='R0',
+            on_success=lambda r: pytest.fail('should not be called'),
+            on_error=lambda r: pytest.fail('should not be called'),
+            log_label='P0',
+        )
+
+        # 500 with a request attribute so validate_api_response can format.
+        resp = _fake_response(500, {})
+        resp.request.method = 'POST'
+        resp.url = 'https://test/...'
+        resp.raise_for_status.side_effect = __import__('requests').HTTPError('500')
+
+        monkeypatch.setattr(
+            session,
+            '_run_with_token_validation',
+            lambda fn, skip_validation=False: resp,
+        )
+
+        with pytest.raises(SharlyChessException):
+            session.send_batch(builder)
+
+    def test_payload_uses_best_effort_mode(self, monkeypatch):
+        session = make_session_for_batch(monkeypatch)
+        builder = SCEBatchBuilder()
+        builder.add_delete(
+            registration_id='R0',
+            on_success=lambda r: None,
+            on_error=lambda r: None,
+            log_label='P0',
+        )
+
+        captured: dict = {}
+
+        def fake_post(url, headers=None, json=None, **kw):
+            captured['url'] = url
+            captured['headers'] = headers
+            captured['json'] = json
+            return _fake_response(
+                HTTP_200_OK, {'results': [{'index': 0, 'status': 'ok'}]}
+            )
+
+        # _run_with_token_validation runs fn() directly here.
+        monkeypatch.setattr(
+            session,
+            '_run_with_token_validation',
+            lambda fn, skip_validation=False: fn(),
+        )
+        monkeypatch.setattr('plugins.sce.sce_session.requests.post', fake_post)
+
+        session.send_batch(builder)
+
+        assert captured['url'] == 'https://test/api/v1/events/E1/registrations/batch'
+        assert captured['headers']['Authorization'] == 'Bearer T'
+        assert captured['json']['mode'] == 'best_effort'
+        assert len(captured['json']['ops']) == 1
+        assert captured['json']['ops'][0]['op'] == 'delete'


### PR DESCRIPTION
- Prevent duplicates creation on SC.com registration re-creation (Pascal's issue)
- Match identical duplicates automatically
- In the duplicates modal, when deleting one duplicate, mark the other one as not duplicate (see below: deleting one or the other remove the other one from the modal)
<img width="654" height="604" alt="image" src="https://github.com/user-attachments/assets/71c75688-7b94-44a8-8d28-eeb4cef23e96" />

