### PR TITLE
Fix form global screen background defaulting to black

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,11 @@
 - Added support for norm exemption 1.4.2c (last round forfeit as loss) (4.2.0)
 - Added custom team ranking documents (4.2.0)
 
+## Screens
+
+- Restored check-in on input screens (4.2.0)
+- Fixed default global background color (4.2.1)
+
 ## _Sharly-Chess.com_
 
 - Added missing timeouts (4.2.0)

--- a/src/web/controllers/admin/screen_config_admin_controller.py
+++ b/src/web/controllers/admin/screen_config_admin_controller.py
@@ -41,7 +41,7 @@ class ScreenConfigAdminController(BaseEventAdminController):
         stored_event = admin_event.stored_event
         return WebContext.values_dict_to_form_data(
             {
-                'background_color': stored_event.background_color,
+                'background_color': admin_event.background_color,
                 'message_text': stored_event.message_text,
                 'message_color': admin_event.message_color,
                 'message_background_color': admin_event.message_background_color,


### PR DESCRIPTION
Opening the screen config modal gives a black color while white is being used