### PR TITLE
Fix display controllers redirected to screens on user input

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@
 
 - Restored check-in on input screens (4.2.0)
 - Fixed default global background color (4.2.1)
+- Fixed display controller redirection on results or check-in input (4.2.1)
 
 ## _Sharly-Chess.com_
 

--- a/src/web/controllers/user/base_screen_user_controller.py
+++ b/src/web/controllers/user/base_screen_user_controller.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from functools import cached_property
 from logging import Logger
 from typing import Any
 
@@ -47,6 +48,16 @@ class ScreenEntityUserWebContext(EventUserWebContext, ABC):
     def screen(self) -> Screen:
         pass
 
+    @cached_property
+    def family(self) -> Family | None:
+        if ':' in self.screen.uniq_id:
+            family_uniq_id: str = self.screen.uniq_id.split(':')[0]
+            try:
+                return self.user_event.families_by_uniq_id[family_uniq_id]
+            except KeyError:
+                raise NotFoundException(f'Family [{family_uniq_id}] not found.')
+        return None
+
     @property
     def background_image(self) -> str | None:
         if self.screen:
@@ -69,7 +80,9 @@ class ScreenEntityUserWebContext(EventUserWebContext, ABC):
         return super().template_context | {
             'rotator': self.rotator,
             'rotator_screen_index': self.rotator_screen_index,
+            'is_rotator': self.is_rotator,
             'screen': self.screen,
+            'family': self.family,
             'display_controller': self.display_controller,
         }
 
@@ -124,24 +137,6 @@ class DisplayControllerUserWebContext(ScreenEntityUserWebContext):
     def screen(self) -> Screen:
         assert self._screen is not None
         return self._screen
-
-
-class BasicScreenOrFamilyUserWebContext(ScreenUserWebContext):
-    def __init__(self, request: HTMXRequest):
-        super().__init__(request)
-        self.family: Family | None = None
-        if ':' in self.screen.uniq_id:
-            family_uniq_id: str = self.screen.uniq_id.split(':')[0]
-            try:
-                self.family = self.user_event.families_by_uniq_id[family_uniq_id]
-            except KeyError:
-                raise NotFoundException(f'Family [{family_uniq_id}] not found.')
-
-    @property
-    def template_context(self) -> dict[str, Any]:
-        return super().template_context | {
-            'family': self.family,
-        }
 
 
 class BaseScreenUserController(BaseUserController):

--- a/src/web/controllers/user/input_user_controller.py
+++ b/src/web/controllers/user/input_user_controller.py
@@ -10,21 +10,20 @@ from litestar.channels import ChannelsPlugin
 
 from data.access_levels.actions import AuthAction
 from data.board import Board
-from data.player import TournamentPlayer
-from data.tournament import Tournament
+from data.screen import Screen
 from utils.enum import Result
 from web.controllers.admin.pairings_admin_controller import PairingsAdminController
 from web.controllers.admin.player_admin_controller import PlayerAdminController
 from web.controllers.user.base_screen_user_controller import (
-    ScreenUserWebContext,
     BaseScreenUserController,
-    BasicScreenOrFamilyUserWebContext,
+    ScreenEntityUserWebContext,
 )
 from web.guards import (
     EventGuard,
     ViewScreenGuard,
     TournamentActionGuard,
     SetResultGuard,
+    ViewDisplayControllerGuard,
 )
 from web.messages import Message
 from web.session import (
@@ -37,10 +36,21 @@ from web.session import (
 from web.utils import RequestUtils
 
 
-class TournamentUserWebContext(ScreenUserWebContext):
+class UserInputWebContext(ScreenEntityUserWebContext):
     def __init__(self, request: HTMXRequest):
         super().__init__(request)
-        self.tournament: Tournament = RequestUtils.get_tournament(request)
+        self.tournament = RequestUtils.get_tournament(request)
+        self.display_controller = RequestUtils.get_optional_display_controller(request)
+        if self.display_controller:
+            screen = self.display_controller.screen
+            assert screen is not None
+            self._screen = screen
+        else:
+            self._screen = RequestUtils.get_screen(request)
+
+    @property
+    def screen(self) -> Screen:
+        return self._screen
 
     @property
     def template_context(self) -> dict[str, Any]:
@@ -49,10 +59,12 @@ class TournamentUserWebContext(ScreenUserWebContext):
         }
 
 
-class BoardUserWebContext(TournamentUserWebContext):
+class ResultUserWebContext(UserInputWebContext):
     def __init__(self, request: HTMXRequest):
         super().__init__(request)
-        self.board: Board = RequestUtils.get_board(request)
+        self.board = RequestUtils.get_board(request)
+        self.round = self.board.round
+        self.result = RequestUtils.get_result(request)
 
     @property
     def template_context(self) -> dict[str, Any]:
@@ -61,20 +73,10 @@ class BoardUserWebContext(TournamentUserWebContext):
         }
 
 
-class ResultUserWebContext(BoardUserWebContext):
+class PlayerUserWebContext(UserInputWebContext):
     def __init__(self, request: HTMXRequest):
         super().__init__(request)
-        self.board = RequestUtils.get_board(request)
-        self.round = self.board.round
-        self.result = RequestUtils.get_result(request)
-
-
-class PlayerUserWebContext(TournamentUserWebContext):
-    def __init__(self, request: HTMXRequest):
-        super().__init__(request)
-        self.tournament_player: TournamentPlayer = RequestUtils.get_tournament_player(
-            request
-        )
+        self.tournament_player = RequestUtils.get_tournament_player(request)
         self.board: Board | None = (
             self.tournament.boards[self.tournament_player.board_id - 1]
             if self.tournament_player.board_id
@@ -89,22 +91,27 @@ class PlayerUserWebContext(TournamentUserWebContext):
         }
 
 
-class BaseInputUserController(BaseScreenUserController):
+class InputUserController(BaseScreenUserController):
+    """Controller containing all the input endpoints accessed from screens.
+    All endpoints have to be accessible from either a screen of a display controller."""
+
     guards = [
         EventGuard(),
         ViewScreenGuard(),
+        ViewDisplayControllerGuard(),
     ]
 
-
-class CheckInUserController(BaseInputUserController):
     @get(
-        path='/view/checkin-modal/{event_uniq_id:str}/{screen_uniq_id:str}/{tournament_id:int}/{player_id:int}',
+        path=[
+            '/view/checkin-modal/{is_screen:int}/{event_uniq_id:str}/'
+            '{screen_uniq_id:str}/{tournament_id:int}/{player_id:int}',
+            '/view/checkin-modal/0/{event_uniq_id:str}/'
+            '{display_controller_id:int}/{tournament_id:int}/{player_id:int}',
+        ],
         name='user-checkin-modal',
     )
     async def htmx_user_checkin_modal(self, request: HTMXRequest) -> Template:
-        web_context: PlayerUserWebContext = PlayerUserWebContext(
-            request,
-        )
+        web_context = PlayerUserWebContext(request)
         return HTMXTemplate(
             template_name='user/modals/check_in_modal.html',
             context=web_context.template_context,
@@ -114,7 +121,12 @@ class CheckInUserController(BaseInputUserController):
         )
 
     @patch(
-        path='/view/toggle-check-in/{event_uniq_id:str}/{screen_uniq_id:str}/{tournament_id:int}/{player_id:int}',
+        path=[
+            '/view/toggle-check-in/{is_screen:int}/{event_uniq_id:str}/'
+            '{screen_uniq_id:str}/{tournament_id:int}/{player_id:int}',
+            '/view/toggle-check-in/0/{event_uniq_id:str}/'
+            '{display_controller_id:int}/{tournament_id:int}/{player_id:int}',
+        ],
         name='user-toggle-check-in',
         guards=[TournamentActionGuard(AuthAction.CHECK_IN_PLAYERS)],
     )
@@ -135,10 +147,8 @@ class CheckInUserController(BaseInputUserController):
                 expiration=time.time() + 20,
             )
         )
-        return self._user_screen_render(BasicScreenOrFamilyUserWebContext(request))
+        return self._user_screen_render(web_context)
 
-
-class IllegalMoveUserController(BaseInputUserController):
     def _delete_or_add_illegal_move(self, request: HTMXRequest, add: bool) -> Template:
         web_context = PlayerUserWebContext(request)
         tournament = web_context.tournament
@@ -160,10 +170,15 @@ class IllegalMoveUserController(BaseInputUserController):
                 )
             else:
                 session_handler.set(last_player_updated)
-        return self._user_screen_render(BasicScreenOrFamilyUserWebContext(request))
+        return self._user_screen_render(web_context)
 
     @put(
-        path='/view/add-illegal-move/{event_uniq_id:str}/{screen_uniq_id:str}/{tournament_id:int}/{player_id:int}',
+        path=[
+            '/view/add-illegal-move/{is_screen:int}/{event_uniq_id:str}/'
+            '{screen_uniq_id:str}/{tournament_id:int}/{player_id:int}',
+            '/view/add-illegal-move/0/{event_uniq_id:str}/'
+            '{display_controller_id:int}/{tournament_id:int}/{player_id:int}',
+        ],
         name='user-add-illegal-move',
         guards=[TournamentActionGuard(AuthAction.SET_ILLEGAL_MOVES)],
         status_code=HTTP_200_OK,
@@ -172,7 +187,12 @@ class IllegalMoveUserController(BaseInputUserController):
         return self._delete_or_add_illegal_move(request, add=True)
 
     @delete(
-        path='/view/delete-illegal-move/{event_uniq_id:str}/{screen_uniq_id:str}/{tournament_id:int}/{player_id:int}',
+        path=[
+            '/view/delete-illegal-move/{is_screen:int}/{event_uniq_id:str}/'
+            '{screen_uniq_id:str}/{tournament_id:int}/{player_id:int}',
+            '/view/delete-illegal-move/0/{event_uniq_id:str}/'
+            '{display_controller_id:int}/{tournament_id:int}/{player_id:int}',
+        ],
         name='user-delete-illegal-move',
         guards=[TournamentActionGuard(AuthAction.SET_ILLEGAL_MOVES)],
         status_code=HTTP_200_OK,
@@ -180,15 +200,18 @@ class IllegalMoveUserController(BaseInputUserController):
     async def htmx_user_delete_illegal_move(self, request: HTMXRequest) -> Template:
         return self._delete_or_add_illegal_move(request, add=False)
 
-
-class ResultUserController(BaseInputUserController):
     @get(
-        path='/view/result-modal/{event_uniq_id:str}/{screen_uniq_id:str}/{tournament_id:int}/{board_id:int}',
+        path=[
+            '/view/result-modal/{is_screen:int}/{event_uniq_id:str}/{screen_uniq_id:str}/'
+            '{tournament_id:int}/{board_id:int}',
+            '/view/result-modal/0/{event_uniq_id:str}/{display_controller_id:int}/'
+            '{tournament_id:int}/{board_id:int}',
+        ],
         name='user-result-modal',
         guards=[TournamentActionGuard(AuthAction.ENTER_RESULTS)],
     )
     async def htmx_user_result_modal(self, request: HTMXRequest) -> Template:
-        web_context = BoardUserWebContext(request)
+        web_context = ResultUserWebContext(request)
         return HTMXTemplate(
             template_name='user/modals/results_modal.html',
             context=web_context.template_context,
@@ -197,7 +220,17 @@ class ResultUserController(BaseInputUserController):
             after='settle',
         )
 
-    def _user_update_result(
+    @put(
+        path=[
+            '/view/update-result/{is_screen:int}/{event_uniq_id:str}/{screen_uniq_id:str}/'
+            '{tournament_id:int}/{round:int}/{board_id:int}/{result:int}',
+            '/view/update-result/0/{event_uniq_id:str}/{display_controller_id:int}/'
+            '{tournament_id:int}/{round:int}/{board_id:int}/{result:int}',
+        ],
+        name='user-update-result',
+        guards=[SetResultGuard()],
+    )
+    async def htmx_user_update_result(
         self,
         request: HTMXRequest,
         channels: ChannelsPlugin,
@@ -224,31 +257,4 @@ class ResultUserController(BaseInputUserController):
                 expiration=time.time() + 20,
             )
         )
-        return self._user_screen_render(BasicScreenOrFamilyUserWebContext(request))
-
-    @put(
-        path='/view/add-result/{event_uniq_id:str}/{screen_uniq_id:str}/'
-        '{tournament_id:int}/{round:int}/{board_id:int}/{result:int}',
-        name='user-add-result',
-        guards=[SetResultGuard()],
-    )
-    async def htmx_user_add_result(
-        self,
-        request: HTMXRequest,
-        channels: ChannelsPlugin,
-    ) -> Template:
-        return self._user_update_result(request, channels=channels)
-
-    @delete(
-        path='/view/delete-result/{event_uniq_id:str}/{screen_uniq_id:str}/'
-        '{tournament_id:int}/{round:int}/{board_id:int}',
-        name='user-delete-result',
-        guards=[TournamentActionGuard(AuthAction.UPDATE_RESULTS)],
-        status_code=HTTP_200_OK,
-    )
-    async def htmx_user_delete_result(
-        self,
-        request: HTMXRequest,
-        channels: ChannelsPlugin,
-    ) -> Template:
-        return self._user_update_result(request, channels=channels)
+        return self._user_screen_render(web_context)

--- a/src/web/controllers/user/screen_user_controller.py
+++ b/src/web/controllers/user/screen_user_controller.py
@@ -12,9 +12,10 @@ from data.tournament import Tournament
 from utils.enum import ScreenType
 from web.controllers.user.base_screen_user_controller import (
     BaseScreenUserController,
-    BasicScreenOrFamilyUserWebContext,
     DisplayControllerUserWebContext,
     RotatorUserWebContext,
+    ScreenUserWebContext,
+    ScreenEntityUserWebContext,
 )
 from web.guards import (
     EventGuard,
@@ -54,12 +55,15 @@ class ScreenUserController(BaseScreenUserController):
     @classmethod
     def _user_screen_refresh_needed(
         cls,
-        web_context: BasicScreenOrFamilyUserWebContext
-        | DisplayControllerUserWebContext,
+        web_context: ScreenEntityUserWebContext,
         date: float,
     ) -> bool:
         date_dt = datetime.fromtimestamp(date)
         screen = web_context.screen
+        family = web_context.family
+        if family:
+            if family.last_update > date_dt:
+                return True
         if screen:
             event = screen.event
             if event.last_update > date_dt:
@@ -98,17 +102,6 @@ class ScreenUserController(BaseScreenUserController):
                                 return True
                 case _:
                     raise ValueError(f'type={screen.type}')
-        elif isinstance(web_context, BasicScreenOrFamilyUserWebContext):
-            family = web_context.family
-            assert family is not None
-            if (
-                max(
-                    family.event.last_update,
-                    family.last_update,
-                )
-                > date_dt
-            ):
-                return True
         return False
 
     @get(
@@ -120,7 +113,7 @@ class ScreenUserController(BaseScreenUserController):
         self,
         request: HTMXRequest,
     ) -> HTMXTemplate | Reswap:
-        web_context = BasicScreenOrFamilyUserWebContext(request)
+        web_context = ScreenUserWebContext(request)
         date: float | None = self.get_if_modified_since(request)
         if date is None or self._user_screen_refresh_needed(web_context, date):
             return self._user_screen_render(web_context)

--- a/src/web/guards.py
+++ b/src/web/guards.py
@@ -169,7 +169,7 @@ class ViewScreenEntityGuard[T](BaseGuard, ABC):
 
     @staticmethod
     def is_entity_public(entity: T) -> bool:
-        return entity.public
+        return getattr(entity, 'public')
 
     def authorize_client(self, client: Client, request: HTMXRequest):
         entity = self.get_entity(request)

--- a/src/web/guards.py
+++ b/src/web/guards.py
@@ -13,6 +13,9 @@ from litestar_htmx import HTMXRequest
 
 from data.access_levels.actions import AuthAction
 from data.access_levels.client import Client
+from data.display_controller import DisplayController
+from data.rotator import Rotator
+from data.screen import Screen
 from data.tournament import Tournament
 from utils.enum import Result
 from web.utils import RequestUtils
@@ -158,46 +161,56 @@ class SetByeGuard(BaseGuard):
         self._authorize_action(action, client)
 
 
-class ViewScreenEntityGuard(BaseGuard, ABC):
-    """Base guard for validating viewing a private / public screen entity."""
-
+class ViewScreenEntityGuard[T](BaseGuard, ABC):
     @staticmethod
     @abstractmethod
-    def is_public(request: HTMXRequest) -> bool:
-        """Get the visibility status of the entity."""
+    def get_entity(request: HTMXRequest) -> T | None:
+        """Get the optional entity from the request."""
+
+    @staticmethod
+    def is_entity_public(entity: T) -> bool:
+        return entity.public
 
     def authorize_client(self, client: Client, request: HTMXRequest):
-        if not self.is_public(request):
-            self._authorize_action(AuthAction.VIEW_PRIVATE_SCREENS, client)
-        else:
-            self._authorize_action(AuthAction.VIEW_PUBLIC_SCREENS, client)
+        entity = self.get_entity(request)
+        if not entity:
+            return
+        action = (
+            AuthAction.VIEW_PUBLIC_SCREENS
+            if self.is_entity_public(entity)
+            else AuthAction.VIEW_PRIVATE_SCREENS
+        )
+        self._authorize_action(action, client)
 
 
-class ViewScreenGuard(ViewScreenEntityGuard):
+class ViewScreenGuard(ViewScreenEntityGuard[Screen]):
     """Guard validating if a client can view a screen.
-    requires: event_uniq_id, screen_uniq_id."""
+    requires: event_uniq_id
+    optional: screen_uniq_id."""
 
     @staticmethod
-    def is_public(request: HTMXRequest) -> bool:
-        return RequestUtils.get_screen(request).public
+    def get_entity(request: HTMXRequest) -> Screen | None:
+        return RequestUtils.get_optional_screen(request)
 
 
-class ViewRotatorGuard(ViewScreenEntityGuard):
+class ViewRotatorGuard(ViewScreenEntityGuard[Rotator]):
     """Guard validating if a client can view a rotator.
-    requires: event_uniq_id, rotator_id."""
+    requires: event_uniq_id
+    optional: rotator_id."""
 
     @staticmethod
-    def is_public(request: HTMXRequest) -> bool:
-        return RequestUtils.get_rotator(request).public
+    def get_entity(request: HTMXRequest) -> Rotator | None:
+        return RequestUtils.get_optional_rotator(request)
 
 
-class ViewDisplayControllerGuard(ViewScreenEntityGuard):
+class ViewDisplayControllerGuard(ViewScreenEntityGuard[DisplayController]):
     """Guard validating if a client can view a display controller.
-    requires: event_uniq_id, display_controller_id."""
+    requires: event_uniq_id
+    optional: display_controller_id."""
 
     @staticmethod
-    def is_public(request: HTMXRequest) -> bool:
-        return RequestUtils.get_display_controller(request).public
+    def get_entity(request: HTMXRequest) -> DisplayController | None:
+        return RequestUtils.get_optional_display_controller(request)
 
 
 class ManageScreenEntityGuard(BaseGuard):

--- a/src/web/settings.py
+++ b/src/web/settings.py
@@ -59,11 +59,7 @@ from web.controllers.background_controller import BackgroundController
 from web.controllers.index_controller import IndexController
 from web.controllers.qrcode_controller import QRCodeController
 from web.controllers.user.screen_user_controller import ScreenUserController
-from web.controllers.user.tournament_user_controller import (
-    CheckInUserController,
-    IllegalMoveUserController,
-    ResultUserController,
-)
+from web.controllers.user.input_user_controller import InputUserController
 from web.sqlite_store import SQLiteStore
 from web.session_backend import SkipUnchangedSessionBackend
 
@@ -85,9 +81,7 @@ _route_handlers: Sequence[ControllerRouterHandler] = [
     IndexController,
     BackgroundController,
     ScreenUserController,
-    ResultUserController,
-    CheckInUserController,
-    IllegalMoveUserController,
+    InputUserController,
     IndexAdminController,
     EventAdminController,
     EventDocumentsController,

--- a/src/web/templates/user/modals/check_in_modal.html
+++ b/src/web/templates/user/modals/check_in_modal.html
@@ -8,7 +8,20 @@
                 <button
                     class="result-button white text-black bg-white ms-auto me-auto btn fs-4 fw-bold p-3"
                     style="width: fit-content;"
-                    hx-patch="{{ url_for('user-toggle-check-in', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, player_id=tournament_player.id) }}"
+                    hx-patch="{{ url_for(
+                            'user-toggle-check-in',
+                            event_uniq_id=user_event.uniq_id,
+                            display_controller_id=display_controller.id,
+                            tournament_id=tournament.id,
+                            player_id=tournament_player.id
+                        ) if display_controller else url_for(
+                            'user-toggle-check-in',
+                            is_screen=1,
+                            event_uniq_id=user_event.uniq_id,
+                            screen_uniq_id=screen.uniq_id,
+                            tournament_id=tournament.id,
+                            player_id=tournament_player.id
+                        ) }}"
                     hx-target="body"
                     hx-indicator="#please-wait"
                 >{% if not tournament_player.check_in %}{{ _('CHECK-IN') }}{% else %}{{ _('CHECK-OUT') }}{% endif %}<br/><br/>{{ tournament_player.last_name }}<br/>{{ tournament_player.first_name }}<br/>{{ tournament_player.rating_str }}</button>

--- a/src/web/templates/user/modals/results_modal.html
+++ b/src/web/templates/user/modals/results_modal.html
@@ -1,5 +1,26 @@
 {% set wtp = board.white_tournament_player %}
 {% set btp = board.black_tournament_player %}
+
+{% macro result_update_url(result) %}
+    {{ url_for(
+        'user-update-result',
+        event_uniq_id=user_event.uniq_id,
+        display_controller_id=display_controller.id,
+        tournament_id=tournament.id,
+        round=tournament.current_round,
+        board_id=board.id,
+        result=result,
+    ) if display_controller else url_for(
+        'user-update-result',
+        is_screen=1,
+        event_uniq_id=user_event.uniq_id,
+        screen_uniq_id=screen.uniq_id,
+        tournament_id=tournament.id,
+        round=tournament.current_round,
+        board_id=board.id,
+        result=result,
+    ) }}
+{% endmacro %}
 <div class="modal-dialog input-screen-result-modal">
     <div class="modal-content bg-secondary-subtle">
         <div class="modal-header">
@@ -13,7 +34,7 @@
                     {% if board.result and not client.can_update_results(wtp.tournament.id) %}
                         disabled
                     {% else %}
-                        hx-put="{{ url_for('user-add-result', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, round=tournament.current_round, board_id=board.id, result=3) }}"
+                        hx-put="{{ result_update_url(3) }}"
                         hx-target="body"
                         hx-indicator="#please-wait"
                     {% endif %}
@@ -24,7 +45,7 @@
                     {% if board.result and not client.can_update_results(wtp.tournament.id) %}
                         disabled
                     {% else %}
-                        hx-put="{{ url_for('user-add-result', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, round=tournament.current_round, board_id=board.id, result=2) }}"
+                        hx-put="{{ result_update_url(2) }}"
                         hx-target="body"
                         hx-indicator="#please-wait"
                     {% endif %}
@@ -35,7 +56,7 @@
                     {% if board.result and not client.can_update_results(wtp.tournament.id) %}
                         disabled
                     {% else %}
-                        hx-put="{{ url_for('user-add-result', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, round=tournament.current_round, board_id=board.id, result=1) }}"
+                        hx-put="{{ result_update_url(1) }}"
                         hx-target="body"
                         hx-indicator="#please-wait"
                     {% endif %}
@@ -46,21 +67,21 @@
                     <button
                         data-testid="white-wins-by-forfeit-button"
                         class="admin-result-button white text-black bg-white col-3 ms-auto me-auto btn fs-4 fw-bold p-3"
-                        hx-put="{{ url_for('user-add-result', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, round=tournament.current_round, board_id=board.id, result=6) }}"
+                        hx-put="{{ result_update_url(6) }}"
                         hx-target="body"
                         hx-indicator="#please-wait"
                     >{{ _('WHITE WINS') }}<br/>{{ _('BY FORFEIT') }}<br/>1 - F</button>
                     <button
                         data-testid="double-forfeit-button"
                         class="admin-result-button draw col-3 ms-auto me-auto btn fs-4 fw-bold p-3"
-                        hx-put="{{ url_for('user-add-result', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, round=tournament.current_round, board_id=board.id, result=5) }}"
+                        hx-put="{{ result_update_url(5) }}"
                         hx-target="body"
                         hx-indicator="#please-wait"
                     >{{ _('DOUBLE') }}<br/>{{ _('FORFEIT') }}<br/>F - F</button>
                     <button
                         data-testid="black-wins-by-forfeit-button"
                         class="admin-result-button black text-white bg-black col-3 ms-auto me-auto btn fs-4 fw-bold p-3"
-                        hx-put="{{ url_for('user-add-result', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, round=tournament.current_round, board_id=board.id, result=4) }}"
+                        hx-put="{{ result_update_url(4) }}"
                         hx-target="body"
                         hx-indicator="#please-wait"
                     >{{ _('BLACK WINS') }}<br/>{{ _('BY FORFEIT') }}<br/>F - 1</button>
@@ -76,7 +97,7 @@
                         disabled
                     {% else %}
                         hx-trigger="click"
-                        hx-delete="{{ url_for('user-delete-result', event_uniq_id=user_event.uniq_id, screen_uniq_id=screen.uniq_id, tournament_id=tournament.id, round=tournament.current_round, board_id=board.id) }}"
+                        hx-put="{{ result_update_url(0) }}"
                         hx-target="body"
                         hx-indicator="#please-wait"
                     {% endif %}

--- a/src/web/templates/user/screen.html
+++ b/src/web/templates/user/screen.html
@@ -25,10 +25,21 @@
         {% if display_controller %}
             <div
                 class="refresher display-controller-refresher"
-                {% if not is_rotator %}
+                {% if is_rotator %}
+                    hx-get="{{ url_for(
+                        'user-display-controller',
+                        event_uniq_id=user_event.uniq_id,
+                        display_controller_id=display_controller.id,
+                        rotator_screen_index=rotator_screen_index + 1,
+                    ) }}"
+                {% else %}
+                    hx-get="{{ url_for(
+                        'user-display-controller',
+                        event_uniq_id=user_event.uniq_id,
+                        display_controller_id=display_controller.id,
+                    ) }}"
                     hx-headers='{"If-Modified-Since": "{{ now_http_date }}"}'
                 {% endif %}
-                hx-get="{{ url_for('user-display-controller', event_uniq_id=user_event.uniq_id, display_controller_id=display_controller.id, rotator_screen_index=rotator_screen_index + 1) }}"
                 hx-trigger="{{ becomes_visible }} every {{ display_controller.delay }}s[{{ refresh_conditions }}]"
                 hx-target="body"
                 hx-indicator="#please-wait"

--- a/src/web/templates/user/screen/sets/board_row_illegal_moves_cell.html
+++ b/src/web/templates/user/screen/sets/board_row_illegal_moves_cell.html
@@ -25,6 +25,13 @@
                         hx-delete="{{ url_for(
                             'user-delete-illegal-move',
                             event_uniq_id=user_event.uniq_id,
+                            display_controller_id=display_controller.id,
+                            tournament_id=tournament.id,
+                            player_id=tournament_player.id
+                        ) if display_controller else url_for(
+                            'user-delete-illegal-move',
+                            is_screen=1,
+                            event_uniq_id=user_event.uniq_id,
                             screen_uniq_id=screen.uniq_id,
                             tournament_id=tournament.id,
                             player_id=tournament_player.id
@@ -43,6 +50,13 @@
                         hx-target="body"
                         hx-put="{{ url_for(
                             'user-add-illegal-move',
+                            event_uniq_id=user_event.uniq_id,
+                            display_controller_id=display_controller.id,
+                            tournament_id=tournament.id,
+                            player_id=tournament_player.id
+                        ) if display_controller else url_for(
+                            'user-add-illegal-move',
+                            is_screen=1,
                             event_uniq_id=user_event.uniq_id,
                             screen_uniq_id=screen.uniq_id,
                             tournament_id=tournament.id,

--- a/src/web/templates/user/screen/sets/boards_set.html
+++ b/src/web/templates/user/screen/sets/boards_set.html
@@ -65,6 +65,13 @@
                                         hx-get="{{ url_for(
                                             'user-result-modal',
                                             event_uniq_id=user_event.uniq_id,
+                                            display_controller_id=display_controller.id,
+                                            tournament_id=tournament.id,
+                                            board_id=board.id
+                                        ) if display_controller else url_for(
+                                            'user-result-modal',
+                                            is_screen=1,
+                                            event_uniq_id=user_event.uniq_id,
                                             screen_uniq_id=screen.uniq_id,
                                             tournament_id=tournament.id,
                                             board_id=board.id

--- a/src/web/templates/user/screen/sets/player_row_player_cell.html
+++ b/src/web/templates/user/screen/sets/player_row_player_cell.html
@@ -17,6 +17,13 @@
         hx-get="{{ url_for(
             'user-checkin-modal',
             event_uniq_id=user_event.uniq_id,
+            display_controller_id=display_controller.id,
+            tournament_id=tournament.id,
+            player_id=player.id
+        ) if display_controller else url_for(
+            'user-checkin-modal',
+            is_screen=1,
+            event_uniq_id=user_event.uniq_id,
             screen_uniq_id=screen.uniq_id,
             tournament_id=tournament.id,
             player_id=player.id

--- a/src/web/utils.py
+++ b/src/web/utils.py
@@ -109,6 +109,13 @@ class RequestUtils:
         request.state[cls.REQUEST_SCREEN_ATTR] = screen
         return screen
 
+    @classmethod
+    def get_optional_screen(cls, request: HTMXRequest) -> Screen | None:
+        try:
+            return cls.get_screen(request)
+        except ValidationException:
+            return None
+
     REQUEST_ROTATOR_ATTR: str = 'sharly_chess_rotator'
     ROTATOR_ID_PARAM: str = 'rotator_id'
 
@@ -151,6 +158,15 @@ class RequestUtils:
             )
         request.state[cls.REQUEST_DISPLAY_CONTROLLER_ATTR] = display_controller
         return display_controller
+
+    @classmethod
+    def get_optional_display_controller(
+        cls, request: HTMXRequest
+    ) -> DisplayController | None:
+        try:
+            return cls.get_display_controller(request)
+        except ValidationException:
+            return None
 
     REQUEST_TOURNAMENT_ATTR: str = 'sharly_chess_tournament'
     TOURNAMENT_ID_PARAM: str = 'tournament_id'

--- a/tests/e2e/access_levels/base_access_level_test.py
+++ b/tests/e2e/access_levels/base_access_level_test.py
@@ -424,7 +424,7 @@ class BaseAccessLevelTest:
                 )
 
             api_request_context.put(
-                f'/view/add-illegal-move/{PUBLIC_EVENT_ID}/{self.paired_screen.uniq_id}/{self.paired_tournament.id}/{alyx.id}'
+                f'/view/add-illegal-move/1/{PUBLIC_EVENT_ID}/{self.paired_screen.uniq_id}/{self.paired_tournament.id}/{alyx.id}'
             )
             expect(illegal_move_icon).to_be_visible()
             expect(illegal_move_icon).not_to_have_attribute(

--- a/tests/e2e/screens/test_single_screens.py
+++ b/tests/e2e/screens/test_single_screens.py
@@ -123,7 +123,7 @@ class TestSingleScreensFunctionality:
 
         # Test that the page is updated after a player checks in on another screen
         api_request_context.patch(
-            f'/view/toggle-check-in/{EVENT_ID}/{SCREEN_ID}/{unpaired_tournament.id}/{barbara.id}'
+            f'/view/toggle-check-in/1/{EVENT_ID}/{SCREEN_ID}/{unpaired_tournament.id}/{barbara.id}'
         )
 
         row = rows.filter(has_text='BARBARA')


### PR DESCRIPTION
To reproduce: 
- Create screen A (input) and screen B (players)
- create a display controller DC
- associate A to DC
- Open DC in tab T --> Displays A
-  input a result from DC
- Associate B to DC

--> T displays A instead of B
