### PR TITLE
Prevent database locked error on SCE schools tournament import

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@
 
 - Added missing timeouts (4.2.0)
 - Prevent moving players from a synced tournament to a not-synced tournament (4.2.0)
+- Fixed tournament import of schools tournaments (4.2.1)
 
 ## _FFE_
 

--- a/src/plugins/ffe/ffe.py
+++ b/src/plugins/ffe/ffe.py
@@ -1001,6 +1001,7 @@ class FfePlugin(Plugin):
         event: 'Event',
         stored_player: StoredPlayer,
         sync_data: SCEPlayerSyncData,
+        database: EventDatabase | None,
     ):
         plugin_data = FfePlayerPluginData.from_stored_value(
             stored_player.plugin_data.get(PLUGIN_NAME, {})

--- a/src/plugins/fra_schools/fra_schools.py
+++ b/src/plugins/fra_schools/fra_schools.py
@@ -26,6 +26,7 @@ from data.print_documents.documents import (
 )
 from data.print_documents.player_splitters import ClubPlayerSplitter
 from data.tie_breaks.system_sets import SystemTieBreakSet
+from database.sqlite.event.event_database import EventDatabase
 from database.sqlite.event.event_store import (
     StoredEvent,
     StoredTournament,
@@ -523,6 +524,7 @@ class FRASchoolsPlugin(Plugin):
         event: Event,
         stored_player: StoredPlayer,
         sync_data: SCEPlayerSyncData,
+        database: EventDatabase | None,
     ):
         plugin_data = FRASchoolsPlayerPluginData.from_stored_value(
             stored_player.plugin_data.get(PLUGIN_NAME, {})
@@ -539,7 +541,9 @@ class FRASchoolsPlugin(Plugin):
                 else:
                     school = FRASchool.from_label(sce_school.label)
                     school.code = sce_school.code
-                    school_id = FRASchoolsUtils.add_event_school(event, school)
+                    school_id = FRASchoolsUtils.add_event_school(
+                        event, school, database=database
+                    )
         plugin_data.fra_school_id = school_id
         stored_player.plugin_data[PLUGIN_NAME] = plugin_data.to_stored_value()
 

--- a/src/plugins/fra_schools/utils.py
+++ b/src/plugins/fra_schools/utils.py
@@ -291,6 +291,7 @@ class FRASchoolsUtils:
         school: FRASchool,
         update_existing: bool = False,
         save: bool = True,
+        database: EventDatabase | None = None,
     ) -> int:
         """Add a school to the event, returning its ID.
         If a school already exists with the same code:
@@ -315,8 +316,11 @@ class FRASchoolsUtils:
         plugin_data.fra_schools_by_id[school_id] = school
         event.stored_event.plugin_data[PLUGIN_NAME] = plugin_data.to_stored_value()
         if save:
-            with EventDatabase(event.uniq_id, True) as database:
+            if database:
                 database.update_stored_event(event.stored_event)
+            else:
+                with EventDatabase(event.uniq_id, True) as database:
+                    database.update_stored_event(event.stored_event)
         return school_id
 
     @classmethod

--- a/src/plugins/sce/locale/babel.cfg
+++ b/src/plugins/sce/locale/babel.cfg
@@ -2,4 +2,4 @@
 
 [jinja2: src/plugins/sce/**/*.html]
 
-[jinja2: src/plugins/sce/**/*.j2]
+[jinja2: src/plugins/sce/**/*.js]

--- a/src/plugins/sce/locale/en/LC_MESSAGES/sce.po
+++ b/src/plugins/sce/locale/en/LC_MESSAGES/sce.po
@@ -345,6 +345,9 @@ msgstr ""
 msgid "Synchronize players"
 msgstr ""
 
+msgid "This field is controlled from Sharly-Chess.com."
+msgstr ""
+
 msgid "Time control"
 msgstr ""
 

--- a/src/plugins/sce/locale/fr/LC_MESSAGES/sce.po
+++ b/src/plugins/sce/locale/fr/LC_MESSAGES/sce.po
@@ -345,6 +345,9 @@ msgstr "Synchroniser automatiquement toutes les %(delay)d minutes."
 msgid "Synchronize players"
 msgstr "Synchroniser les joueur·euses"
 
+msgid "This field is controlled from Sharly-Chess.com."
+msgstr "Ce champ est controllé depuis Sharly-Chess.com."
+
 msgid "Time control"
 msgstr "Cadence"
 

--- a/src/plugins/sce/sce.py
+++ b/src/plugins/sce/sce.py
@@ -71,6 +71,7 @@ class SCEPluginHooks:
         event: Event,
         stored_player: 'StoredPlayer',
         sync_data: SCEPlayerSyncData,
+        database: EventDatabase | None,
     ):
         """Augment a stored player from SCE player shared data."""
 

--- a/src/plugins/sce/sce_data.py
+++ b/src/plugins/sce/sce_data.py
@@ -9,6 +9,7 @@ from data.criteria.tournament_criteria import TournamentCriterion
 from data.event import Event
 from data.player import TournamentPlayer, Player, MIN_YOB
 from data.tournament import Tournament
+from database.sqlite.event.event_database import EventDatabase
 from database.sqlite.event.event_store import StoredTournament, StoredPlayer
 from database.sqlite.sqlite_database import SQLiteDatabase
 from plugins.ffe.utils import PlayerFFELicence
@@ -510,6 +511,7 @@ class SCEPlayerSyncData:
         tournament: Tournament,
         current_rating: int | None = None,
         current_rating_type: PlayerRatingType | None = None,
+        database: EventDatabase | None = None,
     ) -> None:
         event = tournament.event
         stored_player.first_name = self.first_name
@@ -539,7 +541,12 @@ class SCEPlayerSyncData:
         stored_player.plugin_data[PLUGIN_NAME] = plugin_data.to_stored_value()
         plugin_manager.hook_for_event(
             event, 'augment_stored_player_from_sce_player_sync_data'
-        )(event=event, stored_player=stored_player, sync_data=self)
+        )(
+            event=event,
+            stored_player=stored_player,
+            sync_data=self,
+            database=database,
+        )
 
     @staticmethod
     def diff_fields_by_property_name(event: Event) -> dict[str, str]:

--- a/src/plugins/sce/sce_session.py
+++ b/src/plugins/sce/sce_session.py
@@ -459,7 +459,7 @@ class SCESession(Session):
                 PLUGIN_NAME: SCEPlayerPluginData(id=sce_id).to_stored_value(),
             },
         )
-        sync_data.augment_stored_player(stored_player, tournament)
+        sync_data.augment_stored_player(stored_player, tournament, database=database)
         duplicate_player = self.event.get_player_duplicate(stored_player, tournament)
         if not duplicate_player:
             stored_player.id = database.add_stored_player(stored_player)

--- a/src/plugins/sce/templates/sce_event_form_script.js
+++ b/src/plugins/sce/templates/sce_event_form_script.js
@@ -7,10 +7,11 @@
 var sceTooltipByFieldId = {};
 $('#{{ plugin.form_key }}').change(function () {
     if (this.checked) {
+        const message = `{{ _('This field is controlled from Sharly-Chess.com.') }}`
         {% for id in field_ids %}
             var inputContainer = document.getElementById('{{ id }}-input-container');
             sceTooltipByFieldId['{{ id }}'] = new bootstrap.Tooltip(inputContainer, {
-                title: `{{ _('This field is controlled from Sharly-Chess.com.') }}`,
+                title: message,
                 placement: 'top',
             });
             $('#{{ id }}').prop('disabled', true);


### PR DESCRIPTION
To reproduce: 
- create a schools tournament on sc.com
- add a player with a school
- import the event to the local app

--> DB locked error: trying to open the DB to add the new school while the DB is already opened 