### PR TITLE
Fix Toga 0.5.3+ startup error message and locale issue

### DIFF
--- a/src/gui/server_gui_toga.py
+++ b/src/gui/server_gui_toga.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import locale
 import logging
 import os
 import queue
@@ -286,6 +287,31 @@ class SharlyChessServerToga(toga.App):
         # Use FLATPAK_ID if available to match the sandbox ID
         app_id = os.environ.get('FLATPAK_ID', 'com.sharlychess.app')
 
+        # On Windows, the following error message is printed when searching for a valid .NET Core:
+        #
+        # You must install or update .NET to run this application.
+        #
+        # App: C:\OneDrive\echecs\sharly-chess\dev\.venv-3.13\Scripts\python.exe
+        # Architecture: x64
+        # Framework: 'Microsoft.NETCore.App' version '10.0.0' (x64)
+        # .NET location: C:\ProgramFiles\dotnet
+        #
+        # The following frameworks were found:
+        # 6.0.4 at [C:\ProgramFiles\dotnet\shared\Microsoft.NETCore.App]
+        # 9.0.11 at [C:\ProgramFiles\dotnet\shared\Microsoft.NETCore.App]
+        #
+        # Learn more:
+        # https://aka.ms/dotnet/app-launch-failed
+        #
+        # To install missing framework, download:
+        # https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=10.0.0&arch=x64&rid=win-x64&os=win10
+        #
+        # Explicitly request .NET Framework 4.x by setting this variable.
+        # See:
+        # - toga_winforms/__init__.py
+        # - toga_winforms/resources/runtime.json
+        os.environ['TOGA_WINFORMS_USE_NETFX'] = '1'
+
         super().__init__(
             formal_name='Sharly Chess',
             app_id=app_id,
@@ -293,6 +319,16 @@ class SharlyChessServerToga(toga.App):
             home_page='https://sharly-chess.com',
             version=str(SHARLY_CHESS_VERSION),
         )
+
+        # reset the locale after having called toga.App.__init__(), needed by Togo 0.5.3+
+        locale.setlocale(
+            locale.LC_ALL,
+            (
+                None,
+                None,
+            ),
+        )
+
         self.debug = debug
         self.port = port
 

--- a/src/gui/server_gui_toga.py
+++ b/src/gui/server_gui_toga.py
@@ -287,29 +287,8 @@ class SharlyChessServerToga(toga.App):
         # Use FLATPAK_ID if available to match the sandbox ID
         app_id = os.environ.get('FLATPAK_ID', 'com.sharlychess.app')
 
-        # On Windows, the following error message is printed when searching for a valid .NET Core:
-        #
-        # You must install or update .NET to run this application.
-        #
-        # App: C:\OneDrive\echecs\sharly-chess\dev\.venv-3.13\Scripts\python.exe
-        # Architecture: x64
-        # Framework: 'Microsoft.NETCore.App' version '10.0.0' (x64)
-        # .NET location: C:\ProgramFiles\dotnet
-        #
-        # The following frameworks were found:
-        # 6.0.4 at [C:\ProgramFiles\dotnet\shared\Microsoft.NETCore.App]
-        # 9.0.11 at [C:\ProgramFiles\dotnet\shared\Microsoft.NETCore.App]
-        #
-        # Learn more:
-        # https://aka.ms/dotnet/app-launch-failed
-        #
-        # To install missing framework, download:
-        # https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=10.0.0&arch=x64&rid=win-x64&os=win10
-        #
-        # Explicitly request .NET Framework 4.x by setting this variable.
-        # See:
-        # - toga_winforms/__init__.py
-        # - toga_winforms/resources/runtime.json
+        # Explicitly request .NET Framework 4.x by setting this variable
+        # (see https://github.com/Sharly-Chess/sharly-chess/pull/2098)
         os.environ['TOGA_WINFORMS_USE_NETFX'] = '1'
 
         super().__init__(


### PR DESCRIPTION
On Windows with Toga 0.5.3+, the following error message is printed when searching for a valid .NET Core:
```
You must install or update .NET to run this application.

App: C:\OneDrive\echecs\sharly-chess\dev\.venv-3.13\Scripts\python.exe
Architecture: x64
Framework: 'Microsoft.NETCore.App' version '10.0.0' (x64)
.NET location: C:\ProgramFiles\dotnet

The following frameworks were found:
6.0.4 at [C:\ProgramFiles\dotnet\shared\Microsoft.NETCore.App]
9.0.11 at [C:\ProgramFiles\dotnet\shared\Microsoft.NETCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=10.0.0&arch=x64&rid=win-x64&os=win10
```

Setting variable `TOGA_WINFORMS_USE_NETFX` explicitly requests .NET Framework 4.x (see `toga_winforms/__init__.py` and `toga_winforms/resources/runtime.json`).