### PR TITLE
Add V5 install instructions from V4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,4 +35,4 @@ MACOS_SIGNING_CERT_PASSWORD=your_certificate_password_here
 
 # Test variables for testing the V4 - V5 transition
 DEV_LATEST_VERSION=5.0.0
-DEV_WINDOWS_INSTALLER_PATH="export/Sharly Chess Setup 5.0.0.exe"
+DEV_WINDOWS_INSTALLER_PATH="export/Sharly Chess Installer 5.0.0.exe"

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,6 @@ MACOS_SIGNING_CERT_BASE64=MIIKoQIBAzCCCl0GCSqGSIb3DQEHAaCCCk4EggpKMIIKRjCCBQIGCS
 
 # Password for the .p12 certificate file
 MACOS_SIGNING_CERT_PASSWORD=your_certificate_password_here
+
+# Fake that the version 5 is available
+FAKE_V5_AVAILABLE=1

--- a/.env.example
+++ b/.env.example
@@ -35,4 +35,4 @@ MACOS_SIGNING_CERT_PASSWORD=your_certificate_password_here
 
 # Test variables for testing the V4 - V5 transition
 DEV_LATEST_VERSION=5.0.0
-DEV_WINDOWS_SETUP_PATH="export/Sharly Chess Setup 5.0.0.exe"
+DEV_WINDOWS_INSTALLER_PATH="export/Sharly Chess Setup 5.0.0.exe"

--- a/.env.example
+++ b/.env.example
@@ -33,5 +33,6 @@ MACOS_SIGNING_CERT_BASE64=MIIKoQIBAzCCCl0GCSqGSIb3DQEHAaCCCk4EggpKMIIKRjCCBQIGCS
 # Password for the .p12 certificate file
 MACOS_SIGNING_CERT_PASSWORD=your_certificate_password_here
 
-# Fake that the version 5 is available
-FAKE_V5_AVAILABLE=1
+# Test variables for testing the V4 - V5 transition
+DEV_LATEST_VERSION=5.0.0
+DEV_WINDOWS_SETUP_PATH="export/Sharly Chess Setup 5.0.0.exe"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - Prevent reloading templates (4.2.1)
 - Fixed double form submission using the `Enter` key (4.2.4)
 - Fix previous version recovery freeze (4.2.5)
+- Added update instructions for version 5 (4.2.6)
 
 ## Tournaments
 

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -289,9 +289,6 @@ msgstr "SC_T"
 msgid "*** MACOS INSTALL URL"
 msgstr "https://sharly-chess.com/installation-mac/"
 
-msgid "*** WINDOWS INSTALL URL"
-msgstr "https://sharly-chess.com/installation-windows/"
-
 msgid "- *** NAME FOR GENDER NONE"
 msgstr "-"
 
@@ -526,6 +523,9 @@ msgid "<smart_count> week |||| <smart_count> weeks"
 msgstr ""
 
 msgid "A file is expected."
+msgstr ""
+
+msgid "A new version is available. Do you want to install it now"
 msgstr ""
 
 msgid "A player with {column}=[{value}] already exists in the event."
@@ -803,6 +803,9 @@ msgid "Allows pairing of the players, either using a pairing engine or manually"
 msgstr ""
 
 msgid "An error occurred. Consult the logs for more details."
+msgstr ""
+
+msgid "An installer program will start after closing this message."
 msgstr ""
 
 msgid "An integer greater than 1 is expected."
@@ -2100,10 +2103,10 @@ msgstr ""
 msgid "Do you want to install example event databases"
 msgstr ""
 
-msgid "Do you want to install it now"
+msgid "Do you want to recover the data of release [{version}]"
 msgstr ""
 
-msgid "Do you want to recover the data of release [{version}]"
+msgid "Do you want to try again"
 msgstr ""
 
 msgid "Do you want to upgrade from [{old_version}] to [{new_version}]"
@@ -2137,9 +2140,6 @@ msgid "Download"
 msgstr ""
 
 msgid "Download the DMG file from the website that just opened, open it, then copy the application to your Applications folder and run it from there."
-msgstr ""
-
-msgid "Download the installer executable from the page that just opened, then run it."
 msgstr ""
 
 msgid "Download the players matching the search into a file."
@@ -5589,7 +5589,10 @@ msgstr ""
 msgid "Sharing threshold"
 msgstr ""
 
-msgid "Sharly Chess 5 is available!"
+msgid "Sharly Chess - Error"
+msgstr ""
+
+msgid "Sharly Chess - Update"
 msgstr ""
 
 msgid "Sharly Chess Server"
@@ -5990,6 +5993,9 @@ msgid "The forecast becomes available once the last round is paired. Once the to
 msgstr ""
 
 msgid "The installation and update processes have been reworked."
+msgstr ""
+
+msgid "The installer program could not be downloaded. Consult the logs for more details."
 msgstr ""
 
 msgid "The least and the most significant values are removed."

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -286,6 +286,12 @@ msgstr "SC_M"
 msgid "*** KEYBOARD SHORTCUT FOR THE TOURNAMENTS TAB"
 msgstr "SC_T"
 
+msgid "*** MACOS INSTALL URL"
+msgstr "https://sharly-chess.com/installation-mac/"
+
+msgid "*** WINDOWS INSTALL URL"
+msgstr "https://sharly-chess.com/installation-windows/"
+
 msgid "- *** NAME FOR GENDER NONE"
 msgstr "-"
 
@@ -1793,6 +1799,9 @@ msgstr ""
 msgid "Data loss at tournaments, players and pairings level."
 msgstr ""
 
+msgid "Data recovery"
+msgstr ""
+
 msgid "Data source"
 msgstr ""
 
@@ -2091,6 +2100,9 @@ msgstr ""
 msgid "Do you want to install example event databases"
 msgstr ""
 
+msgid "Do you want to install it now"
+msgstr ""
+
 msgid "Do you want to recover the data of release [{version}]"
 msgstr ""
 
@@ -2122,6 +2134,12 @@ msgid "Double-round Berger"
 msgstr ""
 
 msgid "Download"
+msgstr ""
+
+msgid "Download the DMG file from the website that just opened, then drop it into your Applications folder."
+msgstr ""
+
+msgid "Download the installer executable from the page that just opened, then run it."
 msgstr ""
 
 msgid "Download the players matching the search into a file."
@@ -2494,6 +2512,9 @@ msgid "Events"
 msgstr ""
 
 msgid "Events ({num})"
+msgstr ""
+
+msgid "Example databases"
 msgstr ""
 
 msgid "Exclude"
@@ -3103,10 +3124,19 @@ msgstr ""
 msgid "Install"
 msgstr ""
 
+msgid "Install version 5"
+msgstr ""
+
+msgid "Installation error"
+msgstr ""
+
 msgid "Installation of [{lib}] failed."
 msgstr ""
 
 msgid "Installation of release [{version}] failed, exiting."
+msgstr ""
+
+msgid "Installation succeeded"
 msgstr ""
 
 msgid "Installed [{lib}]."
@@ -5559,6 +5589,9 @@ msgstr ""
 msgid "Sharing threshold"
 msgstr ""
 
+msgid "Sharly Chess 5 is available!"
+msgstr ""
+
 msgid "Sharly Chess Server"
 msgstr ""
 
@@ -5584,6 +5617,9 @@ msgid "Sharly Chess settings"
 msgstr ""
 
 msgid "Sharly Chess settings have been updated."
+msgstr ""
+
+msgid "Sharly Chess upgrade"
 msgstr ""
 
 msgid "Sharly Chess using the local network, all the traffic is public. This means anyone connected to the same network could easily gain access to an account without needing to type in the password."
@@ -5924,6 +5960,9 @@ msgstr ""
 msgid "The currency used to represent monetary prizes (defaults to the currency of the event federation)."
 msgstr ""
 
+msgid "The data of this version will be recovered when starting the new version."
+msgstr ""
+
 msgid "The default federation for your events."
 msgstr ""
 
@@ -5948,6 +5987,9 @@ msgid "The following features won't be imported:"
 msgstr ""
 
 msgid "The forecast becomes available once the last round is paired. Once the tournament finishes, this report will list every achieved norm."
+msgstr ""
+
+msgid "The installation and update processes have been reworked in version 5."
 msgstr ""
 
 msgid "The least and the most significant values are removed."
@@ -7595,4 +7637,10 @@ msgstr ""
 
 msgid "← Back to IT1 certificate"
 msgstr ""
+
+#~ msgid ""
+#~ "The installation and update processes have been reworked in version 5.\n"
+#~ "\n"
+#~ "Do you want to install it now"
+#~ msgstr ""
 

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -2136,7 +2136,7 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-msgid "Download the DMG file from the website that just opened, then drop it into your Applications folder."
+msgid "Download the DMG file from the website that just opened, open it, then copy the application to your Applications folder and run it from there."
 msgstr ""
 
 msgid "Download the installer executable from the page that just opened, then run it."
@@ -5989,7 +5989,7 @@ msgstr ""
 msgid "The forecast becomes available once the last round is paired. Once the tournament finishes, this report will list every achieved norm."
 msgstr ""
 
-msgid "The installation and update processes have been reworked in version 5."
+msgid "The installation and update processes have been reworked."
 msgstr ""
 
 msgid "The least and the most significant values are removed."
@@ -7642,5 +7642,11 @@ msgstr ""
 #~ "The installation and update processes have been reworked in version 5.\n"
 #~ "\n"
 #~ "Do you want to install it now"
+#~ msgstr ""
+
+#~ msgid "Download the DMG file from the website that just opened, then drop it into your Applications folder."
+#~ msgstr ""
+
+#~ msgid "The installation and update processes have been reworked in version 5."
 #~ msgstr ""
 

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -286,9 +286,6 @@ msgstr "SC_M"
 msgid "*** KEYBOARD SHORTCUT FOR THE TOURNAMENTS TAB"
 msgstr "SC_T"
 
-msgid "*** MACOS INSTALL URL"
-msgstr "https://sharly-chess.com/installation-mac/"
-
 msgid "- *** NAME FOR GENDER NONE"
 msgstr "-"
 
@@ -523,9 +520,6 @@ msgid "<smart_count> week |||| <smart_count> weeks"
 msgstr ""
 
 msgid "A file is expected."
-msgstr ""
-
-msgid "A new version is available. Do you want to install it now"
 msgstr ""
 
 msgid "A player with {column}=[{value}] already exists in the event."
@@ -2103,6 +2097,9 @@ msgstr ""
 msgid "Do you want to install example event databases"
 msgstr ""
 
+msgid "Do you want to install the update now"
+msgstr ""
+
 msgid "Do you want to recover the data of release [{version}]"
 msgstr ""
 
@@ -3122,9 +3119,6 @@ msgid "Input screens show pairings by board number and allow people to enter res
 msgstr ""
 
 msgid "Install"
-msgstr ""
-
-msgid "Install version 5"
 msgstr ""
 
 msgid "Installation error"
@@ -5628,6 +5622,9 @@ msgstr ""
 msgid "Sharly Chess using the local network, all the traffic is public. This means anyone connected to the same network could easily gain access to an account without needing to type in the password."
 msgstr ""
 
+msgid "Sharly Chess {latest} is available, you have {current}."
+msgstr ""
+
 msgid "Should only be used when the wrong player has been added by mistake."
 msgstr ""
 
@@ -5963,7 +5960,7 @@ msgstr ""
 msgid "The currency used to represent monetary prizes (defaults to the currency of the event federation)."
 msgstr ""
 
-msgid "The data of this version will be recovered when starting the new version."
+msgid "The data of the current version will be recovered when starting the new version."
 msgstr ""
 
 msgid "The default federation for your events."

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -289,9 +289,6 @@ msgstr "SC_T"
 msgid "*** MACOS INSTALL URL"
 msgstr "https://sharly-chess.com/fr/installation-mac/"
 
-msgid "*** WINDOWS INSTALL URL"
-msgstr "https://sharly-chess.com/fr/installation-windows/"
-
 msgid "- *** NAME FOR GENDER NONE"
 msgstr "-"
 
@@ -527,6 +524,9 @@ msgstr "<smart_count> semaine |||| <smart_count> semaines"
 
 msgid "A file is expected."
 msgstr "Un fichier est attendu."
+
+msgid "A new version is available. Do you want to install it now"
+msgstr "Une nouvelle version est disponible. Voulez-vous l'installer maintenant"
 
 msgid "A player with {column}=[{value}] already exists in the event."
 msgstr "Un·e joueur·euse avec {column}=[{value}] existe déjà dans l'évènement."
@@ -804,6 +804,9 @@ msgstr "Autorise l'appariement des joueur·euses, en utilisant un moteur d'appar
 
 msgid "An error occurred. Consult the logs for more details."
 msgstr "Une erreur s'est produite. Consultez les logs pour plus de détails."
+
+msgid "An installer program will start after closing this message."
+msgstr "Un programme d'installation va démarrer après la fermeture de ce message."
 
 msgid "An integer greater than 1 is expected."
 msgstr "Un entier supérieur à 1 est attendu."
@@ -2100,11 +2103,11 @@ msgstr "Ne pas utiliser cet ordre comme classement."
 msgid "Do you want to install example event databases"
 msgstr "Voulez-vous installer des bases d'évènement d'exemple"
 
-msgid "Do you want to install it now"
-msgstr "Voulez-vous l'installer maintenant"
-
 msgid "Do you want to recover the data of release [{version}]"
 msgstr "Voulez-vous récupérer les données de la version [{version}]"
+
+msgid "Do you want to try again"
+msgstr "Voulez-vous réessayer"
 
 msgid "Do you want to upgrade from [{old_version}] to [{new_version}]"
 msgstr "Voulez-vous faire la mise à jour de [{old_version}] à [{new_version}]"
@@ -2138,9 +2141,6 @@ msgstr "Télécharger"
 
 msgid "Download the DMG file from the website that just opened, open it, then copy the application to your Applications folder and run it from there."
 msgstr "Téléchargez le fichier DMG depuis le navigateur qui vient de s'ouvrir, ouvrez-le, puis copiez l'application dans votre dossier Applications puis et exécutez-le."
-
-msgid "Download the installer executable from the page that just opened, then run it."
-msgstr "Télécharger l'exécutable d'installation depuis la page qui vient de s'ouvrir, puis exécutez le."
 
 msgid "Download the players matching the search into a file."
 msgstr "Télécharger un fichier contenant les joueur·euses correspondant à la recherche."
@@ -5591,8 +5591,11 @@ msgstr "Prix partagés"
 msgid "Sharing threshold"
 msgstr "Seuil de partage"
 
-msgid "Sharly Chess 5 is available!"
-msgstr "Sharly Chess 5 is available !"
+msgid "Sharly Chess - Error"
+msgstr "Sharly Chess - Erreur"
+
+msgid "Sharly Chess - Update"
+msgstr "Sharly Chess - Mise à jour"
 
 msgid "Sharly Chess Server"
 msgstr "Serveur Sharly Chess"
@@ -5993,6 +5996,9 @@ msgstr "Les prévisions sont disponibles une fois la dernière ronde appariée. 
 
 msgid "The installation and update processes have been reworked."
 msgstr "Les processus d'installation et de mise à jour ont été retravaillés."
+
+msgid "The installer program could not be downloaded. Consult the logs for more details."
+msgstr "Le programme d'installation n'a pas pu être téléchargé. Consultez les logs pour plus d'informations."
 
 msgid "The least and the most significant values are removed."
 msgid_plural "The {count} least and the {count} most significant values are removed."

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -286,6 +286,12 @@ msgstr "SC_M"
 msgid "*** KEYBOARD SHORTCUT FOR THE TOURNAMENTS TAB"
 msgstr "SC_T"
 
+msgid "*** MACOS INSTALL URL"
+msgstr "https://sharly-chess.com/fr/installation-mac/"
+
+msgid "*** WINDOWS INSTALL URL"
+msgstr "https://sharly-chess.com/fr/installation-windows/"
+
 msgid "- *** NAME FOR GENDER NONE"
 msgstr "-"
 
@@ -1793,6 +1799,9 @@ msgstr "Bordure pointillée"
 msgid "Data loss at tournaments, players and pairings level."
 msgstr "Perte de données au niveau du tournoi, des joueur·euses et des appariements."
 
+msgid "Data recovery"
+msgstr "Récupération de données"
+
 msgid "Data source"
 msgstr "Source de données"
 
@@ -2091,6 +2100,9 @@ msgstr "Ne pas utiliser cet ordre comme classement."
 msgid "Do you want to install example event databases"
 msgstr "Voulez-vous installer des bases d'évènement d'exemple"
 
+msgid "Do you want to install it now"
+msgstr "Voulez-vous l'installer maintenant"
+
 msgid "Do you want to recover the data of release [{version}]"
 msgstr "Voulez-vous récupérer les données de la version [{version}]"
 
@@ -2123,6 +2135,12 @@ msgstr "Berger aller-retour"
 
 msgid "Download"
 msgstr "Télécharger"
+
+msgid "Download the DMG file from the website that just opened, then drop it into your Applications folder."
+msgstr "Télécharger le fichier DMG depuis le navigateur qui vient de s'ouvrir, puis déposez le dans le dossier Applications."
+
+msgid "Download the installer executable from the page that just opened, then run it."
+msgstr "Télécharger l'exécutable d'installation depuis la page qui vient de s'ouvrir, puis exécutez le."
 
 msgid "Download the players matching the search into a file."
 msgstr "Télécharger un fichier contenant les joueur·euses correspondant à la recherche."
@@ -2495,6 +2513,9 @@ msgstr "Évènements"
 
 msgid "Events ({num})"
 msgstr "Évènements ({num})"
+
+msgid "Example databases"
+msgstr "Bases d'exemple"
 
 msgid "Exclude"
 msgstr "Exclure"
@@ -3103,11 +3124,20 @@ msgstr "Les écrans de saisie des résultats présentent les appariements des jo
 msgid "Install"
 msgstr "Installer"
 
+msgid "Install version 5"
+msgstr "Installer la version 5"
+
+msgid "Installation error"
+msgstr "Erreur d'installation"
+
 msgid "Installation of [{lib}] failed."
 msgstr "L'installation de la bibliothèque [{lib}] a échoué."
 
 msgid "Installation of release [{version}] failed, exiting."
 msgstr "L'nstallation de la version [{version}] a échoué, abandon."
+
+msgid "Installation succeeded"
+msgstr "L'installation a réussi"
 
 msgid "Installed [{lib}]."
 msgstr "La bibliothèque [{lib}] a été installée."
@@ -5561,6 +5591,9 @@ msgstr "Prix partagés"
 msgid "Sharing threshold"
 msgstr "Seuil de partage"
 
+msgid "Sharly Chess 5 is available!"
+msgstr "Sharly Chess 5 is available !"
+
 msgid "Sharly Chess Server"
 msgstr "Serveur Sharly Chess"
 
@@ -5587,6 +5620,9 @@ msgstr "Configuration de Sharly Chess"
 
 msgid "Sharly Chess settings have been updated."
 msgstr "La configuration de Sharly Chess a été mise à jour."
+
+msgid "Sharly Chess upgrade"
+msgstr "Mise à jour Sharly Chess"
 
 msgid "Sharly Chess using the local network, all the traffic is public. This means anyone connected to the same network could easily gain access to an account without needing to type in the password."
 msgstr "Sharly Chess utilisant le réseau local, tout le trafic est public. Cela implique que quiconque connecté au même réseau peut facilement récupérer l'accès à un compte sans saisir de mot de passe."
@@ -5926,6 +5962,9 @@ msgstr "La grille américaine montre tous les résultats des joueur·euses, tand
 msgid "The currency used to represent monetary prizes (defaults to the currency of the event federation)."
 msgstr "La monnaie utilisée pour représenter les prix (par défaut la monnaie de la fédération de l'évènement)."
 
+msgid "The data of this version will be recovered when starting the new version."
+msgstr "Les données de cette version seront récupérées au démarrage de la nouvelle version."
+
 msgid "The default federation for your events."
 msgstr "La fédération par défaut pour vos évènements."
 
@@ -5951,6 +5990,9 @@ msgstr "Les fonctionnalités suivant ne seront pas importées :"
 
 msgid "The forecast becomes available once the last round is paired. Once the tournament finishes, this report will list every achieved norm."
 msgstr "Les prévisions sont disponibles une fois la dernière ronde appariée. À la fin du tournoi, ce rapport listera toutes les normes réalisées."
+
+msgid "The installation and update processes have been reworked in version 5."
+msgstr "Les processus d'installation et de mise à jour ont été retravaillés dans la version 5."
 
 msgid "The least and the most significant values are removed."
 msgid_plural "The {count} least and the {count} most significant values are removed."

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -286,9 +286,6 @@ msgstr "SC_M"
 msgid "*** KEYBOARD SHORTCUT FOR THE TOURNAMENTS TAB"
 msgstr "SC_T"
 
-msgid "*** MACOS INSTALL URL"
-msgstr "https://sharly-chess.com/fr/installation-mac/"
-
 msgid "- *** NAME FOR GENDER NONE"
 msgstr "-"
 
@@ -524,9 +521,6 @@ msgstr "<smart_count> semaine |||| <smart_count> semaines"
 
 msgid "A file is expected."
 msgstr "Un fichier est attendu."
-
-msgid "A new version is available. Do you want to install it now"
-msgstr "Une nouvelle version est disponible. Voulez-vous l'installer maintenant"
 
 msgid "A player with {column}=[{value}] already exists in the event."
 msgstr "Un·e joueur·euse avec {column}=[{value}] existe déjà dans l'évènement."
@@ -2103,6 +2097,9 @@ msgstr "Ne pas utiliser cet ordre comme classement."
 msgid "Do you want to install example event databases"
 msgstr "Voulez-vous installer des bases d'évènement d'exemple"
 
+msgid "Do you want to install the update now"
+msgstr "Voulez-vous installer la mise à jour maintenant "
+
 msgid "Do you want to recover the data of release [{version}]"
 msgstr "Voulez-vous récupérer les données de la version [{version}]"
 
@@ -3123,9 +3120,6 @@ msgstr "Les écrans de saisie des résultats présentent les appariements des jo
 
 msgid "Install"
 msgstr "Installer"
-
-msgid "Install version 5"
-msgstr "Installer la version 5"
 
 msgid "Installation error"
 msgstr "Erreur d'installation"
@@ -5630,6 +5624,9 @@ msgstr "Mise à jour Sharly Chess"
 msgid "Sharly Chess using the local network, all the traffic is public. This means anyone connected to the same network could easily gain access to an account without needing to type in the password."
 msgstr "Sharly Chess utilisant le réseau local, tout le trafic est public. Cela implique que quiconque connecté au même réseau peut facilement récupérer l'accès à un compte sans saisir de mot de passe."
 
+msgid "Sharly Chess {latest} is available, you have {current}."
+msgstr "Sharly Chess {latest} est disponible, vous avez la version {current}."
+
 msgid "Should only be used when the wrong player has been added by mistake."
 msgstr "Ne doit être utilisé que lorsque un·e mauvais·e joueur·euse a été ajouté·e par erreur."
 
@@ -5965,8 +5962,8 @@ msgstr "La grille américaine montre tous les résultats des joueur·euses, tand
 msgid "The currency used to represent monetary prizes (defaults to the currency of the event federation)."
 msgstr "La monnaie utilisée pour représenter les prix (par défaut la monnaie de la fédération de l'évènement)."
 
-msgid "The data of this version will be recovered when starting the new version."
-msgstr "Les données de cette version seront récupérées au démarrage de la nouvelle version."
+msgid "The data of the current version will be recovered when starting the new version."
+msgstr "Les données de la version actuelle seront récupérées au démarrage de la nouvelle version."
 
 msgid "The default federation for your events."
 msgstr "La fédération par défaut pour vos évènements."

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -2136,8 +2136,8 @@ msgstr "Berger aller-retour"
 msgid "Download"
 msgstr "Télécharger"
 
-msgid "Download the DMG file from the website that just opened, then drop it into your Applications folder."
-msgstr "Télécharger le fichier DMG depuis le navigateur qui vient de s'ouvrir, puis déposez le dans le dossier Applications."
+msgid "Download the DMG file from the website that just opened, open it, then copy the application to your Applications folder and run it from there."
+msgstr "Téléchargez le fichier DMG depuis le navigateur qui vient de s'ouvrir, ouvrez-le, puis copiez l'application dans votre dossier Applications puis et exécutez-le."
 
 msgid "Download the installer executable from the page that just opened, then run it."
 msgstr "Télécharger l'exécutable d'installation depuis la page qui vient de s'ouvrir, puis exécutez le."
@@ -5991,8 +5991,8 @@ msgstr "Les fonctionnalités suivant ne seront pas importées :"
 msgid "The forecast becomes available once the last round is paired. Once the tournament finishes, this report will list every achieved norm."
 msgstr "Les prévisions sont disponibles une fois la dernière ronde appariée. À la fin du tournoi, ce rapport listera toutes les normes réalisées."
 
-msgid "The installation and update processes have been reworked in version 5."
-msgstr "Les processus d'installation et de mise à jour ont été retravaillés dans la version 5."
+msgid "The installation and update processes have been reworked."
+msgstr "Les processus d'installation et de mise à jour ont été retravaillés."
 
 msgid "The least and the most significant values are removed."
 msgid_plural "The {count} least and the {count} most significant values are removed."

--- a/src/common/engine.py
+++ b/src/common/engine.py
@@ -271,8 +271,9 @@ class Engine:
         else:
             install_url = _('*** MACOS INSTALL URL')
             instruction += _(
-                'Download the DMG file from the website that just opened, '
-                'then drop it into your Applications folder.'
+                'Download the DMG file from the website that just '
+                'opened, open it, then copy the application to your '
+                'Applications folder and run it from there.'
             )
         from web.server_engine import launch_browser
 

--- a/src/common/engine.py
+++ b/src/common/engine.py
@@ -46,6 +46,7 @@ from database.sqlite.config.config_database import ConfigDatabase
 from database.sqlite.event.event_database import EventDatabase
 from database.sqlite.local_source_database import LocalSourceDatabaseManager
 from plugins.manager import plugin_manager
+from utils import Utils
 from utils.program_variables import ProgramVar
 
 logger = get_logger()
@@ -262,21 +263,23 @@ class Engine:
             return
         if not latest_version or latest_version.major < 5:
             return
-        if not input_interactive_yn(
-            _('Sharly Chess - Update'),
-            _('A new version is available. Do you want to install it now'),
-        ):
+        title = _('Sharly Chess - Update')
+        message = _('Sharly Chess {latest} is available, you have {current}.').format(
+            latest=latest_version, current=SHARLY_CHESS_VERSION
+        )
+        message += '\n\n' + _('Do you want to install the update now')
+        if not input_interactive_yn(title, message):
             return
         instruction = _('The installation and update processes have been reworked.')
         instruction += '\n\n'
-        if sys.platform == 'win32':
+        if sys.platform != 'win32':
             instruction += _(
                 'An installer program will start after closing this message.'
             )
         else:
             from web.server_engine import launch_browser
 
-            install_url = _('*** MACOS INSTALL URL')
+            install_url = Utils.doc_url('macos-install')
             Thread(target=launch_browser, args=(install_url,)).start()
             instruction += _(
                 'Download the DMG file from the website that just '
@@ -285,9 +288,10 @@ class Engine:
             )
 
         instruction += '\n\n' + _(
-            'The data of this version will be recovered when starting the new version.'
+            'The data of the current version will be '
+            'recovered when starting the new version.'
         )
-        print_interactive_message(_('Install version 5'), instruction)
+        print_interactive_message(title, instruction)
         if sys.platform == 'darwin':
             quit_app()
         else:

--- a/src/common/engine.py
+++ b/src/common/engine.py
@@ -548,7 +548,7 @@ class Engine:
                             valid_asset_names: list[str] = [
                                 f'sharly-chess-{version}-windows.zip',
                                 f'sharly-chess-{version}.zip',
-                                f'Sharly Chess Setup {version}.exe',
+                                f'Sharly Chess Installer {version}.exe',
                             ]
                         case 'darwin':
                             valid_asset_names = [

--- a/src/common/engine.py
+++ b/src/common/engine.py
@@ -249,6 +249,7 @@ class Engine:
 
     @classmethod
     def _prepare_for_version_5(cls):
+        ProgramVar.LEGACY_VERSION.write_value(str(SHARLY_CHESS_VERSION))
         ProgramVar.LEGACY_VERSION_DIR.write_value(str(BASE_DIR))
         if sys.platform == 'linux':
             # Flatpak upgrades to V5 automatically

--- a/src/common/engine.py
+++ b/src/common/engine.py
@@ -8,6 +8,7 @@ import zipfile
 import os
 import platform
 import subprocess
+from functools import partial
 from json import JSONDecodeError
 from pathlib import Path
 from threading import Thread
@@ -39,6 +40,7 @@ from common.logger import (
 )
 from common.network import NetworkMonitor
 from common.sharly_chess_config import SharlyChessConfig
+from common.windows_setup import WindowsSetup
 from data.loader import EventLoader
 from database.sqlite.config.config_database import ConfigDatabase
 from database.sqlite.event.event_database import EventDatabase
@@ -78,7 +80,8 @@ class Engine:
         if TEST_ENV:
             # skip all the upgrade stuff on TEST_ENV (recovering tests run the migrations explicitly)
             return
-        if more_recent_version and download_url:
+        # Maintain the legacy upgrade behavior while v5 has not been released
+        if more_recent_version and download_url and more_recent_version.major < 5:
             if input_interactive_yn(
                 _('Sharly Chess upgrade'),
                 _(
@@ -90,7 +93,7 @@ class Engine:
                 yes_is_default=False,
             ):
                 self.error = True
-                if error_message := self._install_new_version(
+                if error_message := self._legacy_install_new_version(
                     more_recent_version, download_url
                 ):
                     if print_interactive_message(
@@ -243,46 +246,65 @@ class Engine:
                     ):
                         shutil.copy(file, EVENTS_DIR / file.name)
 
-        if os.getenv('FAKE_V5_AVAILABLE') == '1':
-            # TODO (Molrn) Remove env requirement once V5 is available
-            self._prepare_for_version_5()
+        self._prepare_for_version_5(more_recent_version, download_url)
 
     @classmethod
-    def _prepare_for_version_5(cls):
+    def _prepare_for_version_5(
+        cls,
+        latest_version: Version | None,
+        download_url: str | None,
+    ):
+        # Save the current version for recovery
         ProgramVar.LEGACY_VERSION.write_value(str(SHARLY_CHESS_VERSION))
         ProgramVar.LEGACY_VERSION_DIR.write_value(str(BASE_DIR))
         if sys.platform == 'linux':
             # Flatpak upgrades to V5 automatically
             return
+        if not latest_version or latest_version.major < 5:
+            return
         if not input_interactive_yn(
-            _('Sharly Chess 5 is available!'),
-            _('Do you want to install it now'),
+            _('Sharly Chess - Update'),
+            _('A new version is available. Do you want to install it now'),
         ):
             return
-        instruction = (
-            _('The installation and update processes have been reworked.') + '\n\n'
-        )
+        instruction = _('The installation and update processes have been reworked.')
+        instruction += '\n\n'
         if sys.platform == 'win32':
-            install_url = _('*** WINDOWS INSTALL URL')
             instruction += _(
-                'Download the installer executable from the '
-                'page that just opened, then run it.'
+                'An installer program will start after closing this message.'
             )
         else:
+            from web.server_engine import launch_browser
+
             install_url = _('*** MACOS INSTALL URL')
+            Thread(target=launch_browser, args=(install_url,)).start()
             instruction += _(
                 'Download the DMG file from the website that just '
                 'opened, open it, then copy the application to your '
                 'Applications folder and run it from there.'
             )
-        from web.server_engine import launch_browser
 
-        Thread(target=launch_browser, args=(install_url,)).start()
         instruction += '\n\n' + _(
             'The data of this version will be recovered when starting the new version.'
         )
         print_interactive_message(_('Install version 5'), instruction)
-        quit_app()
+        if sys.platform == 'darwin':
+            quit_app()
+        else:
+            cls._install_windows_v5(latest_version, download_url)
+
+    @classmethod
+    def _install_windows_v5(cls, version, download_url: str | None):
+        if WindowsSetup.download(version, download_url):
+            quit_app(partial(WindowsSetup.run, version=version))
+            return
+        message = _(
+            'The installer program could not be downloaded. '
+            'Consult the logs for more details.'
+        )
+        message += '\n\n' + _('Do you want to try again')
+        if input_interactive_yn(_('Sharly Chess - Error'), message):
+            cls._install_windows_v5(version, download_url)
 
     @classmethod
     def _recover_previous_version(
@@ -447,6 +469,8 @@ class Engine:
                 'Already looked for a more recent version less than one hour ago, skipping.'
             )
             return None, None
+        if dev_latest := os.getenv('DEV_LATEST_VERSION'):
+            return Version(dev_latest), None
         current_stable: bool = bool(
             re.match(r'^(\d+\.\d+\.\d+)$', str(SHARLY_CHESS_VERSION))
         )
@@ -523,9 +547,13 @@ class Engine:
                             valid_asset_names: list[str] = [
                                 f'sharly-chess-{version}-windows.zip',
                                 f'sharly-chess-{version}.zip',
+                                f'Sharly Chess Setup {version}.exe',
                             ]
                         case 'darwin':
-                            valid_asset_names = [f'sharly-chess-{version}-macos.dmg']
+                            valid_asset_names = [
+                                f'sharly-chess-{version}-macos.dmg',
+                                f'sharly-chess-{version}-mac.dmg',
+                            ]
                         case 'linux':
                             # Detect architecture for Linux
                             # Allow override via BUILD_ARCH environment variable (useful for cross-compilation/QEMU)
@@ -609,7 +637,7 @@ class Engine:
             return None, None
 
     @staticmethod
-    def _install_new_version(version: Version, download_url: str) -> str | None:
+    def _legacy_install_new_version(version: Version, download_url: str) -> str | None:
         """Install the new stable version at the same directory level.
         Returns an error message on failure, None on success."""
         new_version_dir: Path = Path('..') / f'sharly-chess-{version}'

--- a/src/common/engine.py
+++ b/src/common/engine.py
@@ -40,7 +40,7 @@ from common.logger import (
 )
 from common.network import NetworkMonitor
 from common.sharly_chess_config import SharlyChessConfig
-from common.windows_setup import WindowsSetup
+from common.windows_installer import WindowsInstaller
 from data.loader import EventLoader
 from database.sqlite.config.config_database import ConfigDatabase
 from database.sqlite.event.event_database import EventDatabase
@@ -295,8 +295,8 @@ class Engine:
 
     @classmethod
     def _install_windows_v5(cls, version, download_url: str | None):
-        if WindowsSetup.download(version, download_url):
-            quit_app(partial(WindowsSetup.run, version=version))
+        if WindowsInstaller.download(version, download_url):
+            quit_app(partial(WindowsInstaller.run, version=version))
             return
         message = _(
             'The installer program could not be downloaded. '
@@ -470,6 +470,7 @@ class Engine:
             )
             return None, None
         if dev_latest := os.getenv('DEV_LATEST_VERSION'):
+            logger.warning('Using fake latest version [%s]', dev_latest)
             return Version(dev_latest), None
         current_stable: bool = bool(
             re.match(r'^(\d+\.\d+\.\d+)$', str(SHARLY_CHESS_VERSION))

--- a/src/common/engine.py
+++ b/src/common/engine.py
@@ -10,6 +10,7 @@ import platform
 import subprocess
 from json import JSONDecodeError
 from pathlib import Path
+from threading import Thread
 from time import time
 from typing import Any
 
@@ -25,6 +26,7 @@ from common import (
     DEVEL_ENV,
     EVENTS_DIR,
     TMP_DIR,
+    BASE_DIR,
 )
 from common.i18n import _
 from common.installation_checker import InstallationChecker
@@ -42,6 +44,7 @@ from database.sqlite.config.config_database import ConfigDatabase
 from database.sqlite.event.event_database import EventDatabase
 from database.sqlite.local_source_database import LocalSourceDatabaseManager
 from plugins.manager import plugin_manager
+from utils.program_variables import ProgramVar
 
 logger = get_logger()
 
@@ -77,6 +80,7 @@ class Engine:
             return
         if more_recent_version and download_url:
             if input_interactive_yn(
+                _('Sharly Chess upgrade'),
                 _(
                     'Do you want to upgrade from [{old_version}] to [{new_version}]'
                 ).format(
@@ -90,13 +94,14 @@ class Engine:
                     more_recent_version, download_url
                 ):
                     if print_interactive_message(
+                        _('Installation error'),
                         error_message
                         + '\n\n'
                         + _(
                             'Installation of release [{version}] failed, exiting.'
                         ).format(
                             version=more_recent_version,
-                        )
+                        ),
                     ):
                         quit_app()
                 return
@@ -177,6 +182,7 @@ class Engine:
                 version_num: int | None = None
                 if len(previous_databases) == 1:
                     if input_interactive_yn(
+                        _('Data recovery'),
                         _(
                             'Do you want to recover the data of release [{version}]'
                         ).format(version=previous_versions[0][0]),
@@ -228,6 +234,7 @@ class Engine:
                     )
             if DEVEL_ENV and not recovered_version:
                 if input_interactive_yn(
+                    _('Example databases'),
                     _('Do you want to install example event databases'),
                     yes_is_default=True,
                 ):
@@ -235,6 +242,45 @@ class Engine:
                         f'*.{SharlyChessConfig.event_database_ext}'
                     ):
                         shutil.copy(file, EVENTS_DIR / file.name)
+
+        if os.getenv('FAKE_V5_AVAILABLE') == '1':
+            # TODO (Molrn) Remove env requirement once V5 is available
+            self._prepare_for_version_5()
+
+    @classmethod
+    def _prepare_for_version_5(cls):
+        ProgramVar.LEGACY_VERSION_DIR.write_value(str(BASE_DIR))
+        if sys.platform == 'linux':
+            # Flatpak upgrades to V5 automatically
+            return
+        if not input_interactive_yn(
+            _('Sharly Chess 5 is available!'),
+            _('Do you want to install it now'),
+        ):
+            return
+        instruction = (
+            _('The installation and update processes have been reworked.') + '\n\n'
+        )
+        if sys.platform == 'win32':
+            install_url = _('*** WINDOWS INSTALL URL')
+            instruction += _(
+                'Download the installer executable from the '
+                'page that just opened, then run it.'
+            )
+        else:
+            install_url = _('*** MACOS INSTALL URL')
+            instruction += _(
+                'Download the DMG file from the website that just opened, '
+                'then drop it into your Applications folder.'
+            )
+        from web.server_engine import launch_browser
+
+        Thread(target=launch_browser, args=(install_url,)).start()
+        instruction += '\n\n' + _(
+            'The data of this version will be recovered when starting the new version.'
+        )
+        print_interactive_message(_('Install version 5'), instruction)
+        quit_app()
 
     @classmethod
     def _recover_previous_version(
@@ -712,6 +758,7 @@ class Engine:
                 return _('Unexpected error during installation: [{ex}].').format(ex=ex)
 
         if print_interactive_message(
+            _('Installation succeeded'),
             _('Release {version} has been installed in [{folder}].').format(
                 version=version,
                 folder=new_version_dir.absolute(),

--- a/src/common/logger.py
+++ b/src/common/logger.py
@@ -250,7 +250,9 @@ def input_interactive_choices(
     return result
 
 
-def input_interactive_yn(question: str, yes_is_default: bool = False) -> bool:
+def input_interactive_yn(
+    title: str, question: str, yes_is_default: bool = False
+) -> bool:
     """Prints the message to stdout with color postfixed with [Y/n] etc, and returns the user input.
     If the message could not be Unicode decoded, raises KeyboardInterrupt."""
     from common.i18n import _
@@ -259,7 +261,7 @@ def input_interactive_yn(question: str, yes_is_default: bool = False) -> bool:
 
     if GUILogHandler.instance:
         return GUILogHandler.instance.gui.handle_interactive_yn(
-            question, yes_is_default
+            title, question, yes_is_default
         )
 
     yes_answer = _('Y *** THE LETTER TO ANSWER YES')
@@ -283,11 +285,11 @@ def input_interactive_yn(question: str, yes_is_default: bool = False) -> bool:
             return False
 
 
-def print_interactive_message(message: str) -> bool:
+def print_interactive_message(title: str, message: str) -> bool:
     __flush_logger()
 
     if GUILogHandler.instance:
-        return GUILogHandler.instance.gui.handle_interactive_message(message)
+        return GUILogHandler.instance.gui.handle_interactive_message(title, message)
 
     print(Fore.CYAN + Style.BRIGHT + message + Style.RESET_ALL, end='')
     return True

--- a/src/common/logger.py
+++ b/src/common/logger.py
@@ -3,7 +3,7 @@ from logging import Logger, getLogger
 from logging.config import dictConfig
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from colorama import Fore, Style
 
@@ -295,8 +295,9 @@ def print_interactive_message(title: str, message: str) -> bool:
     return True
 
 
-def quit_app() -> None:
+def quit_app(post_exit_task: Callable | None = None) -> None:
     if GUILogHandler.instance:
-        return GUILogHandler.instance.gui.quit_app()
-
+        return GUILogHandler.instance.gui.quit_app(post_exit_task)
+    if post_exit_task:
+        post_exit_task()
     sys.exit(0)

--- a/src/common/windows_installer.py
+++ b/src/common/windows_installer.py
@@ -11,18 +11,18 @@ from common.logger import get_logger
 logger = get_logger()
 
 
-class WindowsSetup:
-    """Wrapper for the Windows Setup executable."""
+class WindowsInstaller:
+    """Wrapper for the Windows Installer executable."""
 
     @staticmethod
     def dev_exe_path() -> Path | None:
         """Env variable set in dev to bypass the requirement to download a published setup."""
-        dev_exe = os.getenv('DEV_WINDOWS_SETUP_PATH')
+        dev_exe = os.getenv('DEV_WINDOWS_INSTALLER_PATH')
         if dev_exe:
             exe_path = Path(dev_exe)
             if exe_path.exists():
                 return exe_path
-            logger.error('Dev updater exe path [%s] not found.')
+            logger.error('Dev updater exe path [%s] not found.', dev_exe)
         return None
 
     @classmethod
@@ -30,7 +30,7 @@ class WindowsSetup:
         dev_exe = cls.dev_exe_path()
         if dev_exe:
             return dev_exe
-        return TMP_DIR / f'Sharly Chess Setup {version}.exe'
+        return TMP_DIR / f'Sharly Chess Installer {version}.exe'
 
     @classmethod
     def download(cls, version: Version, url: str | None) -> bool:

--- a/src/common/windows_setup.py
+++ b/src/common/windows_setup.py
@@ -1,0 +1,65 @@
+import ctypes
+import os
+from pathlib import Path
+
+from packaging.version import Version
+from requests import get, RequestException
+
+from common import TMP_DIR
+from common.logger import get_logger
+
+logger = get_logger()
+
+
+class WindowsSetup:
+    """Wrapper for the Windows Setup executable."""
+
+    @staticmethod
+    def dev_exe_path() -> Path | None:
+        """Env variable set in dev to bypass the requirement to download a published setup."""
+        dev_exe = os.getenv('DEV_WINDOWS_SETUP_PATH')
+        if dev_exe:
+            exe_path = Path(dev_exe)
+            if exe_path.exists():
+                return exe_path
+            logger.error('Dev updater exe path [%s] not found.')
+        return None
+
+    @classmethod
+    def exe_path(cls, version: Version) -> Path:
+        dev_exe = cls.dev_exe_path()
+        if dev_exe:
+            return dev_exe
+        return TMP_DIR / f'Sharly Chess Setup {version}.exe'
+
+    @classmethod
+    def download(cls, version: Version, url: str | None) -> bool:
+        """Downloads the updater, returns True if successful."""
+        if cls.dev_exe_path():
+            # Downloading bypassed in dev
+            return True
+        exe_path = cls.exe_path(version)
+        if exe_path.exists():
+            return True
+        if not url:
+            logger.error('No Download URL provided.')
+            return False
+        try:
+            response = get(url, allow_redirects=True, timeout=5)
+            response.raise_for_status()
+            with open(exe_path, 'wb') as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            return True
+        except RequestException as ex:
+            logger.error('An error occurred while requesting GitHub.')
+            logger.debug('Failed to read [%s]: [%s].', url, ex)
+            return False
+
+    @classmethod
+    def run(cls, version: Version):
+        exe = str(cls.exe_path(version))
+        # Type error when not running on windows
+        ctypes.windll.shell32.ShellExecuteW(  # type: ignore[attr-defined]
+            None, 'runas', exe, None, None, 1
+        )

--- a/src/gui/server_gui_toga.py
+++ b/src/gui/server_gui_toga.py
@@ -19,7 +19,7 @@ import threading
 import webbrowser
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Any
+from typing import Optional, Any, Callable
 from PIL import Image as PILImage
 
 import toga
@@ -916,7 +916,7 @@ class SharlyChessServerToga(toga.App):
         except Exception:
             return False
 
-    def quit_app(self) -> None:
+    def quit_app(self, post_exit_task: Callable | None = None) -> None:
         loop = self.server_loop
         if loop is None or loop.is_closed():
             return
@@ -927,6 +927,9 @@ class SharlyChessServerToga(toga.App):
             if task is not None and not task.done():
                 task.cancel()
             loop.stop()
+            self.exit()
+            if post_exit_task:
+                post_exit_task()
 
         loop.call_soon_threadsafe(_stop)
 

--- a/src/gui/server_gui_toga.py
+++ b/src/gui/server_gui_toga.py
@@ -810,7 +810,9 @@ class SharlyChessServerToga(toga.App):
         self._update_config('launch_browser', widget.value)
 
     # --- Interactive prompts ---
-    def handle_interactive_yn(self, question: str, yes_is_default: bool) -> bool:
+    def handle_interactive_yn(
+        self, title: str, question: str, yes_is_default: bool
+    ) -> bool:
         """Blocking Yes/No prompt callable from background threads."""
         text = question + '?'
 
@@ -818,7 +820,7 @@ class SharlyChessServerToga(toga.App):
             # Show the dialog on the main window; returns True/False
             assert isinstance(self.main_window, toga.MainWindow)
             dialog = toga.QuestionDialog(
-                title=_('Server Setup'),
+                title=title,
                 message=text,
             )
             return await self.main_window.dialog(dialog)
@@ -899,16 +901,12 @@ class SharlyChessServerToga(toga.App):
         except Exception:
             return None
 
-    def handle_interactive_message(self, message: str) -> bool:
+    def handle_interactive_message(self, title: str, message: str) -> bool:
         """Blocking Yes/No prompt callable from background threads."""
 
         async def _message_on_ui():
-            # Show the dialog on the main window; returns True/False
             assert isinstance(self.main_window, toga.MainWindow)
-            dialog = toga.InfoDialog(
-                title='Sharly Chess',
-                message=message,
-            )
+            dialog = toga.InfoDialog(title=title, message=message)
             return await self.main_window.dialog(dialog)
 
         # Schedule the coroutine on the UI loop and wait for the result

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -363,6 +363,15 @@ class Utils:
                 suffix = f' ≥ {min_rating}'
         return f'{prefix}{_("Rating")}{suffix}'
 
+    @staticmethod
+    def doc_url(resource_id: str) -> str:
+        """Create a localized URL for the documentation site to a resource."""
+        from common.sharly_chess_config import SharlyChessConfig
+
+        locale = SharlyChessConfig().locale
+        locale_url = f'{locale}/' if locale != 'en' else ''
+        return f'https://sharly-chess.com/{locale_url}h/{resource_id}'
+
 
 class SupportsEquals(Protocol):
     def __eq__(self, other: object) -> bool: ...

--- a/src/utils/program_variables.py
+++ b/src/utils/program_variables.py
@@ -29,6 +29,7 @@ class ProgramVar(StrEnum):
     These variables are stored at a user-level static path,
     and must be considered requiring a restart to be refreshed."""
 
+    LEGACY_VERSION = 'legacy_version'
     LEGACY_VERSION_DIR = 'legacy_version_directory'
 
     @property

--- a/src/utils/program_variables.py
+++ b/src/utils/program_variables.py
@@ -1,0 +1,108 @@
+import os
+import plistlib
+import sys
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+
+if sys.platform == 'win32':
+    import winreg
+else:
+    # Avoid winreg mypy errors when not running on windows
+    winreg: Any = {}
+
+# OS-specific Paths
+MACOS_SUPPORT_DIR = (
+    Path.home() / 'Library' / 'Application Support' / 'com.sharlychess.thp'
+)
+MACOS_DATA_PLIST = MACOS_SUPPORT_DIR.parent / 'com.sharlychess.plist'
+if sys.platform == 'darwin':
+    MACOS_DATA_PLIST.parent.mkdir(parents=True, exist_ok=True)
+
+LINUX_ENV_FILE = Path.home() / '.bashrc'
+WIN_REG_PATH = r'Software\Sharly Chess\Sharly Chess'
+
+
+class ProgramVar(StrEnum):
+    """Enum containing all the program variables.
+    These variables are stored at a user-level static path,
+    and must be considered requiring a restart to be refreshed."""
+
+    LEGACY_VERSION_DIR = 'legacy_version_directory'
+
+    @property
+    def stored_name(self) -> str:
+        """Name used to store the variable."""
+        from common import DEVEL_ENV
+
+        name = self.value
+        if DEVEL_ENV:
+            # Prefix variables in dev to prevent impacting the prod env of the developer
+            name = f'dev_{name}'
+        if sys.platform == 'linux':
+            # As linux uses env variables add an app specific prefix
+            name = f'SHARLY_CHESS_{name.upper()}'
+        return name
+
+    def read_value(self) -> str | None:
+        name = self.stored_name
+        match sys.platform:
+            case 'win32':
+                try:
+                    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, WIN_REG_PATH) as key:
+                        value, reg_type = winreg.QueryValueEx(key, name)
+                        return str(value) if value else None
+                except FileNotFoundError:
+                    return None
+            case 'darwin':
+                return _read_macos_data_plist().get(name)
+            case 'linux':
+                return os.getenv(name)
+        return None
+
+    def clear_value(self):
+        name = self.stored_name
+        match sys.platform:
+            case 'win32':
+                # winreg.deleteValue requires admin priviledges, set empty value instead
+                self.write_value('')
+            case 'darwin':
+                data = _read_macos_data_plist()
+                if data.pop(name, None) is not None:
+                    _write_macos_data_plist(data)
+            case 'linux':
+                self.write_value('')
+
+    def write_value(self, value: str):
+        self.write_variables({self: value})
+
+    @classmethod
+    def write_variables(cls, value_by_var: dict['ProgramVar', str]):
+        match sys.platform:
+            case 'win32':  # Use windows registries
+                with winreg.CreateKey(winreg.HKEY_CURRENT_USER, WIN_REG_PATH) as key:
+                    for var, value in value_by_var.items():
+                        winreg.SetValueEx(key, var.stored_name, 0, winreg.REG_SZ, value)
+            case 'darwin':  # Use Plist
+                data = _read_macos_data_plist()
+                for var, value in value_by_var.items():
+                    data[var.stored_name] = value
+                _write_macos_data_plist(data)
+            case 'linux':  # Use env variables
+                with open(LINUX_ENV_FILE, 'a') as f:
+                    for var, value in value_by_var.items():
+                        f.write(f'\nexport {var.stored_name}="{value}"\n')
+
+
+def _read_macos_data_plist() -> dict:
+    try:
+        with open(MACOS_DATA_PLIST, 'rb') as plist_file:
+            return plistlib.load(plist_file)
+    except (FileNotFoundError, OSError, plistlib.InvalidFileException):
+        return {}
+
+
+def _write_macos_data_plist(data: dict):
+    with open(MACOS_DATA_PLIST, 'wb') as plist_file:
+        plistlib.dump(data, plist_file)


### PR DESCRIPTION
Can be merged before V5 is ready, will only activate once V5 is ready.  
## Testing
### Windows  
- get a setup exe from #2104 
- set the following .env vars
  - DEV_LATEST_VERSION=5.0.0
  - DEV_WINDOWS_INSTALLER_PATH="export/Sharly Chess Installer 5.0.0.dev1.exe"
## macOS  
  Set the env variable `DEV_LATEST_VERSION=5.0.0`