### PR TITLE
Fix V5 windows release name (stable)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,4 +35,4 @@ MACOS_SIGNING_CERT_PASSWORD=your_certificate_password_here
 
 # Test variables for testing the V4 - V5 transition
 DEV_LATEST_VERSION=5.0.0
-DEV_WINDOWS_INSTALLER_PATH="export/Sharly Chess Installer 5.0.0.exe"
+DEV_WINDOWS_INSTALLER_PATH="export/sharly-chess-installer-5.0.0.exe"

--- a/src/common/engine.py
+++ b/src/common/engine.py
@@ -552,7 +552,7 @@ class Engine:
                             valid_asset_names: list[str] = [
                                 f'sharly-chess-{version}-windows.zip',
                                 f'sharly-chess-{version}.zip',
-                                f'Sharly Chess Installer {version}.exe',
+                                f'sharly-chess-installer-{version}.exe',
                             ]
                         case 'darwin':
                             valid_asset_names = [

--- a/src/common/windows_installer.py
+++ b/src/common/windows_installer.py
@@ -30,7 +30,7 @@ class WindowsInstaller:
         dev_exe = cls.dev_exe_path()
         if dev_exe:
             return dev_exe
-        return TMP_DIR / f'Sharly Chess Installer {version}.exe'
+        return TMP_DIR / f'sharly-chess-installer-{version}.exe'
 
     @classmethod
     def download(cls, version: Version, url: str | None) -> bool:


### PR DESCRIPTION
GH does not accept spaces in assets. 4.2.6 will not detect V5, but it will still detect v4.2.7 which will detect v5 so we are fine on this