### PR TITLE
Fix windows path `%USERPROFILE%` error

### DIFF
--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -122,9 +122,9 @@ def _app_data_dir() -> Path:
         return TEST_DATA_DIR
     if MANUAL_PATH_USED:
         return Path()
-    data_dir_val = ProgramVar.DATA_DIR.read_value()
-    if data_dir_val:
-        return Path(data_dir_val)
+    data_dir = ProgramVar.DATA_DIR.read_path_value()
+    if data_dir:
+        return data_dir
     default = _default_data_dir()
     ProgramVar.DATA_DIR.write_value(str(default))
     return default
@@ -179,9 +179,8 @@ DATA_DIR.mkdir(parents=True, exist_ok=True)
 if not os.access(DATA_DIR, os.W_OK):
     raise SharlyChessException(f'Data path [{DATA_DIR.absolute()}] is not writable.')
 
-previous_dir_val = ProgramVar.PREVIOUS_DATA_DIR.read_value()
-if previous_dir_val and not MANUAL_PATH_USED:
-    previous_dir = Path(previous_dir_val)
+previous_dir = ProgramVar.PREVIOUS_DATA_DIR.read_path_value()
+if previous_dir and not MANUAL_PATH_USED:
     if previous_dir.exists() and not any(DATA_DIR.iterdir()):
         # The data dir changed: move the previous content over
         try:

--- a/src/utils/program_variables.py
+++ b/src/utils/program_variables.py
@@ -68,6 +68,16 @@ class ProgramVar(StrEnum):
                 return os.getenv(name)
         return None
 
+    def read_path_value(self) -> Path | None:
+        value = self.read_value()
+        if not value:
+            return None
+        if sys.platform == 'win32':
+            # Take Windows path variables into account (ex: %USERPROFILE%)
+            # InnoSetup can use those variables on some windows distributions
+            value = str(os.path.expandvars(value))
+        return Path(value)
+
     def clear_value(self):
         name = self.stored_name
         match sys.platform:

--- a/windows-setup.iss
+++ b/windows-setup.iss
@@ -166,11 +166,25 @@ begin
   end;
 end;
 
+function ExpandEnvStrings(lpSrc: PAnsiChar; lpDst: PAnsiChar; nSize: Cardinal): Cardinal;
+external 'ExpandEnvironmentStringsA@kernel32.dll stdcall';
+
+function GetExpandedPath(const Path: String): String;
+var
+  Buffer: AnsiString;
+begin
+  SetLength(Buffer, 1024);
+  if ExpandEnvStrings(PAnsiChar(AnsiString(Path)), PAnsiChar(Buffer), 1024) > 0 then
+    Result := Buffer
+  else
+    Result := Path; // Fallback if expansion fails
+end;
+
 function GetDataDir(Param: string) : string;
 begin
   if DataDirExists() then
     Result := DataDir;
-  Result := DataDirPage.Values[0];
+  Result := GetExpandedPath(DataDirPage.Values[0]);
 end;
 
 function GetActiveLanguage(Param: string) : string;


### PR DESCRIPTION
To test:
- set the windows registry `dev_data_directory=%USERPROFILE%\Documents\Sharly Chess`
- Check that it is correctly read and displayed in the toga app