### PR TITLE
Add simple arbiter staff role

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 
 - Custom tags can be created and added to events for easier filtering (5.0.0)
 - Event creation allowed for access level "Organization" (5.0.0)
+- Staff members can now be assigned as arbiters, separately from chief and deputy arbiter roles, and are included in tournament documents and _Chess-Results_ exports (5.0.0)
 
 ## Players
 

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -1548,7 +1548,7 @@ msgstr ""
 msgid "Candidate Master"
 msgstr ""
 
-msgid "Cannot be both chief and deputy on the same tournament."
+msgid "Cannot have multiple arbiter roles on the same tournament."
 msgstr ""
 
 #, python-brace-format
@@ -7848,6 +7848,9 @@ msgstr ""
 msgid "The tournaments for which the staff member is a deputy arbiter."
 msgstr ""
 
+msgid "The tournaments for which the staff member is an arbiter."
+msgstr ""
+
 msgid "The tournaments for which the staff member is the chief arbiter."
 msgstr ""
 
@@ -9778,4 +9781,7 @@ msgstr ""
 
 msgid "← Back to IT1 certificate"
 msgstr ""
+
+#~ msgid "Cannot be both chief and deputy on the same tournament."
+#~ msgstr ""
 

--- a/locale/fr/LC_MESSAGES/messages.po
+++ b/locale/fr/LC_MESSAGES/messages.po
@@ -1548,8 +1548,8 @@ msgstr "Annuler « %(bye)s » à la ronde n°%(round)s for [%(player)s]?"
 msgid "Candidate Master"
 msgstr "Candidat Maître"
 
-msgid "Cannot be both chief and deputy on the same tournament."
-msgstr "Impossible d’être à la fois arbitre principal·e et arbitre adjoint·e sur le même tournoi."
+msgid "Cannot have multiple arbiter roles on the same tournament."
+msgstr "Impossible d’avoir plusieurs rôles d’arbitre sur le même tournoi."
 
 #, python-brace-format
 msgid "Cannot tile {remaining} remaining players into a base table for {t} teams."
@@ -7850,6 +7850,9 @@ msgstr "Le tournoi des écrans de l'écran multiple."
 msgid "The tournaments for which the staff member is a deputy arbiter."
 msgstr "Les tournois pour lesquels le membre du staff est arbitre adjoint·e."
 
+msgid "The tournaments for which the staff member is an arbiter."
+msgstr "Les tournois pour lesquels le membre du staff est arbitre."
+
 msgid "The tournaments for which the staff member is the chief arbiter."
 msgstr "Les tournois pour lesquels le membre du staff est arbitre principal·e."
 
@@ -9780,4 +9783,7 @@ msgstr "—"
 
 msgid "← Back to IT1 certificate"
 msgstr "← Retour au certificat IT1"
+
+#~ msgid "Cannot be both chief and deputy on the same tournament."
+#~ msgstr "Impossible d’être à la fois arbitre principal·e et arbitre adjoint·e sur le même tournoi."
 

--- a/src/data/print_documents/options.py
+++ b/src/data/print_documents/options.py
@@ -342,7 +342,7 @@ class MatchSheetArbiterPrintOption(PrintOption):
         return _('Chief arbiter')
 
     def arbiter_options(self) -> 'dict[str, str]':
-        """``{account_id: full_name}`` for the arbiters (chief + deputies)
+        """``{account_id: full_name}`` for all the arbiters
         of the event's team tournaments — the staff that can sign a sheet."""
         result: dict[str, str] = {}
         if self.event is None or not self.event.is_team_event:
@@ -354,6 +354,7 @@ class MatchSheetArbiterPrintOption(PrintOption):
             if tournament.chief_arbiter is not None:
                 arbiters.append(tournament.chief_arbiter)
             arbiters.extend(tournament.deputy_arbiters)
+            arbiters.extend(tournament.arbiters)
             for account in arbiters:
                 result.setdefault(str(account.id), account.full_name)
         return result

--- a/src/data/tournament.py
+++ b/src/data/tournament.py
@@ -2323,6 +2323,18 @@ class Tournament:
         ]
 
     @property
+    def arbiters(self) -> list[Account]:
+        return [
+            account
+            for account in self.event.accounts_by_id.values()
+            if (
+                (role := account.get_role(RoleType.ARBITER))
+                and role.tournament_ids
+                and self.id in role.tournament_ids
+            )
+        ]
+
+    @property
     def max_ranking_round(self) -> int:
         if not self.started:
             return 0

--- a/src/database/sqlite/event/migrations/m098_add_arbiter_role.py
+++ b/src/database/sqlite/event/migrations/m098_add_arbiter_role.py
@@ -1,0 +1,21 @@
+from database.sqlite.migration import BaseMigration
+
+
+class Migration(BaseMigration):
+    """Prevent an account from holding multiple arbiter roles for one tournament."""
+
+    def forward(self):
+        self.database.execute('DROP INDEX `ux_no_dual_arbiter_role`')
+        self.database.execute(
+            'CREATE UNIQUE INDEX `ux_no_dual_arbiter_role` '
+            'ON `account_role`(`account_id`, `tournament_id`) '
+            'WHERE `role` IN ("chief_arbiter", "deputy_arbiter", "arbiter")'
+        )
+
+    def backward(self):
+        self.database.execute('DROP INDEX `ux_no_dual_arbiter_role`')
+        self.database.execute(
+            'CREATE UNIQUE INDEX `ux_no_dual_arbiter_role` '
+            'ON `account_role`(`account_id`, `tournament_id`) '
+            'WHERE `role` IN ("chief_arbiter", "deputy_arbiter")'
+        )

--- a/src/plugins/chess_results/chess_results_session.py
+++ b/src/plugins/chess_results/chess_results_session.py
@@ -198,6 +198,9 @@ class ChessResultsSession(Session):
                 'director': (event.organiser_director or '')[:80],
                 'organiser': (event.organiser_name or '')[:80],
                 'location': tournament.location or '',
+                'arbiter': ', '.join(
+                    arbiter.fide_arbiter_str for arbiter in tournament.arbiters
+                ),
                 'rounds': str(tournament.rounds),
                 'currentround': str(tournament.current_round or 0),
                 'rankinground': str(

--- a/src/plugins/ffe/print_documents/ffe_types.py
+++ b/src/plugins/ffe/print_documents/ffe_types.py
@@ -109,12 +109,13 @@ class FFEDocumentType(IdentifiableEntity, ABC):
 
     @cached_property
     def arbiters(self) -> str:
-        """Returns the lists of arbiters, chief arbiters first then deputy arbiters, as a textarea string."""
+        """Returns the lists of arbiters by role as a textarea string."""
         accounts_by_role: dict[RoleType, set[Account]] = {
             role_type: set()
             for role_type in [
                 RoleType.CHIEF_ARBITER,
                 RoleType.DEPUTY_ARBITER,
+                RoleType.ARBITER,
                 RoleType.ORGANISER,
             ]
         }
@@ -139,6 +140,14 @@ class FFEDocumentType(IdentifiableEntity, ABC):
             ),
             key=lambda a: a.full_name,
         )
+        arbiters: list[Account] = sorted(
+            (
+                account
+                for account in accounts_by_role[RoleType.ARBITER]
+                if account not in chief_arbiters and account not in deputy_arbiters
+            ),
+            key=lambda a: a.full_name,
+        )
 
         def format_arbiter(arbiter: Account) -> str:
             return ' '.join(
@@ -156,7 +165,8 @@ class FFEDocumentType(IdentifiableEntity, ABC):
 
         return (
             f'Arbitres en chef :\n{", ".join(format_arbiter(arbiter) for arbiter in chief_arbiters)}\n\n'
-            f'Arbitres adjoint·es :\n{", ".join(format_arbiter(arbiter) for arbiter in deputy_arbiters)}\n'
+            f'Arbitres adjoint·es :\n{", ".join(format_arbiter(arbiter) for arbiter in deputy_arbiters)}\n\n'
+            f'Arbitres :\n{", ".join(format_arbiter(arbiter) for arbiter in arbiters)}\n'
         )
 
     @cached_property

--- a/src/utils/enum.py
+++ b/src/utils/enum.py
@@ -1037,6 +1037,7 @@ class TeamSortMode(StrEnum):
 class RoleType(StrEnum):
     CHIEF_ARBITER = 'chief_arbiter'
     DEPUTY_ARBITER = 'deputy_arbiter'
+    ARBITER = 'arbiter'
     ORGANISER = 'organiser'
 
     @property
@@ -1049,7 +1050,8 @@ class RoleType(StrEnum):
         order_map = {
             RoleType.CHIEF_ARBITER: 0,
             RoleType.DEPUTY_ARBITER: 1,
-            RoleType.ORGANISER: 2,
+            RoleType.ARBITER: 2,
+            RoleType.ORGANISER: 3,
         }
         return order_map[self]
 
@@ -1059,6 +1061,8 @@ class RoleType(StrEnum):
                 return _('Chief arbiter')
             case RoleType.DEPUTY_ARBITER:
                 return _('Deputy arbiter')
+            case RoleType.ARBITER:
+                return _('Arbiter')
             case RoleType.ORGANISER:
                 return _('Organiser')
             case _:

--- a/src/web/controllers/admin/account_admin_controller.py
+++ b/src/web/controllers/admin/account_admin_controller.py
@@ -148,6 +148,7 @@ class AccountAdminController(BaseEventAdminController):
                 'tournament_ids': [],
                 'chief_tournament_ids': [],
                 'deputy_tournament_ids': [],
+                'arbiter_tournament_ids': [],
             }
         )
         fide_arbiter_title_options = {'': '-'} | {
@@ -180,6 +181,7 @@ class AccountAdminController(BaseEventAdminController):
 
         chief_role = account.get_role(RoleType.CHIEF_ARBITER)
         deputy_role = account.get_role(RoleType.DEPUTY_ARBITER)
+        arbiter_role = account.get_role(RoleType.ARBITER)
 
         return WebContext.values_dict_to_form_data(
             {
@@ -192,6 +194,7 @@ class AccountAdminController(BaseEventAdminController):
                 'phone': stored_account.phone,
                 'chief_tournament_ids': chief_role.tournament_ids or [],
                 'deputy_tournament_ids': deputy_role.tournament_ids or [],
+                'arbiter_tournament_ids': arbiter_role.tournament_ids or [],
             }
             | plugin_form_data
         )
@@ -367,13 +370,23 @@ class AccountAdminController(BaseEventAdminController):
             flat_data, 'chief_tournament_ids'
         )
         deputy_tournament_ids = WebContext.form_data_to_list_int(
-            flat_data, field := 'deputy_tournament_ids'
+            flat_data, 'deputy_tournament_ids'
         )
-        for tournament_id in deputy_tournament_ids:
-            if tournament_id in chief_tournament_ids:
+        arbiter_tournament_ids = WebContext.form_data_to_list_int(
+            flat_data, 'arbiter_tournament_ids'
+        )
+        tournament_ids_by_field = {
+            'chief_tournament_ids': chief_tournament_ids,
+            'deputy_tournament_ids': deputy_tournament_ids,
+            'arbiter_tournament_ids': arbiter_tournament_ids,
+        }
+        seen_tournament_ids: set[int] = set()
+        for field, tournament_ids in tournament_ids_by_field.items():
+            if seen_tournament_ids.intersection(tournament_ids):
                 errors[field] = _(
-                    'Cannot be both chief and deputy on the same tournament.'
+                    'Cannot have multiple arbiter roles on the same tournament.'
                 )
+            seen_tournament_ids.update(tournament_ids)
         stored_roles: list[StoredRole] = []
         if chief_tournament_ids:
             stored_roles.append(
@@ -389,6 +402,14 @@ class AccountAdminController(BaseEventAdminController):
                     account_id=None,
                     role=RoleType.DEPUTY_ARBITER.value,
                     tournament_ids=deputy_tournament_ids,
+                )
+            )
+        if arbiter_tournament_ids:
+            stored_roles.append(
+                StoredRole(
+                    account_id=None,
+                    role=RoleType.ARBITER.value,
+                    tournament_ids=arbiter_tournament_ids,
                 )
             )
 

--- a/src/web/templates/admin/accounts/account_modal.html
+++ b/src/web/templates/admin/accounts/account_modal.html
@@ -89,6 +89,18 @@
                             data=data, errors=errors
                         ) }}
                     </div>
+                    <div class="col-12 col-md-6">
+                        {{ admin_macros.select_input(
+                            name='arbiter_tournament_ids',
+                            label=_('%(string)s:', string=_('Arbiter')),
+                            tooltip_text=_('The tournaments for which the staff member is an arbiter.'),
+                            select_all=true,
+                            select_options=tournament_options,
+                            multiple_select=true,
+                            placeholder=_('Choose one, many or no tournaments.'),
+                            data=data, errors=errors
+                        ) }}
+                    </div>
                 </div>
             </form>
         </div>

--- a/src/web/templates/admin/tournaments/tournament_components.j2
+++ b/src/web/templates/admin/tournaments/tournament_components.j2
@@ -470,6 +470,21 @@
                     ><i>{{ _('None') }}</i></span>
                 {% endif %}
             </div>
+            <div>
+                <div>{{ _('%(string)s:', string=_('Arbiters')) }}</div>
+                {% if tournament.arbiters %}
+                    <ul class="mb-0">
+                        {% for arbiter in tournament.arbiters %}
+                            <li>{{ arbiter.full_name }}</li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <span
+                        class="text-secondary"
+                        {{ macros.tooltip_attributes('info', _('Use the Staff tab to declare arbiters.'), 'right') }}
+                    ><i>{{ _('None') }}</i></span>
+                {% endif %}
+            </div>
         </section>
     {% endset %}
 

--- a/tests/unit/test_exports.py
+++ b/tests/unit/test_exports.py
@@ -1,4 +1,7 @@
+import xml.etree.ElementTree as ET
+from sqlite3 import IntegrityError
 from unittest import TestCase
+from unittest.mock import patch
 
 import pytest
 
@@ -11,10 +14,15 @@ from data.tie_breaks.tie_breaks import (
     WinsTieBreak,
 )
 from data.tournament import Tournament
+from database.sqlite.event.event_database import EventDatabase
+from database.sqlite.event.event_store import StoredAccount, StoredRole
 from plugins.chess_results.chess_results_mappers import ChessResultsTieBreak
+from plugins.chess_results.chess_results_session import ChessResultsSession
+from plugins.chess_results.utils import CRUtils
 from plugins.ffe.ffe_tie_breaks import PapiPerformanceTieBreak
 from plugins.ffe.papi_converter import PapiConverter
 from tests.test_config import TestUtils
+from utils.enum import RoleType
 
 
 EVENT_ID = 'test-tournament-exporters-event'
@@ -47,6 +55,55 @@ class TournamentExporterTestCase(TestCase):
                 ChessResultsTieBreak.from_tie_break(self.tournament, tie_break)
             except NotImplementedError:
                 self.fail(f'Tie-break [{tie_break.id}] not handled.')
+
+    def test_chess_results_exports_each_arbiter_role(self):
+        assert self.tournament.id is not None
+
+        account_by_role = {}
+        for role_type, first_name in (
+            (RoleType.CHIEF_ARBITER, 'Chief'),
+            (RoleType.DEPUTY_ARBITER, 'Deputy'),
+            (RoleType.ARBITER, 'Simple'),
+        ):
+            account_by_role[role_type] = self.event.create_account(
+                StoredAccount(
+                    id=None,
+                    active=True,
+                    first_name=first_name,
+                    last_name='Arbiter',
+                    stored_roles=[
+                        StoredRole(
+                            account_id=None,
+                            role=role_type.value,
+                            tournament_ids=[self.tournament.id],
+                        )
+                    ],
+                )
+            )
+
+        with patch.object(CRUtils, 'encrypt', return_value='encrypted-test-sid'):
+            xml = ChessResultsSession(self.tournament).build_tournament_xml(
+                self.tournament,
+                sid='test-sid',
+                tnr='test-key',
+                creator_id='test-creator',
+                state=None,
+            )
+        tournament_data = ET.fromstring(xml).find('./tournamentdata/tournament')
+        assert tournament_data is not None
+        assert tournament_data.attrib['chiefarbiter'] == 'Arbiter, Chief'
+        assert tournament_data.attrib['deputyarbiter'] == 'Arbiter, Deputy'
+        assert tournament_data.attrib['arbiter'] == 'Arbiter, Simple'
+        assert self.tournament.arbiters == [account_by_role[RoleType.ARBITER]]
+
+        simple_arbiter = account_by_role[RoleType.ARBITER]
+        with EventDatabase(EVENT_ID, write=True) as database:
+            with self.assertRaises(IntegrityError):
+                database.add_stored_roles(
+                    simple_arbiter.id,
+                    RoleType.DEPUTY_ARBITER.value,
+                    [self.tournament.id],
+                )
 
     # -------------------------------------------------------------------------
     # Papi


### PR DESCRIPTION
## Summary

- add a tournament-bound Arbiter staff role alongside chief and deputy arbiters
- surface simple arbiters in staff and tournament views and arbiter-based documents
- send simple arbiters through the Chess-Results arbiter field
- extend the existing database constraint so one account cannot hold multiple arbiter roles for the same tournament

## Testing

- python -m pytest -m "not release_only" (935 passed, 1 deselected)
- ruff check --target-version=py313 --exit-non-zero-on-fix .
- ruff format --check .
- mypy src tests
- python -m pytest -m release_only tests/unit/recover/test_recover.py (1 passed)

Closes #1969